### PR TITLE
fix(pool): warn when archive is enabled with checkpoint TTL off

### DIFF
--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -265,6 +265,9 @@ func NewManager(ctx context.Context, cfg *config.Config, eng Engine) (*Manager, 
 			m.archiveEnabled = true
 		}
 	}
+	if m.archiveEnabled && m.ckptTTL == 0 {
+		log.WithFunc("pool.NewManager").Warn(ctx, "archive enabled with checkpoint_ttl_hours=0: a checkpoint whose delete fails is not reclaimed")
+	}
 	return m, nil
 }
 


### PR DESCRIPTION
Archive relies on the checkpoint TTL to reclaim a checkpoint whose physical delete failed (the claim is already gone, so the ck is unpinned and only the TTL sweep can remove it). With `checkpoint_ttl_hours=0` that rare orphan is never reclaimed — emit a startup warning so the misconfiguration is visible.

One-line change in `NewManager`; no behaviour change beyond the log line.