### PR TITLE
review: tighten comments + unsafe SAFETY note

### DIFF
--- a/sandboxd/server/server.go
+++ b/sandboxd/server/server.go
@@ -465,7 +465,7 @@ func (s *Server) requireRoot(next http.HandlerFunc) http.HandlerFunc {
 }
 
 // resolveScope matches the bearer token to root ("") or a tenant name. With
-// no api token and no tenants the node-level endpoints stay open, as before.
+// no api token and no tenants the node-level endpoints stay open.
 func (s *Server) resolveScope(r *http.Request) (string, bool) {
 	if s.apiToken == "" && len(s.tenants) == 0 {
 		return "", true

--- a/sdk/openai/cocoonsandbox_openai/adapter.py
+++ b/sdk/openai/cocoonsandbox_openai/adapter.py
@@ -126,8 +126,6 @@ class CocoonSandboxSession(BaseSandboxSession):
         return Sandbox(client=client, id=s.sandbox_id, token=s.sandbox_token, owner=s.owner or s.addr)
 
     def _abs(self, path: Path | str) -> Path:
-        # The SDK hands paths as str or Path; a relative one roots at the
-        # manifest workspace.
         path = Path(path)
         if path.is_absolute():
             return path

--- a/silkd/src/sysutil.rs
+++ b/silkd/src/sysutil.rs
@@ -101,6 +101,8 @@ fn lookup_user(user: &str) -> Result<(u32, u32, String), String> {
     if pw.is_null() {
         return Err(format!("unknown user {user:?}"));
     }
+    // SAFETY: pw is non-null (checked) and, with NSS_LOCK still held, points to
+    // a valid passwd whose pw_dir is a NUL-terminated string it owns.
     let pw = unsafe { &*pw };
     let home = unsafe { std::ffi::CStr::from_ptr(pw.pw_dir) }
         .to_string_lossy()


### PR DESCRIPTION
Whole-repo comment/style pass over sandbox `main` (`/code` Go, `/code-rs` Rust, `/code-py` Python). The tree was audited file-by-file; it came back already within budget, so this PR is deliberately small.

## Changes
- **sandboxd/server/server.go** — drop the `, as before.` edit-narration tail from `resolveScope`'s godoc; the sentence is complete without it.
- **sdk/openai/.../adapter.py** — remove the restated-code comment in `_abs`; the three-line body (Path coerce → absolute passthrough → join under `manifest.root`) is self-evident.
- **silkd/src/sysutil.rs** — add the missing SAFETY invariant (`/code-rs` rule 5) on `lookup_user`'s non-null passwd dereference: `pw` is non-null (checked) and, with `NSS_LOCK` held, points to a valid `passwd` whose `pw_dir` is a NUL-terminated string it owns. The other unsafe blocks already carry their invariant (guard comments on `kill_group`/`signal_pid`, the `NSS_LOCK` note on `getpwnam`, the `F_GETFL/F_SETFL` note on `set_nonblocking`, the `openpty` SAFETY block).

## Audit result
Across ~95 source files the pass found only these three items — two removable comments and one genuine unsafe-justification gap. Declaration layout, logging idioms, context propagation, error handling, and English-only were all clean; no manufactured churn.

## Gates
- Rust: `cargo fmt --check` ✓, `clippy --all-targets -D warnings` on macOS ✓ and in a `rust:1-slim` Linux container (incl. vsock/tokio-vsock) ✓, `cargo test` ✓ (10 passed).
- Go: `go build`/`vet` ✓, `golangci-lint run` on `GOOS=linux` and `GOOS=darwin` ✓ (0 issues), `golangci-lint fmt --diff` ✓.
- Python: `ruff check` ✓, `pytest` ✓ (4 passed, Python 3.12 venv with both SDK packages editable-installed).