### PR TITLE
perf(pool): read vsock from lifecycle -o json, skip the vm list poll

### DIFF
--- a/e2e/fakeengine_test.go
+++ b/e2e/fakeengine_test.go
@@ -38,11 +38,11 @@ func newFakeEngine(dir string) *fakeEngine {
 	}
 }
 
-func (f *fakeEngine) Clone(_ context.Context, _, name string, _ types.PoolKey) error {
+func (f *fakeEngine) Clone(_ context.Context, _, name string, _ types.PoolKey) (string, error) {
 	return f.create(name)
 }
 
-func (f *fakeEngine) RunCold(_ context.Context, name string, _ types.PoolKey) error {
+func (f *fakeEngine) RunCold(_ context.Context, name string, _ types.PoolKey) (string, error) {
 	return f.create(name)
 }
 
@@ -74,7 +74,7 @@ func (f *fakeEngine) Hibernate(ctx context.Context, name, _ string) error {
 	return f.Remove(ctx, name)
 }
 
-func (f *fakeEngine) Restore(_ context.Context, name, _ string) error {
+func (f *fakeEngine) Restore(_ context.Context, name, _ string) (string, error) {
 	return f.create(name)
 }
 
@@ -99,16 +99,16 @@ func (f *fakeEngine) DialGuestPort(context.Context, string, uint16) (net.Conn, e
 	return nil, fmt.Errorf("fakeEngine has no guest port")
 }
 
-func (f *fakeEngine) create(name string) error {
+func (f *fakeEngine) create(name string) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.seq++
 	sock := filepath.Join(f.dir, fmt.Sprintf("v%d.sock", f.seq))
 	l, err := silkdtest.ListenHybrid(sock, 2048)
 	if err != nil {
-		return err
+		return "", err
 	}
 	f.listeners[name] = l
 	f.socks[name] = sock
-	return nil
+	return sock, nil
 }

--- a/sandboxd/engine/engine.go
+++ b/sandboxd/engine/engine.go
@@ -320,10 +320,8 @@ func (e *Engine) infoRoundTrip(ctx context.Context, vsockSocket string) error {
 	return nil
 }
 
-// parseVsock pulls the vsock UDS out of a lifecycle command's --output json VM
-// record. Best-effort: a missing socket (the VMM had not bound it by cocoon's
-// post-start inspect) or an unparseable record yields "", and the caller falls
-// back to polling `vm list` until the socket appears.
+// parseVsock reads the vsock UDS from a lifecycle command's --output json VM
+// record; best-effort, so an empty or unparseable record yields "" (poll fallback).
 func parseVsock(ctx context.Context, out []byte) string {
 	var rec types.VMRecord
 	if err := json.Unmarshal(out, &rec); err != nil {

--- a/sandboxd/engine/engine.go
+++ b/sandboxd/engine/engine.go
@@ -53,24 +53,31 @@ func New(bin, bridge, network string) *Engine {
 	return &Engine{bin: bin, bridge: bridge, network: network}
 }
 
-// Clone restores a VM from an exported golden directory. The no-network lane
-// passes no net flags at all — the golden has no NIC to retarget, the only
-// clone shape FC supports; the egress lane re-attaches to the node's bridge
-// or CNI network. cocoon signals the in-guest reseed itself after resume.
-func (e *Engine) Clone(ctx context.Context, fromDir, name string, key types.PoolKey) error {
-	_, err := e.run(ctx, e.cloneArgs(fromDir, name, key)...)
-	return err
+// Clone restores a VM from an exported golden directory, returning its vsock
+// UDS. The no-network lane passes no net flags at all — the golden has no NIC
+// to retarget, the only clone shape FC supports; the egress lane re-attaches
+// to the node's bridge or CNI network. cocoon signals the in-guest reseed
+// itself after resume.
+func (e *Engine) Clone(ctx context.Context, fromDir, name string, key types.PoolKey) (string, error) {
+	out, err := e.run(ctx, e.cloneArgs(fromDir, name, key)...)
+	if err != nil {
+		return "", err
+	}
+	return parseVsock(ctx, out), nil
 }
 
 // RunCold boots a VM from the template image (golden builds and cache-miss
-// claims).
-func (e *Engine) RunCold(ctx context.Context, name string, key types.PoolKey) error {
+// claims), returning its vsock UDS.
+func (e *Engine) RunCold(ctx context.Context, name string, key types.PoolKey) (string, error) {
 	args, err := e.runColdArgs(name, key)
 	if err != nil {
-		return err
+		return "", err
 	}
-	_, err = e.run(ctx, args...)
-	return err
+	out, err := e.run(ctx, args...)
+	if err != nil {
+		return "", err
+	}
+	return parseVsock(ctx, out), nil
 }
 
 // Remove force-deletes a VM; `rm --force` skips the graceful stop window
@@ -94,10 +101,13 @@ func (e *Engine) Hibernate(ctx context.Context, vmName, snapName string) error {
 }
 
 // Restore resumes a VM from a snapshot with its memory state and identity
-// intact (cocoon reseeds entropy only on restore).
-func (e *Engine) Restore(ctx context.Context, vmName, snapRef string) error {
-	_, err := e.run(ctx, "vm", "restore", vmName, snapRef)
-	return err
+// intact (cocoon reseeds entropy only on restore), returning its vsock UDS.
+func (e *Engine) Restore(ctx context.Context, vmName, snapRef string) (string, error) {
+	out, err := e.run(ctx, "vm", "restore", "--output", "json", vmName, snapRef)
+	if err != nil {
+		return "", err
+	}
+	return parseVsock(ctx, out), nil
 }
 
 // SnapshotExport exports a snapshot into toDir (cocoon requires it absent or
@@ -238,7 +248,7 @@ func (e *Engine) cloneArgs(fromDir, name string, key types.PoolKey) []string {
 	// --pull: a checkpoint/template export carries only COW + memory; on a
 	// cross-node claim the base image blobs resolve locally or are pulled
 	// by digest.
-	args := []string{"vm", "clone", "--from-dir", fromDir, "--name", name, "--pull"}
+	args := []string{"vm", "clone", "--from-dir", fromDir, "--name", name, "--pull", "--output", "json"}
 	return append(args, e.netArgs(key, false)...)
 }
 
@@ -247,7 +257,7 @@ func (e *Engine) runColdArgs(name string, key types.PoolKey) ([]string, error) {
 	if !ok {
 		return nil, fmt.Errorf("unknown size %q", key.Size)
 	}
-	args := []string{"vm", "run", "--name", name, "--cpu", strconv.Itoa(spec.CPU), "--memory", spec.Memory}
+	args := []string{"vm", "run", "--name", name, "--output", "json", "--cpu", strconv.Itoa(spec.CPU), "--memory", spec.Memory}
 	if key.Backend() == types.BackendFC {
 		args = append(args, "--fc")
 	}
@@ -308,6 +318,19 @@ func (e *Engine) infoRoundTrip(ctx context.Context, vsockSocket string) error {
 		return fmt.Errorf("info reply type %q", frame.Type)
 	}
 	return nil
+}
+
+// parseVsock pulls the vsock UDS out of a lifecycle command's --output json VM
+// record. Best-effort: a missing socket (the VMM had not bound it by cocoon's
+// post-start inspect) or an unparseable record yields "", and the caller falls
+// back to polling `vm list` until the socket appears.
+func parseVsock(ctx context.Context, out []byte) string {
+	var rec types.VMRecord
+	if err := json.Unmarshal(out, &rec); err != nil {
+		log.WithFunc("engine.parseVsock").Warnf(ctx, "parse vm record, will poll for vsock: %v", err)
+		return ""
+	}
+	return rec.VsockSocket
 }
 
 // readLine reads byte-wise so nothing past the newline is consumed —

--- a/sandboxd/pool/hibernate.go
+++ b/sandboxd/pool/hibernate.go
@@ -75,10 +75,11 @@ func (m *Manager) wakeResolved(ctx context.Context, sb *types.Sandbox) (string, 
 	ctx = context.WithoutCancel(ctx)
 	wakeStart := time.Now()
 	snap := sb.HibernateSnap
-	if err := m.eng.Restore(ctx, sb.VMName, snap); err != nil {
+	restoredSock, err := m.eng.Restore(ctx, sb.VMName, snap)
+	if err != nil {
 		return "", fmt.Errorf("wake %s: %w", sb.ID, err)
 	}
-	sock, err := m.probeReady(ctx, sb.VMName, claimProbeTimeout)
+	sock, err := m.probeReady(ctx, sb.VMName, restoredSock, claimProbeTimeout)
 	if err != nil {
 		return "", fmt.Errorf("wake %s: %w", sb.ID, err)
 	}

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -70,15 +70,15 @@ var (
 
 // Engine is the slice of the cocoon driver the manager consumes.
 type Engine interface {
-	Clone(ctx context.Context, fromDir, name string, key types.PoolKey) error
-	RunCold(ctx context.Context, name string, key types.PoolKey) error
+	Clone(ctx context.Context, fromDir, name string, key types.PoolKey) (string, error)
+	RunCold(ctx context.Context, name string, key types.PoolKey) (string, error)
 	Remove(ctx context.Context, name string) error
 	SnapshotSave(ctx context.Context, vmName, snapName string) error
 	SnapshotExport(ctx context.Context, snapName, toDir string) error
 	SnapshotRemove(ctx context.Context, snapName string) error
 	SnapshotList(ctx context.Context) ([]string, error)
 	Hibernate(ctx context.Context, vmName, snapName string) error
-	Restore(ctx context.Context, vmName, snapRef string) error
+	Restore(ctx context.Context, vmName, snapRef string) (string, error)
 	List(ctx context.Context, filters ...string) ([]types.VMRecord, error)
 	Probe(ctx context.Context, vsockSocket string, timeout time.Duration) error
 	DialGuestPort(ctx context.Context, vsockSocket string, port uint16) (net.Conn, error)

--- a/sandboxd/pool/pool_test.go
+++ b/sandboxd/pool/pool_test.go
@@ -515,30 +515,41 @@ func newFakeEngine() *fakeEngine {
 	return &fakeEngine{vms: map[string]string{}, stopped: map[string]bool{}}
 }
 
-func (f *fakeEngine) Clone(_ context.Context, fromDir, name string, _ types.PoolKey) error {
+func (f *fakeEngine) Clone(_ context.Context, fromDir, name string, _ types.PoolKey) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.clones = append(f.clones, name)
 	f.cloneFroms = append(f.cloneFroms, fromDir)
 	if f.cloneErr != nil {
-		return f.cloneErr
+		return "", f.cloneErr
 	}
 	if f.cloneFailNth > 0 && len(f.clones) == f.cloneFailNth {
-		return errors.New("clone failed")
+		return "", errors.New("clone failed")
 	}
 	f.vms[name] = "/vsock/" + name
-	return nil
+	return f.lateVsock(f.vms[name]), nil
 }
 
-func (f *fakeEngine) RunCold(_ context.Context, name string, _ types.PoolKey) error {
+func (f *fakeEngine) RunCold(_ context.Context, name string, _ types.PoolKey) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.colds = append(f.colds, name)
 	if f.runColdErr != nil {
-		return f.runColdErr
+		return "", f.runColdErr
 	}
 	f.vms[name] = "/vsock/" + name
-	return nil
+	return f.lateVsock(f.vms[name]), nil
+}
+
+// lateVsock models cocoon's report-once-running lag: while vsockLateN ticks
+// remain, a lifecycle command or List reports no socket yet (consuming one),
+// forcing the caller's poll fallback.
+func (f *fakeEngine) lateVsock(sock string) string {
+	if f.vsockLateN > 0 {
+		f.vsockLateN--
+		return ""
+	}
+	return sock
 }
 
 // removed reports whether name was destroyed, under the fake's own lock —
@@ -612,15 +623,15 @@ func (f *fakeEngine) Hibernate(_ context.Context, name, snapName string) error {
 	return nil
 }
 
-func (f *fakeEngine) Restore(_ context.Context, name, _ string) error {
+func (f *fakeEngine) Restore(_ context.Context, name, _ string) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.restores = append(f.restores, name)
 	if f.restoreErr != nil {
-		return f.restoreErr
+		return "", f.restoreErr
 	}
 	f.stopped[name] = false
-	return nil
+	return f.lateVsock(f.vms[name]), nil
 }
 
 func (f *fakeEngine) List(_ context.Context, filters ...string) ([]types.VMRecord, error) {
@@ -631,10 +642,7 @@ func (f *fakeEngine) List(_ context.Context, filters ...string) ([]types.VMRecor
 		if len(filters) > 0 && !slices.Contains(filters, name) {
 			continue
 		}
-		if f.vsockLateN > 0 {
-			f.vsockLateN--
-			sock = ""
-		}
+		sock = f.lateVsock(sock)
 		state := vmStateRunning
 		if f.stopped[name] {
 			state = "stopped"

--- a/sandboxd/pool/pool_test.go
+++ b/sandboxd/pool/pool_test.go
@@ -542,8 +542,7 @@ func (f *fakeEngine) RunCold(_ context.Context, name string, _ types.PoolKey) (s
 }
 
 // lateVsock models cocoon's report-once-running lag: while vsockLateN ticks
-// remain, a lifecycle command or List reports no socket yet (consuming one),
-// forcing the caller's poll fallback.
+// remain it reports no socket (consuming one), forcing the caller's poll.
 func (f *fakeEngine) lateVsock(sock string) string {
 	if f.vsockLateN > 0 {
 		f.vsockLateN--

--- a/sandboxd/pool/refill.go
+++ b/sandboxd/pool/refill.go
@@ -93,10 +93,11 @@ func (m *Manager) buildGolden(ctx context.Context, p *pool) {
 }
 
 func (m *Manager) buildGoldenSteps(ctx context.Context, key types.PoolKey, name, snap, final string) error {
-	if err := m.eng.RunCold(ctx, name, key); err != nil {
+	sock, err := m.eng.RunCold(ctx, name, key)
+	if err != nil {
 		return err
 	}
-	if _, err := m.probeReady(ctx, name, coldProbeTimeout); err != nil {
+	if _, err := m.probeReady(ctx, name, sock, coldProbeTimeout); err != nil {
 		return err
 	}
 	if err := m.eng.SnapshotSave(ctx, name, snap); err != nil {
@@ -161,16 +162,16 @@ func (m *Manager) exportSource(ctx context.Context, sb *types.Sandbox, exportDir
 func (m *Manager) provision(ctx context.Context, key types.PoolKey, golden string) (*types.Sandbox, error) {
 	name := vmName(key)
 	probeTimeout := claimProbeTimeout
+	var sock string
 	var err error
 	if golden != "" {
-		err = m.eng.Clone(ctx, golden, name, key)
+		sock, err = m.eng.Clone(ctx, golden, name, key)
 	} else {
-		err = m.eng.RunCold(ctx, name, key)
+		sock, err = m.eng.RunCold(ctx, name, key)
 		probeTimeout = coldProbeTimeout
 	}
-	var sock string
 	if err == nil {
-		sock, err = m.probeReady(ctx, name, probeTimeout)
+		sock, err = m.probeReady(ctx, name, sock, probeTimeout)
 	}
 	if err != nil {
 		m.destroy(ctx, name)
@@ -205,20 +206,24 @@ func (m *Manager) cloneBatch(ctx context.Context, key types.PoolKey, dir string,
 	return children, nil
 }
 
-// probeReady resolves a VM's vsock socket and waits until its silkd answers,
-// returning the socket — the claim-ready gate after create, clone, or restore.
-// One budget covers both waits: cocoon reports the vsock socket only once the
-// VMM reaches running, and a heavy image (android's 8G alloc) can widen the
-// created→running window past the first List.
-func (m *Manager) probeReady(ctx context.Context, name string, timeout time.Duration) (string, error) {
+// probeReady waits until a VM's silkd answers, returning its vsock socket —
+// the claim-ready gate after clone, cold-run, or restore. sock is the socket
+// the lifecycle command already reported; when empty (cocoon's post-start
+// inspect ran before the VMM bound it — a heavy image's android 8G alloc
+// widens that window) it falls back to polling `vm list` until the socket
+// appears, within the same probe budget.
+func (m *Manager) probeReady(ctx context.Context, name, sock string, timeout time.Duration) (string, error) {
 	deadline := time.Now().Add(timeout)
-	sock, err := m.vsockOf(ctx, name)
-	for err != nil && time.Now().Before(deadline) && ctx.Err() == nil {
-		time.Sleep(vsockPollInterval)
+	if sock == "" {
+		var err error
 		sock, err = m.vsockOf(ctx, name)
-	}
-	if err != nil {
-		return "", err
+		for err != nil && time.Now().Before(deadline) && ctx.Err() == nil {
+			time.Sleep(vsockPollInterval)
+			sock, err = m.vsockOf(ctx, name)
+		}
+		if err != nil {
+			return "", err
+		}
 	}
 	if err := m.eng.Probe(ctx, sock, time.Until(deadline)); err != nil {
 		return "", err

--- a/sandboxd/pool/refill.go
+++ b/sandboxd/pool/refill.go
@@ -206,12 +206,9 @@ func (m *Manager) cloneBatch(ctx context.Context, key types.PoolKey, dir string,
 	return children, nil
 }
 
-// probeReady waits until a VM's silkd answers, returning its vsock socket —
-// the claim-ready gate after clone, cold-run, or restore. sock is the socket
-// the lifecycle command already reported; when empty (cocoon's post-start
-// inspect ran before the VMM bound it — a heavy image's android 8G alloc
-// widens that window) it falls back to polling `vm list` until the socket
-// appears, within the same probe budget.
+// probeReady waits until a VM's silkd answers, returning its vsock socket. sock
+// is what the lifecycle command reported; when empty (a heavy image can boot
+// past cocoon's post-start inspect) it polls `vm list` until the socket appears.
 func (m *Manager) probeReady(ctx context.Context, name, sock string, timeout time.Duration) (string, error) {
 	deadline := time.Now().Add(timeout)
 	if sock == "" {


### PR DESCRIPTION
The claim/refill/wake paths resolved a new VM's vsock UDS by polling `cocoon vm list` (`vsockOf`) after every clone/cold-boot/restore. cocoon now carries the socket in the lifecycle command's own `--output json` record (`vm run` and `vm restore` today; `vm clone` once cocoon #108 lands), so we can read it directly and skip the extra subprocess.

## Change
- `engine.Clone/RunCold/Restore` run with `--output json` and return the parsed `vsock_socket` (`parseVsock`, best-effort: an empty or unparseable record yields `""`).
- `probeReady(name, sock, timeout)` takes the pre-resolved socket; it polls `vm list` only when `sock == ""` — the heavy-image window (android's 8G alloc) where cocoon's post-start inspect ran before the VMM bound the UDS.
- Callers updated: `provision` (clone/cold), `buildGoldenSteps` (cold), `wakeResolved` (restore); `wakeArchived` inherits via `provision`. Engine interface signatures change `error → (string, error)`.

## Pairing with cocoon
`vm run -o json` (inspect-after-start) and `vm restore -o json` (cocoon #107) already populate `vsock_socket`, so **cold-miss and wake stop paying the `vm list` subprocess immediately**. `vm clone -o json` omits it until **cocoon #108** ships to the fleet; until then clone-sourced provisioning (golden refill, fork, archive-wake) falls back to the poll — correct, no regression, just no speed-up yet. The fallback also degrades gracefully on any older cocoon.

## Gates
- `go build ./...` ✓, `go test -race ./...` ✓ (all sandboxd packages)
- `golangci-lint run` on `GOOS=linux` and `GOOS=darwin` ✓ (0 issues), `golangci-lint fmt --diff` ✓
- Adversarial review (2 agents) + my own senior pass: plumbing correct, no swallowed errors, all four call sites updated, fast-path timing sound. Both agents independently surfaced the cocoon clone-`-o json` gap → filed as cocoon #108.

## Hardware (bare-metal .79, fleet cocoon `v0.4.8-master.5beb36a`)
`sandboxd-e2e.sh` regression: warm claim 0.3–0.6ms, miss/clone-tier 65ms, 15-step smoke PASS (hibernate 446ms, fork 685ms, promote 547ms, checkpoint 576ms), reap + restart-readopt PASS, rc=0. No regression; wake resolves vsock from restore metadata, clone still polls (pre-#108).