### PR TITLE
harden(silkd): cap session exit-code tail scan

### DIFF
--- a/silkd/src/session.rs
+++ b/silkd/src/session.rs
@@ -23,6 +23,11 @@ use crate::sysutil;
 pub const IDLE_TTL: Duration = Duration::from_secs(30 * 60);
 pub const REAP_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Bounds the post-marker scan for the exit-code line's newline: the line is
+/// tiny and atomic with the marker, so this only caps a backgrounded child
+/// flooding stdout without a newline.
+const EXIT_TAIL_MAX: usize = 64 * 1024;
+
 /// Registry of live shell sessions, addressed by id across connections.
 #[derive(Clone, Default)]
 pub struct Table {
@@ -244,7 +249,7 @@ impl Io {
             if let Some(pos) = find(&acc, mb) {
                 emit(&mut out, &mut frame, &acc[..pos]).await;
                 let mut rest = acc[pos + mb.len()..].to_vec();
-                while !rest.contains(&b'\n') {
+                while !rest.contains(&b'\n') && rest.len() < EXIT_TAIL_MAX {
                     let m = self.stdout.read(&mut buf).await?;
                     if m == 0 {
                         break;


### PR DESCRIPTION
`session.rs` `converse` reads the shell's output up to an unpredictable sentinel marker, then scans the bytes *after* the marker for the exit-code line's terminating newline:

```rust
let mut rest = acc[pos + mb.len()..].to_vec();
while !rest.contains(&b'\n') { rest.extend_from_slice(read...); }
```

The loop had no size bound on `rest`.

**Nuance (why this is defense-in-depth, not a live exploit):** the exit-code line comes from a single `printf '<marker> %s\n' "$?"` — ~44 bytes, well under `PIPE_BUF` (4096), so it is one atomic pipe write. The newline is therefore always contiguous with the marker in the stream, and the loop runs at most once. The unbounded path only opens if a **backgrounded child** the command left behind floods the shared stdout with newline-free bytes faster than the printf's newline is delivered — then `rest` could grow without limit (a self-DoS on silkd, the guest's sole daemon).

**Fix:** bound the scan at 64KB (`EXIT_TAIL_MAX`) — the exit line is tiny, so this never bites in normal operation, and it matches the `MAX_FRAME` OOM discipline the rest of silkd already applies to untrusted-length reads (`proto.rs` `cap_check`). Normal exit-code parsing is unchanged.

## Gates
- macOS: `cargo fmt --check` ✓, `clippy --all-targets -D warnings` ✓, `cargo test` ✓ (all suites).
- Linux (`rust:1-slim` container, protocol fixtures mounted + git present): `clippy` ✓, `cargo test` ✓ (all suites, TEST=0).
- Change doesn't alter the normal (atomic-newline) path — existing session round-trip tests cover it.