### PR TITLE
perf(pool): fold archived count into Info's single locked pass (F7)

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -44,7 +44,7 @@ func TestEndToEnd(t *testing.T) {
 		// Warm-hit = zero VM ops is proven by the pool unit tests; asserting
 		// create counts here would race the background refill ticker.
 		waitFor(t, func() bool {
-			infos, _, _ := stack.mgr.Info()
+			infos, _ := stack.mgr.Info()
 			return len(infos) == 1 && infos[0].Warm >= 1
 		})
 		warm, err := stack.client.New(t.Context(), "rt:24.04")

--- a/sandboxd/pool/archive_test.go
+++ b/sandboxd/pool/archive_test.go
@@ -17,6 +17,11 @@ func breakStore(t *testing.T, m *Manager) {
 	m.store.path = filepath.Join(t.TempDir(), "gone", "claims.json")
 }
 
+func archivedCount(m *Manager) int {
+	_, g := m.Info()
+	return g.Archived
+}
+
 // archivePool is the pool shape the archive tests share: idle→hibernate at 1s,
 // archive at 2s, a long retention window (overridden per test).
 func archivePool(delete int) config.PoolSpec {
@@ -66,7 +71,7 @@ func TestArchiveLifecycleRoundTrip(t *testing.T) {
 	waitFor(t, func() bool { return hibernated(m) == 1 })
 
 	m.archiveOnce(t.Context())
-	waitFor(t, func() bool { return m.ArchivedCount() == 1 })
+	waitFor(t, func() bool { return archivedCount(m) == 1 })
 
 	m.mu.Lock()
 	ck, vm, snap := sb.ArchiveCk, sb.VMName, sb.HibernateSnap
@@ -95,7 +100,7 @@ func TestArchiveLifecycleRoundTrip(t *testing.T) {
 	if wokeCk != "" || wokeVM == "" {
 		t.Errorf("woke record ck=%q vm=%q, want ck cleared + vm set", wokeCk, wokeVM)
 	}
-	if m.ArchivedCount() != 0 {
+	if archivedCount(m) != 0 {
 		t.Error("woke claim still counted as archived")
 	}
 	if ckExists(t, m, ck) {
@@ -141,7 +146,7 @@ func TestArchiveKeepsForeverWhenDeleteZero(t *testing.T) {
 	}
 
 	m.reapOnce(t.Context())
-	if m.ArchivedCount() != 1 || !ckExists(t, m, ck) {
+	if archivedCount(m) != 1 || !ckExists(t, m, ck) {
 		t.Fatal("reap purged a keep-forever archived sandbox")
 	}
 	if _, err := m.WakeAgentSocket(t.Context(), id, token); err != nil {
@@ -167,7 +172,7 @@ func TestArchiveRetentionPurge(t *testing.T) {
 	m.mu.Unlock()
 
 	m.reapOnce(t.Context())
-	waitFor(t, func() bool { return m.ArchivedCount() == 0 })
+	waitFor(t, func() bool { return archivedCount(m) == 0 })
 	waitFor(t, func() bool { return !ckExists(t, m, ck) })
 
 	m.mu.Lock()
@@ -222,7 +227,7 @@ func TestIdleOnceSkipsArchived(t *testing.T) {
 	if got := eng.hibernateCount(); got != hibBefore {
 		t.Errorf("idle sweep hibernated an archived claim: %d→%d", hibBefore, got)
 	}
-	if m.ArchivedCount() != 1 {
+	if archivedCount(m) != 1 {
 		t.Error("idle sweep disturbed the archived claim")
 	}
 }
@@ -388,7 +393,7 @@ func TestArchiveOnceSkipsInFlight(t *testing.T) {
 	if got := eng.exportCount(); got != exportsBefore {
 		t.Errorf("archiveOnce double-exported an in-flight sandbox: %d→%d", exportsBefore, got)
 	}
-	if m.ArchivedCount() != 0 {
+	if archivedCount(m) != 0 {
 		t.Error("archiveOnce archived a sandbox already being archived elsewhere")
 	}
 }

--- a/sandboxd/pool/fork_test.go
+++ b/sandboxd/pool/fork_test.go
@@ -120,8 +120,8 @@ func TestForkAllOrNothing(t *testing.T) {
 	}
 	// Every successfully built child is destroyed; only the parent's claim
 	// survives in memory and on disk.
-	if _, claimed, _ := m.Info(); claimed != 1 {
-		t.Errorf("claimed=%d, want only the parent", claimed)
+	if _, g := m.Info(); g.Claimed != 1 {
+		t.Errorf("claimed=%d, want only the parent", g.Claimed)
 	}
 	if got, _ := newClaimStore(m.dataDir).load(); len(got) != 1 {
 		t.Errorf("persisted %d claims, want only the parent", len(got))

--- a/sandboxd/pool/hibernate_test.go
+++ b/sandboxd/pool/hibernate_test.go
@@ -24,8 +24,8 @@ func TestHibernateWakeCycle(t *testing.T) {
 	if len(eng.hibernates) != 1 {
 		t.Errorf("engine hibernated %d times, want 1 (idempotent)", len(eng.hibernates))
 	}
-	if _, _, hibernated := m.Info(); hibernated != 1 {
-		t.Errorf("hibernated count %d, want 1", hibernated)
+	if _, g := m.Info(); g.Hibernated != 1 {
+		t.Errorf("hibernated count %d, want 1", g.Hibernated)
 	}
 	if got, _ := newClaimStore(m.dataDir).load(); got[sb.ID] == nil || got[sb.ID].HibernateSnap == "" {
 		t.Error("hibernation flag not persisted")
@@ -47,8 +47,8 @@ func TestHibernateWakeCycle(t *testing.T) {
 	if !slices.Contains(eng.snapRemoves, eng.hibernates[0]) {
 		t.Errorf("snapRemoves=%v, want consumed snapshot dropped", eng.snapRemoves)
 	}
-	if _, _, hibernated := m.Info(); hibernated != 0 {
-		t.Errorf("hibernated count %d after wake, want 0", hibernated)
+	if _, g := m.Info(); g.Hibernated != 0 {
+		t.Errorf("hibernated count %d after wake, want 0", g.Hibernated)
 	}
 
 	// Awake sandbox: the fast path must not touch the engine again.
@@ -72,8 +72,8 @@ func TestWakeFailureKeepsHibernated(t *testing.T) {
 	if _, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err == nil {
 		t.Fatal("WakeAgentSocket succeeded despite restore failure")
 	}
-	if _, _, hibernated := m.Info(); hibernated != 1 {
-		t.Errorf("hibernated count %d, want 1 (wake failed, snapshot kept)", hibernated)
+	if _, g := m.Info(); g.Hibernated != 1 {
+		t.Errorf("hibernated count %d, want 1 (wake failed, snapshot kept)", g.Hibernated)
 	}
 	if len(eng.snapRemoves) != 0 {
 		t.Errorf("snapRemoves=%v, want none after failed wake", eng.snapRemoves)
@@ -125,8 +125,8 @@ func TestReleaseMidHibernateDropsOrphanSnapshot(t *testing.T) {
 	if !slices.Contains(eng.snapRemoves, eng.hibernates[0]) {
 		t.Errorf("snapRemoves=%v, want the orphaned snapshot dropped", eng.snapRemoves)
 	}
-	if _, _, hibernated := m.Info(); hibernated != 0 {
-		t.Errorf("hibernated count %d, want 0", hibernated)
+	if _, g := m.Info(); g.Hibernated != 0 {
+		t.Errorf("hibernated count %d, want 0", g.Hibernated)
 	}
 }
 
@@ -152,8 +152,8 @@ func TestReconcileAdoptsHibernated(t *testing.T) {
 	if slices.Contains(eng.removes, "sbx-hibernated-1") {
 		t.Error("reconcile destroyed a hibernated claim's VM")
 	}
-	if _, _, hibernated := m.Info(); hibernated != 1 {
-		t.Errorf("hibernated count %d after reconcile, want 1", hibernated)
+	if _, g := m.Info(); g.Hibernated != 1 {
+		t.Errorf("hibernated count %d after reconcile, want 1", g.Hibernated)
 	}
 	if _, err := m.WakeAgentSocket(t.Context(), "sb_hib", "tok"); err != nil {
 		t.Fatalf("wake after reconcile: %v", err)

--- a/sandboxd/pool/idle_test.go
+++ b/sandboxd/pool/idle_test.go
@@ -79,6 +79,6 @@ func backdate(m *Manager, sb *types.Sandbox, by time.Duration) {
 }
 
 func hibernated(m *Manager) int {
-	_, _, n := m.Info()
-	return n
+	_, g := m.Info()
+	return g.Hibernated
 }

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -103,6 +103,13 @@ type PoolInfo struct {
 	Golden    bool          `json:"golden"`
 }
 
+// Gauges are the manager's point-in-time claim counts.
+type Gauges struct {
+	Claimed    int
+	Hibernated int
+	Archived   int
+}
+
 type pool struct {
 	key types.PoolKey
 
@@ -499,13 +506,6 @@ func (m *Manager) SetPools(ctx context.Context, specs []config.PoolSpec) error {
 // the server starts serving.
 func (m *Manager) SetTemplateNotifier(fn func()) {
 	m.notifyTemplates = fn
-}
-
-// Gauges are the manager's point-in-time claim counts.
-type Gauges struct {
-	Claimed    int
-	Hibernated int
-	Archived   int
 }
 
 // Info reports pool states (sorted for stable output) and the claim gauges —

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -501,14 +501,21 @@ func (m *Manager) SetTemplateNotifier(fn func()) {
 	m.notifyTemplates = fn
 }
 
-// Info reports pool states (sorted for stable output), the claim count, and
-// how many claims are hibernated.
-func (m *Manager) Info() ([]PoolInfo, int, int) {
+// Gauges are the manager's point-in-time claim counts.
+type Gauges struct {
+	Claimed    int
+	Hibernated int
+	Archived   int
+}
+
+// Info reports pool states (sorted for stable output) and the claim gauges —
+// one locked pass counts hibernated and archived together.
+func (m *Manager) Info() ([]PoolInfo, Gauges) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	infos := make([]PoolInfo, 0, len(m.pools))
+	pools := make([]PoolInfo, 0, len(m.pools))
 	for _, p := range m.pools {
-		infos = append(infos, PoolInfo{
+		pools = append(pools, PoolInfo{
 			Key:       p.key,
 			Warm:      len(p.warm),
 			Refilling: p.refilling,
@@ -516,28 +523,17 @@ func (m *Manager) Info() ([]PoolInfo, int, int) {
 			Golden:    p.goldenDir != "",
 		})
 	}
-	slices.SortFunc(infos, func(a, b PoolInfo) int { return strings.Compare(a.Key.Hash(), b.Key.Hash()) })
-	hibernated := 0
+	slices.SortFunc(pools, func(a, b PoolInfo) int { return strings.Compare(a.Key.Hash(), b.Key.Hash()) })
+	g := Gauges{Claimed: len(m.claimed)}
 	for _, sb := range m.claimed {
 		if sb.HibernateSnap != "" {
-			hibernated++
+			g.Hibernated++
 		}
-	}
-	return infos, len(m.claimed), hibernated
-}
-
-// ArchivedCount returns how many live claims are archived to the store (no
-// local VM); separate from Info's gauges to keep its arity — and its callers.
-func (m *Manager) ArchivedCount() int {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	n := 0
-	for _, sb := range m.claimed {
 		if sb.ArchiveCk != "" {
-			n++
+			g.Archived++
 		}
 	}
-	return n
+	return pools, g
 }
 
 // Sandboxes lists the live claims, for the operator index.

--- a/sandboxd/pool/pool_test.go
+++ b/sandboxd/pool/pool_test.go
@@ -103,8 +103,8 @@ func TestClaimProbeFailureDestroysVM(t *testing.T) {
 	if len(eng.removes) != 1 {
 		t.Errorf("removes=%v, want the failed VM destroyed", eng.removes)
 	}
-	if _, n, _ := m.Info(); n != 0 {
-		t.Errorf("claimed=%d, want 0", n)
+	if _, g := m.Info(); g.Claimed != 0 {
+		t.Errorf("claimed=%d, want 0", g.Claimed)
 	}
 }
 
@@ -203,8 +203,8 @@ func TestReapDestroysExpiredClaims(t *testing.T) {
 	m.reapOnce(t.Context())
 	// The destroy batch is fanned off the ticker loop; poll for it.
 	waitFor(t, func() bool { return eng.removed(sb.VMName) })
-	if _, n, _ := m.Info(); n != 0 {
-		t.Errorf("claimed=%d, want 0", n)
+	if _, g := m.Info(); g.Claimed != 0 {
+		t.Errorf("claimed=%d, want 0", g.Claimed)
 	}
 	if got, _ := newClaimStore(m.dataDir).load(); len(got) != 0 {
 		t.Errorf("reap not persisted: %d entries", len(got))
@@ -261,7 +261,7 @@ func TestRefillTopsUpToTarget(t *testing.T) {
 
 	m.refillOnce(t.Context())
 	waitFor(t, func() bool {
-		infos, _, _ := m.Info()
+		infos, _ := m.Info()
 		return infos[0].Warm == 2 && infos[0].Refilling == 0
 	})
 	if n := eng.cloneCount(); n != 2 {
@@ -281,7 +281,7 @@ func TestSetPoolsGrowShrinkAndDrain(t *testing.T) {
 		t.Fatalf("SetPools grow: %v", err)
 	}
 	waitFor(t, func() bool {
-		infos, _, _ := m.Info()
+		infos, _ := m.Info()
 		return len(infos) == 1 && infos[0].Target == 2 && infos[0].Warm == 2 && infos[0].Golden
 	})
 	if n := eng.cloneCount(); n != 2 {
@@ -291,7 +291,7 @@ func TestSetPoolsGrowShrinkAndDrain(t *testing.T) {
 	if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: testKey, Warm: 1}}); err != nil {
 		t.Fatalf("SetPools shrink: %v", err)
 	}
-	infos, _, _ := m.Info()
+	infos, _ := m.Info()
 	if len(infos) != 1 || infos[0].Target != 1 || infos[0].Warm != 1 {
 		t.Fatalf("after shrink info=%+v, want target=1 warm=1", infos)
 	}
@@ -302,7 +302,7 @@ func TestSetPoolsGrowShrinkAndDrain(t *testing.T) {
 	if err := m.SetPools(t.Context(), nil); err != nil {
 		t.Fatalf("SetPools drain: %v", err)
 	}
-	infos, _, _ = m.Info()
+	infos, _ = m.Info()
 	if len(infos) != 0 {
 		t.Fatalf("after drain info=%+v, want no configured pools", infos)
 	}
@@ -337,12 +337,12 @@ func TestRefillRespectsSemaphore(t *testing.T) {
 
 	close(eng.probeStall)
 	waitFor(t, func() bool {
-		infos, _, _ := m.Info()
+		infos, _ := m.Info()
 		return infos[0].Warm+infos[0].Refilling >= maxConcurrentRefills && infos[0].Refilling == 0
 	})
 	m.refillOnce(t.Context())
 	waitFor(t, func() bool {
-		infos, _, _ := m.Info()
+		infos, _ := m.Info()
 		return infos[0].Warm == 6
 	})
 }
@@ -353,7 +353,7 @@ func TestGoldenBuildPipeline(t *testing.T) {
 
 	m.refillOnce(t.Context())
 	waitFor(t, func() bool {
-		infos, _, _ := m.Info()
+		infos, _ := m.Info()
 		return infos[0].Golden
 	})
 	m.mu.Lock()
@@ -369,7 +369,7 @@ func TestGoldenBuildPipeline(t *testing.T) {
 
 	m.refillOnce(t.Context())
 	waitFor(t, func() bool {
-		infos, _, _ := m.Info()
+		infos, _ := m.Info()
 		return infos[0].Warm == 1
 	})
 }

--- a/sandboxd/server/metrics.go
+++ b/sandboxd/server/metrics.go
@@ -18,8 +18,7 @@ type SandboxListResponse struct {
 // gauges only, no client library. Latency rides as *_seconds_total next to
 // its count, so dashboards derive averages without histogram machinery.
 func (s *Server) handleMetrics(w http.ResponseWriter, _ *http.Request) {
-	pools, claimed, hibernated := s.mgr.Info()
-	archived := s.mgr.ArchivedCount()
+	pools, g := s.mgr.Info()
 	c := s.mgr.Counters()
 
 	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
@@ -27,11 +26,11 @@ func (s *Server) handleMetrics(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprintf(w, "# HELP sandboxd_%s %s\n# TYPE sandboxd_%s %s\n", name, help, name, kind)
 	}
 	metric("claimed", "gauge", "live claims on this node")
-	_, _ = fmt.Fprintf(w, "sandboxd_claimed %d\n", claimed)
+	_, _ = fmt.Fprintf(w, "sandboxd_claimed %d\n", g.Claimed)
 	metric("hibernated", "gauge", "claims currently hibernated")
-	_, _ = fmt.Fprintf(w, "sandboxd_hibernated %d\n", hibernated)
+	_, _ = fmt.Fprintf(w, "sandboxd_hibernated %d\n", g.Hibernated)
 	metric("archived", "gauge", "claims archived to the checkpoint store")
-	_, _ = fmt.Fprintf(w, "sandboxd_archived %d\n", archived)
+	_, _ = fmt.Fprintf(w, "sandboxd_archived %d\n", g.Archived)
 
 	if tenants := s.mgr.TenantClaims(); len(tenants) > 0 {
 		metric("tenant_claims", "gauge", "live claims per configured tenant")

--- a/sandboxd/server/server.go
+++ b/sandboxd/server/server.go
@@ -76,8 +76,7 @@ type Manager interface {
 	AgentSocket(id, token string) (string, error)
 	WakeAgentSocket(ctx context.Context, id, token string) (string, error)
 	SetPools(ctx context.Context, pools []config.PoolSpec) error
-	Info() ([]pool.PoolInfo, int, int)
-	ArchivedCount() int
+	Info() ([]pool.PoolInfo, pool.Gauges)
 }
 
 // Dialer opens the hybrid-vsock connection to a VM's silkd.
@@ -426,8 +425,8 @@ func (s *Server) handlePeers(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) handleInfo(w http.ResponseWriter, _ *http.Request) {
-	pools, claimed, hibernated := s.mgr.Info()
-	resp := InfoResponse{Pools: pools, Claimed: claimed, Hibernated: hibernated, Archived: s.mgr.ArchivedCount()}
+	pools, g := s.mgr.Info()
+	resp := InfoResponse{Pools: pools, Claimed: g.Claimed, Hibernated: g.Hibernated, Archived: g.Archived}
 	if s.placer != nil {
 		resp.Peers = s.placer.PeerAddrs()
 	}

--- a/sandboxd/server/server_test.go
+++ b/sandboxd/server/server_test.go
@@ -946,11 +946,9 @@ func (f *fakeManager) SetPools(_ context.Context, pools []config.PoolSpec) error
 	return f.setPools(pools)
 }
 
-func (f *fakeManager) Info() ([]pool.PoolInfo, int, int) {
-	return f.infoPools, 0, 0
+func (f *fakeManager) Info() ([]pool.PoolInfo, pool.Gauges) {
+	return f.infoPools, pool.Gauges{}
 }
-
-func (f *fakeManager) ArchivedCount() int { return 0 }
 
 type fakeDialer struct {
 	dial func(ctx context.Context, sock string) (net.Conn, error)


### PR DESCRIPTION
`/metrics` (scraped ~every second) and `/v1/info` each took **two** separate `m.mu` critical sections that both walked the full `m.claimed` map: `Info()` for the hibernated count, then `ArchivedCount()` for the archived count. On a high-claim node that competes twice per scrape with the claim/wake/release data plane for the manager mutex.

## Change
- `Info()` now returns `([]PoolInfo, Gauges)` where `Gauges{Claimed, Hibernated, Archived}` is computed in **one** locked pass — one lock acquisition, one `m.claimed` walk.
- `ArchivedCount()` is removed (no caller wanted it standalone; both callers wanted it alongside `Info`'s other gauges). The `server.Manager` interface drops it.
- The `Gauges` struct also replaces the 4-positional-`int` return shape, so single-value call sites read `g.Hibernated` instead of `_, _, hibernated, _` (which `dogsled` flags).

Per-scrape: locked sections 3→2, full `m.claimed` scans 2→1. `TenantClaims` stays separate — it walks `m.tenantMax` (O(tenants)), not the claim map.

## Why no hardware A/B
`/metrics` and `/v1/info` are periodic/operator paths, off the claim/wake/release hot path — this is a straightforward lock-consolidation, not a latency-critical change. Verified by the unit suite (the metrics/info handlers and every gauge assertion) rather than a bench.

## Gates
- `go test -race ./...` ✓ (sandboxd all 9 packages + e2e module).
- `golangci-lint run` on `GOOS=linux` and `GOOS=darwin` ✓ (0 issues — the prior `dogsled` blanks are gone), `golangci-lint fmt --diff` ✓.