### PR TITLE
review(sdk-py): annotate public return types

### DIFF
--- a/sdk/python/cocoonsandbox/checkpoint.py
+++ b/sdk/python/cocoonsandbox/checkpoint.py
@@ -4,6 +4,11 @@ keeps running and can be checkpointed again, so captures form a tree."""
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .sandbox import Sandbox
+
 
 class Checkpoint:
     """A captured sandbox state on its owner node."""
@@ -16,7 +21,7 @@ class Checkpoint:
         self.sandbox_id = rec.get("sandbox_id", "")
         self.created_at = rec.get("created_at", "")
 
-    def new(self, ttl_seconds: int = 0):
+    def new(self, ttl_seconds: int = 0) -> Sandbox:
         """Claims a fresh sandbox branched from the checkpoint."""
         body = {"ttl_seconds": ttl_seconds} if ttl_seconds else {}
         reply = self._client._post_json(self._addr, f"/v1/checkpoints/{self.id}/claim", body, "claim checkpoint")

--- a/sdk/python/cocoonsandbox/conn.py
+++ b/sdk/python/cocoonsandbox/conn.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import contextlib
 import socket
+from collections.abc import Iterator
 
 from .errors import APIError, ProtocolError, SilkdError
 from .frames import MAX_FRAME, decode_response, encode_request
@@ -17,10 +18,10 @@ class Conn:
         self._sock = sock
         self._reader = reader
 
-    def __enter__(self):
+    def __enter__(self) -> Conn:
         return self
 
-    def __exit__(self, *exc):
+    def __exit__(self, *exc) -> None:
         self.close()
 
     def send(self, op: str, **fields) -> None:
@@ -39,7 +40,7 @@ class Conn:
             raise SilkdError(frame.get("kind", "internal"), frame.get("message", ""))
         return frame
 
-    def recv_until(self, *terminal: str):
+    def recv_until(self, *terminal: str) -> Iterator[dict]:
         """Yields frames until one of the terminal types arrives; the
         terminal frame is yielded last."""
         while True:

--- a/sdk/python/cocoonsandbox/sandbox.py
+++ b/sdk/python/cocoonsandbox/sandbox.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import contextlib
 import socket
 import threading
+from collections.abc import Iterator
 
 from .checkpoint import Checkpoint
 from .conn import Conn, dial_agent
@@ -28,10 +29,10 @@ class Sandbox:
         self.deadline = deadline
         self.from_checkpoint = from_checkpoint
 
-    def __enter__(self):
+    def __enter__(self) -> Sandbox:
         return self
 
-    def __exit__(self, *exc):
+    def __exit__(self, *exc) -> None:
         try:
             self.close()
         except Exception:
@@ -372,7 +373,7 @@ class Watcher:
     def __init__(self, conn: Conn):
         self._conn = conn
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[dict]:
         # The stream is connection-bound: closing the watcher (or the server
         # dropping the conn) ends iteration rather than raising.
         while True:
@@ -395,10 +396,10 @@ class Pty:
         self._conn = conn
         self.pid = pid
 
-    def __enter__(self):
+    def __enter__(self) -> Pty:
         return self
 
-    def __exit__(self, *exc):
+    def __exit__(self, *exc) -> None:
         self.close()
 
     def read(self) -> bytes:
@@ -445,10 +446,10 @@ class PortConn:
         self._conn = conn
         self._eof = False
 
-    def __enter__(self):
+    def __enter__(self) -> PortConn:
         return self
 
-    def __exit__(self, *exc):
+    def __exit__(self, *exc) -> None:
         self.close()
 
     def send(self, data: bytes) -> None:

--- a/sdk/python/cocoonsandbox/template.py
+++ b/sdk/python/cocoonsandbox/template.py
@@ -5,6 +5,10 @@ name-based Client calls route via gossip and lag a promote by about a tick."""
 from __future__ import annotations
 
 import urllib.parse
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .sandbox import Sandbox
 
 
 class Template:
@@ -17,7 +21,7 @@ class Template:
         self.net = net
         self.size = size
 
-    def new(self, ttl_seconds: int = 0):
+    def new(self, ttl_seconds: int = 0) -> Sandbox:
         """Claims a sandbox cloned from the template, on the template's
         node; the key axes are the template's own."""
         # Local import: a top-level one would close the client → sandbox →


### PR DESCRIPTION
Fills the remaining return-type gaps in the Python SDK's public surface (`/code-py`: public signatures fully annotated).

- **`Checkpoint.new` / `Template.new`** → `Sandbox`. Both are imported under `if TYPE_CHECKING:` because a top-level `from .sandbox import Sandbox` would close the `client → sandbox → checkpoint/template` cycle (`template.py` already breaks the same cycle with a function-local import for `_claim_body`). `from __future__ import annotations` is already present, so the annotation stays a string at runtime — zero import cost.
- **Generators** `Conn.recv_until` and `Watcher.__iter__` → `Iterator[dict]` (`collections.abc.Iterator`).
- **Context-manager dunders** on `Sandbox`, `Conn`, `Pty`, `PortConn` → `__enter__` returns the class, `__exit__` returns `None`.

Annotations only — no behavior change.

## Gates
- `ruff check` ✓ (import order clean).
- `pytest` ✓ — 101 passed (Python 3.12 venv, base + openai SDK editable-installed).