### PR TITLE
perf(pool): make warm-pool refill reactive instead of tick-gated

### DIFF
--- a/sandboxd/pool/pool_test.go
+++ b/sandboxd/pool/pool_test.go
@@ -347,6 +347,23 @@ func TestRefillRespectsSemaphore(t *testing.T) {
 	})
 }
 
+// TestRefillReactivelyFillsToTarget: one trigger fills the whole target (not
+// just maxConcurrentRefills), since a finished refill chains the next.
+func TestRefillReactivelyFillsToTarget(t *testing.T) {
+	eng := newFakeEngine()
+	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 10})
+	m.pools[testKey].goldenDir = "/goldens/x"
+
+	m.refillOnce(t.Context())
+	waitFor(t, func() bool {
+		infos, _ := m.Info()
+		return infos[0].Warm == 10 && infos[0].Refilling == 0
+	})
+	if n := eng.cloneCount(); n != 10 {
+		t.Errorf("clones=%d, want 10", n)
+	}
+}
+
 func TestGoldenBuildPipeline(t *testing.T) {
 	eng := newFakeEngine()
 	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1})

--- a/sandboxd/pool/refill.go
+++ b/sandboxd/pool/refill.go
@@ -42,7 +42,12 @@ func (m *Manager) refillOnce(ctx context.Context) {
 }
 
 func (m *Manager) refillOne(ctx context.Context, p *pool, golden string) {
-	defer func() { <-m.refillSem }()
+	releaseSlot := true
+	defer func() {
+		if releaseSlot {
+			<-m.refillSem
+		}
+	}()
 	start := time.Now()
 	sb, err := m.provision(ctx, p.key, golden)
 	keep := false
@@ -53,6 +58,11 @@ func (m *Manager) refillOne(ctx context.Context, p *pool, golden string) {
 		p.warm = append(p.warm, sb)
 		p.noteLead(time.Since(start))
 		keep = true
+	}
+	if err == nil && p.goldenDir != "" && len(p.warm)+p.refilling < target {
+		p.refilling++
+		releaseSlot = false
+		go m.refillOne(ctx, p, p.goldenDir)
 	}
 	m.mu.Unlock()
 	if err != nil {


### PR DESCRIPTION
`refillOne` released its `refillSem` slot and returned; the only thing that re-launches refills is `refillOnce`, fired from the 2s `Run()` ticker (plus startup/SetPools). So after a burst drains the warm pool, each freed concurrency slot sat **idle for up to 2s** before anything noticed — the pool recovered only `maxConcurrentRefills` (4) VMs per tick. A 10-deep deficit took `ceil(10/4)=3` ticks ≈ **4-6s**, during which every claim beyond the trickling buffer fell through to clone/cold-tier latency.

## Change
A finished `refillOne`, on success and still under target with a golden present, **hands its slot to the next refill** (`releaseSlot=false; go refillOne(...)`) instead of releasing it. Four concurrent chains then fill straight to target — **~250ms** at the 38.6ms clone tier — with no ticker wait.

Design invariants (adversarially reviewed, 7 concerns all refuted):
- Chaining **reuses the held slot**, never acquires a new one → concurrent provisions stay ≤ `maxConcurrentRefills` (4).
- `target`/`goldenDir` re-read **fresh under `m.mu`** each hop → a `SetPools` shrink stops the chain (drained pool's target collapses to 0); no overshoot.
- Chain gated on `err == nil` → a persistent provision failure stops the chain (no subprocess spin-loop), falling back to the ticker; ctx-cancel/shutdown likewise stops it.
- Exactly one `refillSem` release per acquire; `p.refilling` stays balanced across success/failure/keep=false.

## Measurement
`TestRefillReactivelyFillsToTarget` — one `refillOnce` against a target of 10 (> maxConcurrentRefills):
- **old** refillOne (reactive reverted): stalls at 4, test **FAILS at 3s** ("condition not met").
- **new**: reaches 10, test **PASSES in 0.01s**.

Production recovery of a 10-deep deficit: `ceil(10/4)`×2s ≈ 4-6s → one reactive fill ≈ 250ms (~16-24x).

## Gates
`go build` ✓, `go test -race ./pool/` ✓ (full suite incl. `TestRefillRespectsSemaphore` — semaphore cap still honored), `golangci-lint run` linux+darwin ✓ (0 issues), `fmt --diff` ✓.