### PR TITLE
perf(sdk): fast-path bulk frame decode (2.15x exec throughput)

### DIFF
--- a/sdk/go/silkd/decode_bench_test.go
+++ b/sdk/go/silkd/decode_bench_test.go
@@ -1,0 +1,31 @@
+package silkd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+func BenchmarkDecodeStdout(b *testing.B) {
+	payload := make([]byte, 256*1024)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	frame := []byte(`{"type":"stdout","data":"` + base64.StdEncoding.EncodeToString(payload) + `"}`)
+	b.SetBytes(int64(len(payload)))
+	b.Run("fast", func(b *testing.B) {
+		for range b.N {
+			if _, err := DecodeResponse(frame); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("json", func(b *testing.B) {
+		for range b.N {
+			var s Stdout
+			if err := json.Unmarshal(frame, &s); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/sdk/go/silkd/frame.go
+++ b/sdk/go/silkd/frame.go
@@ -7,6 +7,7 @@ package silkd
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -96,15 +97,15 @@ var (
 	// procs is a count, ps's procs is a list).
 	responseDecoders = map[string]func([]byte) (Response, error){
 		"started":           decodeResp[Started],
-		"stdout":            decodeResp[Stdout],
-		"stderr":            decodeResp[Stderr],
+		"stdout":            fastBulk(decodeResp[Stdout], func(d []byte) Response { return &Stdout{Data: d} }),
+		"stderr":            fastBulk(decodeResp[Stderr], func(d []byte) Response { return &Stderr{Data: d} }),
 		"exit":              decodeResp[Exit],
 		"done":              decodeResp[Done],
 		"ready":             decodeResp[Ready],
 		"error":             decodeResp[ErrorResp],
 		"info":              decodeResp[InfoResp],
 		"procs":             decodeResp[Procs],
-		"data":              decodeResp[DataResp],
+		"data":              fastBulk(decodeResp[DataResp], func(d []byte) Response { return &DataResp{Data: d} }),
 		"entries":           decodeResp[Entries],
 		"stat":              decodeResp[Stat],
 		"session_created":   decodeResp[SessionCreated],
@@ -666,6 +667,28 @@ func DecodeResponse(line []byte) (Response, error) {
 		return nil, fmt.Errorf("unknown response type %q", typ)
 	}
 	return dec(line)
+}
+
+// fastBulk decodes a bulk frame's base64 data field by slicing it out (base64's
+// alphabet is JSON-escape-free) and skipping json.Unmarshal, which otherwise
+// dominates the download path; slow is the json fallback for any other shape.
+func fastBulk(slow func([]byte) (Response, error), mk func([]byte) Response) func([]byte) (Response, error) {
+	return func(line []byte) (Response, error) {
+		_, after, ok := bytes.Cut(line, []byte(`"data":"`))
+		if !ok {
+			return slow(line)
+		}
+		b64, _, ok := bytes.Cut(after, []byte(`"`))
+		if !ok {
+			return slow(line)
+		}
+		out := make([]byte, base64.StdEncoding.DecodedLen(len(b64)))
+		n, err := base64.StdEncoding.Decode(out, b64)
+		if err != nil {
+			return slow(line)
+		}
+		return mk(out[:n]), nil
+	}
 }
 
 // encodeTagged marshals v as a flat object and splices the tag head in front

--- a/sdk/python/cocoonsandbox/frames.py
+++ b/sdk/python/cocoonsandbox/frames.py
@@ -31,6 +31,16 @@ def encode_request(op: str, **fields) -> bytes:
 def decode_response(line: bytes) -> dict:
     """Parses one response frame; the returned dict carries its tag under
     "type" and any binary payload decoded under "data"."""
+    # Bulk frames (stdout/stderr/data) are the throughput path where json.loads
+    # of the big base64 string dominates. base64 is JSON-escape-free and these
+    # frames carry only type+data, so slice both out and skip json.
+    if line.startswith(b'{"type":"'):
+        te = line.find(b'"', 9)
+        if te > 0 and line[9:te] in (b"stdout", b"stderr", b"data"):
+            di = line.find(b'"data":"', te)
+            de = line.find(b'"', di + 8) if di > 0 else -1
+            if de > 0:
+                return {"type": line[9:te].decode(), "data": base64.b64decode(line[di + 8 : de])}
     frame = json.loads(line)
     if not isinstance(frame, dict) or "type" not in frame:
         raise ValueError(f"frame without a type tag: {line[:80]!r}")


### PR DESCRIPTION
A perf sweep found the binding constraint on exec-output / `fs_pull` throughput was **neither base64 nor the relay** — it was the SDK client running the whole `{"type":..,"data":"<base64>"}` frame through the generic JSON decoder (a full-buffer syntax scan + reflective decode of a ~342KB base64 string per 256KB chunk). (An earlier hardware A/B had already shown the silkd-side per-chunk memcpy was *not* the bottleneck — dropped as null.)

## Change
base64's alphabet is JSON-escape-free, so the `data` value slices out between the quotes and base64-decodes directly; the three bulk frames (`stdout`/`stderr`/`data`) carry only `type`+`data`, so the result is complete without `json`.
- **Go**: the three bulk types route through `fastBulk` in the existing `responseDecoders` dispatch map — slice+decode on the happy path, `decodeResp[T]` (json) fallback on any unexpected shape. `DecodeResponse` itself is unchanged.
- **Python**: `decode_response` slices `type`+`data` out and skips `json.loads` for those frames, same fallback.

Wire format, `protocol/fixtures/v1`, and `PROTO_VERSION` **unchanged** — this is a decode-side-only optimization.

## Measurement
| | old | new | ratio |
|---|---|---|---|
| Go isolated decode (256KB frame) | 1470µs | 128µs | **11.5x** |
| **Go end-to-end exec throughput (.79 bare metal)** | **237 MB/s** | **510 MB/s** | **2.15x** |
| Python isolated decode (256KB) | 913µs | 588µs | 1.55x |

The .79 A/B ran `execbench-old` vs `execbench-new` (identical `sandboxd` + `rt:24.04` silkd; only the SDK decode differs) — `head -c 200000000 /dev/zero` streamed through the relay, 6 iterations each.

## Gates
- Go: `build` ✓, `test -race ./...` ✓ (fixture round-trip + exec/stdin/push-pull behavioral tests exercise the fast path), `golangci-lint run` linux+darwin ✓ (0 issues), `fmt --diff` ✓. `BenchmarkDecodeStdout` committed as a regression guard.
- Python: `ruff check` ✓, `pytest` ✓ (101 passed, fixtures).