### PR TITLE
perf(pool): marshal the claims journal off the manager mutex (F1 part 2)

### DIFF
--- a/sandboxd/pool/claims.go
+++ b/sandboxd/pool/claims.go
@@ -9,15 +9,32 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/cocoonstack/sandbox/sandboxd/types"
 )
 
-// claimSnapshot is a sequenced, pre-marshaled claim set awaiting a durable write.
+// claimSnapshot is a sequenced, detached copy of the claim set awaiting a
+// durable write; commit() marshals it off the manager mutex.
 type claimSnapshot struct {
-	raw []byte
-	seq uint64
-	err error
+	claims map[string]claimDTO
+	seq    uint64
+}
+
+// claimDTO is the persisted projection of a Sandbox (its json fields only),
+// copied by value so commit's marshal runs off the manager mutex without
+// racing the live record's Transition mutex and lastActivity.
+type claimDTO struct {
+	ID             string        `json:"id"`
+	VMName         string        `json:"vm_name"`
+	Key            types.PoolKey `json:"key"`
+	Token          string        `json:"token,omitempty"`
+	Deadline       time.Time     `json:"deadline,omitzero"`
+	Tenant         string        `json:"tenant,omitempty"`
+	VsockSocket    string        `json:"vsock_socket,omitempty"`
+	HibernateSnap  string        `json:"hibernate_snap,omitempty"`
+	ArchiveCk      string        `json:"archive_ck,omitempty"`
+	FromCheckpoint string        `json:"from_checkpoint,omitempty"`
 }
 
 // claimStore persists claimed sandboxes across daemon restarts. Warm pool
@@ -57,30 +74,40 @@ func (s *claimStore) load() (map[string]*types.Sandbox, error) {
 	return claims, nil
 }
 
-// snapshot marshals the claim set and stamps it with the next sequence. The
-// caller holds the manager mutex, so the map is consistent and sequences are
-// handed out in mutation order; the file write happens later in commit().
+// snapshot copies the claim set into a detached, sequenced value and stamps it
+// with the next sequence. The caller holds the manager mutex, so it does only a
+// cheap field copy — not the marshal — and sequences are handed out in mutation
+// order; commit() marshals and writes off the mutex.
 func (s *claimStore) snapshot(claims map[string]*types.Sandbox) claimSnapshot {
 	seq := s.seq.Add(1)
-	raw, err := json.Marshal(claims)
-	return claimSnapshot{raw: raw, seq: seq, err: err}
+	dtos := make(map[string]claimDTO, len(claims))
+	for id, sb := range claims {
+		dtos[id] = claimDTO{
+			ID: sb.ID, VMName: sb.VMName, Key: sb.Key, Token: sb.Token,
+			Deadline: sb.Deadline, Tenant: sb.Tenant, VsockSocket: sb.VsockSocket,
+			HibernateSnap: sb.HibernateSnap, ArchiveCk: sb.ArchiveCk,
+			FromCheckpoint: sb.FromCheckpoint,
+		}
+	}
+	return claimSnapshot{claims: dtos, seq: seq}
 }
 
-// commit durably writes a snapshot off the manager mutex. Serialized by s.mu so
-// writes never interleave; coalescing so a snapshot no newer than the last
-// written is a no-op — a higher sequence already persisted a later state that
-// supersedes it, so the caller's intent is satisfied.
+// commit marshals a snapshot and durably writes it, off the manager mutex.
+// Serialized by s.mu so writes never interleave; coalescing so a snapshot no
+// newer than the last written is a no-op — a higher sequence already persisted
+// a later state that supersedes it — which also skips its marshal.
 func (s *claimStore) commit(snap claimSnapshot) error {
-	if snap.err != nil {
-		return fmt.Errorf("encode claims: %w", snap.err)
-	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if snap.seq <= s.written {
 		return nil
 	}
+	raw, err := json.Marshal(snap.claims)
+	if err != nil {
+		return fmt.Errorf("encode claims: %w", err)
+	}
 	tmp := s.path + ".tmp"
-	if err := os.WriteFile(tmp, snap.raw, 0o600); err != nil {
+	if err := os.WriteFile(tmp, raw, 0o600); err != nil {
 		return fmt.Errorf("write claims: %w", err)
 	}
 	if err := os.Rename(tmp, s.path); err != nil {


### PR DESCRIPTION
F1 (#6) moved the claims.json write+rename off the manager mutex, but the **O(N) `json.Marshal` of the whole claim map still ran under `m.mu`** — inside `snapshot()`, which every claim/release/wake/hibernate/reap holds `m.mu` to call. At scale that reflective marshal is the dominant thing serialized against the data plane on the persist path.

## Change
- `snapshot()` (under `m.mu`) now does only a **cheap by-value field copy** of each claim into a `claimDTO` map — no reflection, no JSON buffer.
- `commit()` (off `m.mu`, under the store mutex `s.mu`) does the `json.Marshal` + write + rename.
- The copy is **by value** precisely so the off-`m.mu` marshal can't race the live `*Sandbox`'s `Transition` mutex or `lastActivity` atomic (verified under `-race`). `claimDTO` mirrors `Sandbox`'s JSON fields exactly, so `claims.json` is byte-identical (`TestStoreRoundTrip`).
- Bonus: a coalesced snapshot (`seq <= written`) now skips its marshal entirely (the marshal moved past the coalescing check).

## Measurement (`BenchmarkStorePersistContention`, the F1 metric)
The ns a concurrent `m.mu` acquire waits while a persist holds the lock:

| live claims | old (marshal under lock) | new (field copy under lock) | ratio |
|---|---|---|---|
| 100 | 51 ns | 27 ns | ~1.9x |
| 1000 | 211 ns | 34 ns | **~6.2x** |

Grows with claim count (the marshal is O(N); the copy is O(N) but ~two orders cheaper per element). Modest in absolute terms at small pools, material on a busy multi-tenant node with thousands of live claims.

## Gates
`go build` ✓, `go test -race ./pool/` ✓ (no data race; `TestStoreRoundTrip`/`TestClaimStoreCommitCoalesces` confirm format + coalescing), `golangci-lint run` linux+darwin ✓ (0 issues), `fmt --diff` ✓.