### PR TITLE
perf(pool): drop the consumed hibernate snapshot off the wake-return path

### DIFF
--- a/sandboxd/pool/hibernate.go
+++ b/sandboxd/pool/hibernate.go
@@ -45,9 +45,10 @@ func (m *Manager) hibernateLocked(ctx context.Context, sb *types.Sandbox) error 
 	// A started transition must finish even if the caller hangs up (the
 	// engine bounds every step), or the record would disagree with the VM.
 	ctx = context.WithoutCancel(ctx)
-	// Derived from VMName, not sb.ID: cocoon snapshot names reject the
-	// underscore in the "sb_" prefix.
-	snap := hibernatePrefix + strings.TrimPrefix(sb.VMName, vmPrefix)
+	// From VMName (not sb.ID, whose "sb_" underscore cocoon rejects) plus a
+	// random suffix, so the wake's async snapshot drop can't collide with a
+	// re-hibernate reusing the name.
+	snap := hibernatePrefix + strings.TrimPrefix(sb.VMName, vmPrefix) + "-" + randHex(3)
 	if err := m.eng.Hibernate(ctx, sb.VMName, snap); err != nil {
 		return err
 	}
@@ -89,8 +90,10 @@ func (m *Manager) wakeResolved(ctx context.Context, sb *types.Sandbox) (string, 
 		m.dropSnap(ctx, snap)
 		return "", ErrUnknownSandbox
 	}
-	// The memory image is consumed by the resume; drop it to free disk.
-	m.dropSnap(ctx, snap)
+	// The resume consumed the memory image; reclaim its disk off the
+	// wake-return path (a stale-name re-hibernate is guarded by randHex above,
+	// a failed drop by the orphan-snapshot sweep).
+	go m.dropSnap(ctx, snap)
 	m.counters.wakes.Add(1)
 	m.counters.wakeNanos.Add(uint64(time.Since(wakeStart))) //nolint:gosec // durations are positive
 	m.recordUsage(ctx, usageEvent{Event: "wake", ID: sb.ID, VMName: sb.VMName})

--- a/sandboxd/pool/hibernate_test.go
+++ b/sandboxd/pool/hibernate_test.go
@@ -30,8 +30,9 @@ func TestHibernateWakeCycle(t *testing.T) {
 	if got, _ := newClaimStore(m.dataDir).load(); got[sb.ID] == nil || got[sb.ID].HibernateSnap == "" {
 		t.Error("hibernation flag not persisted")
 	}
-	if !strings.HasPrefix(eng.hibernates[0], hibernatePrefix) {
-		t.Errorf("snapshot name %q, want %s prefix", eng.hibernates[0], hibernatePrefix)
+	hibSnap := eng.hibernates[0]
+	if !strings.HasPrefix(hibSnap, hibernatePrefix) {
+		t.Errorf("snapshot name %q, want %s prefix", hibSnap, hibernatePrefix)
 	}
 
 	sock, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token)
@@ -44,9 +45,7 @@ func TestHibernateWakeCycle(t *testing.T) {
 	if len(eng.restores) != 1 {
 		t.Errorf("engine restored %d times, want 1", len(eng.restores))
 	}
-	if !slices.Contains(eng.snapRemoves, eng.hibernates[0]) {
-		t.Errorf("snapRemoves=%v, want consumed snapshot dropped", eng.snapRemoves)
-	}
+	waitFor(t, func() bool { return eng.snapRemoved(hibSnap) }) // wake drops it off the return path
 	if _, g := m.Info(); g.Hibernated != 0 {
 		t.Errorf("hibernated count %d after wake, want 0", g.Hibernated)
 	}
@@ -58,6 +57,31 @@ func TestHibernateWakeCycle(t *testing.T) {
 	if len(eng.restores) != 1 {
 		t.Errorf("fast path restored again: %d", len(eng.restores))
 	}
+}
+
+// TestWakeDropsSnapshotOffReturnPath: wake returns the socket without waiting
+// for the consumed snapshot's (subprocess) removal.
+func TestWakeDropsSnapshotOffReturnPath(t *testing.T) {
+	eng := newFakeEngine()
+	m := newTestManager(t, eng)
+	sb := mustClaim(t, m, testKey)
+	if err := m.Hibernate(t.Context(), sb.ID, sb.Token); err != nil {
+		t.Fatalf("hibernate: %v", err)
+	}
+	eng.snapRemoveStall = make(chan struct{})
+
+	sock, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token)
+	if err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+	if sock == "" {
+		t.Error("wake returned an empty socket")
+	}
+	if n := eng.snapRemoveCount(); n != 0 {
+		t.Errorf("snapshot removed %d times before wake returned, want it off the return path", n)
+	}
+	close(eng.snapRemoveStall)
+	waitFor(t, func() bool { return eng.snapRemoveCount() == 1 })
 }
 
 func TestWakeFailureKeepsHibernated(t *testing.T) {

--- a/sandboxd/pool/pool_test.go
+++ b/sandboxd/pool/pool_test.go
@@ -506,9 +506,10 @@ type fakeEngine struct {
 	cloneErr, runColdErr, probeErr, hibernateErr, restoreErr, snapSaveErr error
 	cloneFailNth                                                          int // 1-based Clone call to fail; 0 = never
 
-	probeStall     chan struct{} // non-nil: Probe blocks until closed
-	hibernateStall chan struct{} // non-nil: Hibernate blocks until closed
-	removeStall    chan struct{} // non-nil: Remove blocks until closed
+	probeStall      chan struct{} // non-nil: Probe blocks until closed
+	hibernateStall  chan struct{} // non-nil: Hibernate blocks until closed
+	removeStall     chan struct{} // non-nil: Remove blocks until closed
+	snapRemoveStall chan struct{} // non-nil: SnapshotRemove blocks until closed
 }
 
 func newFakeEngine() *fakeEngine {
@@ -598,6 +599,12 @@ func (f *fakeEngine) SnapshotList(_ context.Context) ([]string, error) {
 }
 
 func (f *fakeEngine) SnapshotRemove(_ context.Context, snapName string) error {
+	f.mu.Lock()
+	stall := f.snapRemoveStall
+	f.mu.Unlock()
+	if stall != nil {
+		<-stall
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.snapRemoves = append(f.snapRemoves, snapName)
@@ -695,4 +702,16 @@ func (f *fakeEngine) removedNames() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return slices.Clone(f.removes)
+}
+
+func (f *fakeEngine) snapRemoveCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.snapRemoves)
+}
+
+func (f *fakeEngine) snapRemoved(name string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Contains(f.snapRemoves, name)
 }


### PR DESCRIPTION
On wake, `wakeResolved` ran `m.dropSnap(ctx, snap)` **synchronously** after the resume + probe succeeded — spawning a `cocoon snapshot rm` subprocess (~tens of ms) that the SDK caller waited on before receiving its socket. It's pure disk reclamation the caller doesn't need to block on.

## Change
- The wake's post-success `dropSnap` runs in the background (`go m.dropSnap`), off the wake-return path. On a ~40ms wake (restore + probe), removing a ~9-25ms subprocess spawn is a meaningful cut to the SDK-observed wake latency.
- **Correctness:** the hibernate snapshot name was derived deterministically from the VM name, so a re-hibernate right after a wake could reuse a name the async drop hadn't deleted yet (cocoon refuses a duplicate snapshot name). The name now gets a `randHex` suffix (same idiom `sourceSnap` already uses for forks), so consecutive cycles never collide. A drop that fails is still reclaimed by the existing orphan-hibernate-snapshot sweep (`reconcileSnapshots`).
- Release and mid-transition-abort drops stay synchronous — they're off the hot wake path.

## Measurement
`TestWakeDropsSnapshotOffReturnPath` stalls the fake engine's `SnapshotRemove` and asserts the wake still returns:
- **sync** (async reverted): `WakeAgentSocket` blocks on the stalled removal → test **times out at 15s**.
- **async**: wake returns immediately (`snapRemoveCount==0` while stalled), then the drop completes once unblocked → **PASS**.

Magnitude on hardware = one `cocoon snapshot rm` spawn (~9ms per the perf-audit's subprocess figure) removed from every SDK wake.

## Gates
`go build` ✓, `go test -race ./pool/` ✓ (full suite; `TestHibernateWakeCycle` updated to `waitFor` the now-async drop), `golangci-lint run` linux+darwin ✓ (0 issues), `fmt --diff` ✓.