### PR TITLE
perf(silkd): memchr the session sentinel scan (~26x)

### DIFF
--- a/silkd/Cargo.lock
+++ b/silkd/Cargo.lock
@@ -482,6 +482,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "libc",
+ "memchr",
  "notify",
  "regex",
  "serde",

--- a/silkd/Cargo.toml
+++ b/silkd/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 base64 = "0.22"
 libc = "0.2"
+memchr = "2"
 notify = "6"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/silkd/src/session.rs
+++ b/silkd/src/session.rs
@@ -246,7 +246,7 @@ impl Io {
                 return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "shell exited"));
             }
             acc.extend_from_slice(&buf[..n]);
-            if let Some(pos) = find(&acc, mb) {
+            if let Some(pos) = memchr::memmem::find(&acc, mb) {
                 emit(&mut out, &mut frame, &acc[..pos]).await;
                 let mut rest = acc[pos + mb.len()..].to_vec();
                 while !rest.contains(&b'\n') && rest.len() < EXIT_TAIL_MAX {
@@ -302,13 +302,6 @@ async fn emit<W: AsyncWrite + Unpin>(out: &mut Option<&mut W>, frame: &mut Vec<u
     if failed {
         *out = None;
     }
-}
-
-fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    if needle.is_empty() || haystack.len() < needle.len() {
-        return None;
-    }
-    haystack.windows(needle.len()).position(|w| w == needle)
 }
 
 /// POSIX single-quote quoting: wrap in '…', closing/reopening around any


### PR DESCRIPTION
A persistent-shell (`session`) command's output is delimited by an unpredictable `__SILK_<32hex>__` sentinel. `converse` scanned each accumulated ~32KB output chunk for it with a hand-rolled `haystack.windows(needle.len()).position(|w| w == needle)` byte-walk, once per read. For a session command with large output (a build, a verbose log), that scan runs on every 32KB chunk.

## Measurement (isolated, M2 Max)
Scanning a 32KB no-match buffer for the 41-byte marker:
| | µs/scan |
|---|---|
| naive `windows().position()` | **37.8 µs** |
| `memchr::memmem::find` | **1.4 µs** |
| ratio | **~26x** |

37.8µs/32KB is **more than the base64 encode of the same bytes** (~15µs) — so on a large-output session command the sentinel scan was a larger per-chunk cost than the base64 the perf sweep had assumed dominated. For a 200MB session command (~6100 chunks) the scans alone drop from ~230ms to ~9ms.

## Change
Replace the naive `find` with `memchr::memmem::find` (SIMD first-byte skipping); `memchr` was already in the lock tree via `regex`, now a direct dep. **Only the session path uses this scan — plain `exec` is unaffected** (it frames on the exit protocol, not a sentinel).

## Gates
- macOS: `fmt --check` ✓, `clippy --all-targets -D warnings` ✓, `cargo test` ✓.
- Linux (native arm64 `rust:1-slim` container, fixtures + git): `clippy` ✓, `cargo test` ✓ (18/18 incl. the session round-trip tests that drive `converse`).