### PR TITLE
review: tighten comments, fix stale claims-journal docs

### DIFF
--- a/boot/init/src/cfg.rs
+++ b/boot/init/src/cfg.rs
@@ -327,16 +327,13 @@ mod tests {
 
     #[test]
     fn parse_ip_param_variants() {
-        // No DNS, zero gateway.
         let p = parse_ip_param("10.0.0.2::0.0.0.0:255.255.254.0:vm:eth1:off").unwrap();
         assert_eq!(p.prefix, 23);
         assert_eq!(p.gateway, None);
         assert!(p.dns.is_empty());
         assert_eq!(p.device, "eth1");
-        // Zero DNS entries are filtered.
         let p = parse_ip_param("10.0.0.2::10.0.0.1:255.255.255.0:vm:eth0:off:0.0.0.0").unwrap();
         assert!(p.dns.is_empty());
-        // Shorthand and malformed forms are ignored.
         assert_eq!(parse_ip_param("dhcp"), None);
         assert_eq!(parse_ip_param("off"), None);
         assert_eq!(parse_ip_param("10.0.0.2::gw:not-a-mask:vm:eth0:off"), None);

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -101,22 +101,19 @@ snapshot paths.
 
 ## Claims-journal write path
 
-Every claim/release/hibernate persists `claims.json` inside the pool mutex
-(marshal + write + rename). Benchmark (`BenchmarkStoreSaveScaling`, APFS
-SSD), per save:
+`claim`/`release`/`hibernate`/`wake` persist `claims.json`, but the write is
+kept off the manager mutex — the lock every data-plane op contends. `snapshot()`
+takes a cheap by-value copy of the claim map under the mutex; `commit()` marshals
+it, writes, and renames off the mutex, serialized and coalescing by sequence so
+an older snapshot never overwrites a newer one. Only the startup `Reconcile`
+pass (pre-contention) still marshals and writes in one call under the lock.
 
-| live claims | ns/op | B/op |
-|---|---|---|
-| 10 | ~181k (0.18ms) | 4.5k |
-| 100 | ~240k (0.24ms) | 36k |
-| 1000 | ~829k (0.83ms) | 385k |
-
-At realistic scale the in-mutex write is sub-millisecond and dwarfed by the
-provision path (~40ms clone, ~230ms cold); the mutex-held serialization
-does not approach a 2× claim-latency regression. **Decision: keep the
-simple in-mutex write; do not move to a store-owned sequential writer.**
-The benchmark stays as a regression sentinel — revisit only if it crosses
-into the milliseconds at the deployment's real claim count.
+`BenchmarkStorePersistContention` measures the ns a concurrent manager-mutex
+acquire waits during a persist. Moving first the write (F1), then the marshal
+(F1 part 2), off the lock cut that wait from tens of µs to tens of ns — the
+marshal-off-lock split alone is a ~6× drop at 1000 live claims, a margin that
+grows with claim count. `BenchmarkStoreSaveScaling` (the combined `save()`
+Reconcile uses) stays as a regression sentinel.
 
 ## Measured and declined (decision data)
 

--- a/sandboxd/engine/portconn.go
+++ b/sandboxd/engine/portconn.go
@@ -20,12 +20,9 @@ const (
 	portReadBuf = 64 << 10
 )
 
-// guestPortConn adapts silkd's framed port_forward channel to a plain
-// net.Conn: the guest's TCP bytes ride inside newline-JSON `data` frames
-// (base64 payloads), so writes wrap into `{"op":"data",...}` frames and
-// reads unwrap `{"type":"data",...}` frames back to raw bytes. This is the
-// server-side twin of the SDK's PortConn, so a reverse proxy can splice HTTP
-// straight through it.
+// guestPortConn adapts silkd's newline-JSON data-frame port_forward channel to
+// a plain net.Conn (base64 payloads), the server-side twin of the SDK's
+// PortConn, so a reverse proxy can splice HTTP straight through it.
 type guestPortConn struct {
 	net.Conn
 	r       *bufio.Reader

--- a/sandboxd/pool/claims.go
+++ b/sandboxd/pool/claims.go
@@ -41,12 +41,11 @@ type claimDTO struct {
 // VMs are deliberately not persisted: they are cheap to rebuild and unsafe
 // to trust after an unsupervised gap.
 //
-// A write is split so the manager mutex covers only the marshal (a consistent
-// snapshot of the claim map), not the file syscalls: snapshot() runs under the
-// manager mutex, commit() writes off it. commit is serialized and coalescing —
-// a snapshot no newer than one already on disk is dropped, because sequence
-// order matches the manager-mutex mutation order, so the newest write wins and
-// an older one only ever describes a superseded state.
+// The write is split to keep the manager mutex off both the marshal and the
+// file syscalls: snapshot() takes a cheap field-copy under the mutex, commit()
+// marshals and writes off it — serialized and coalescing so a snapshot no newer
+// than one already on disk is dropped (sequence order matches mutation order,
+// so an older write only ever describes a superseded state).
 type claimStore struct {
 	path string
 

--- a/sandboxd/server/server.go
+++ b/sandboxd/server/server.go
@@ -210,13 +210,10 @@ func (s *Server) handleClaim(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// redirectClaim answers a warm-miss claim with a redirect when a peer is the
-// better node: one that reports warm sandboxes, or — when this node has no
-// golden for the key — the owner of a promoted template gossip names, which
-// provisions from it instead of us cold-booting a nonexistent image ref. A
-// claim already redirected here carries no_redirect and must warm-or-provision
-// locally, never bounce again — that avoids a two-node stale-view ping-pong
-// when both just emptied their pools.
+// redirectClaim redirects a warm-miss to a better peer — a warm holder, or the
+// template owner when we lack a golden (so we don't cold-boot a nonexistent
+// image ref). A no_redirect request must resolve locally, never bounce again,
+// to avoid a two-node ping-pong.
 func (s *Server) redirectClaim(ctx context.Context, w http.ResponseWriter, req types.ClaimRequest, key types.PoolKey, hash string) bool {
 	if s.placer == nil || req.NoRedirect {
 		return false

--- a/sdk/openai/cocoonsandbox_openai/adapter.py
+++ b/sdk/openai/cocoonsandbox_openai/adapter.py
@@ -165,7 +165,7 @@ class CocoonSandboxClient(BaseSandboxClient[CocoonSandboxClientOptions]):
         inner = session._inner
         if not isinstance(inner, CocoonSandboxSession):
             raise TypeError("CocoonSandboxClient.delete expects a CocoonSandboxSession")
-        await inner._shutdown_backend()  # close any local port proxies
+        await inner._shutdown_backend()
         await asyncio.to_thread(inner._sandbox().close)  # 404-safe in the SDK
         return session
 


### PR DESCRIPTION
Whole-repo `/code /code-rs /code-py` comment-budget pass plus a docs-staleness check against the recently merged #12–#16. Comment-only + docs; no behavior change. A 5-agent scan flagged ~50 candidates; most were already-tight, load-bearing WHY comments (#7 tightened them) and were **deliberately left alone** — this PR applies only genuine reductions and two real staleness fixes.

## Staleness fixes (the substantive part)
- **`docs/performance.md` — "Claims-journal write path"**: the section stated *"keep the simple in-mutex write; do not move to a store-owned sequential writer."* F1 (#6) and F1-part-2 (#14) did exactly that. Rewritten for the `snapshot()` (field-copy under the manager mutex) / `commit()` (marshal + write off it) split, with the stale `BenchmarkStoreSaveScaling` table replaced by a `BenchmarkStorePersistContention` description (kept to the robust ~6× ratio; absolute ns not re-cited without a fresh hardware run).
- **`sandboxd/pool/claims.go` — `claimStore` doc**: still said *"the manager mutex covers only the marshal"*. #14 moved the marshal **off** the mutex (snapshot now takes a cheap field-copy). Corrected + tightened.

## Comment reductions (restate / narrative only)
- `sandboxd/server/server.go` `redirectClaim`: dropped scenario-painting, kept the redirect targets + no_redirect ping-pong WHY.
- `sandboxd/engine/portconn.go` `guestPortConn`: dropped the `{op:data}`/`{type:data}` restate-of-code, kept the wire format + purpose.
- `boot/init/src/cfg.rs`: removed three test sub-case labels the asserts already state.
- `sdk/openai/.../adapter.py`: removed one restate comment (kept the load-bearing `# 404-safe in the SDK`).

## Deliberately NOT changed
- Dense multi-line WHY in `refill.go`, `claim.go`, `pool.go`, `hibernate.go`, `mesh.go`, `relay.go`, silkd `exec.rs`/`session.rs`/`lsp.rs` — accurate and load-bearing; re-compressing #7-approved prose would be churn.
- `docs/benchmarks.md` fs_pull row is stale post-#13 (~2× faster) but the log is append-only; a fresh row needs a bare-metal re-bench (.79 currently off), so no fabricated number was added.

## Gates
- Go (sandboxd): `go build` ✓, `go vet` darwin+linux ✓, `golangci-lint run` darwin+linux → 0 issues, `golangci-lint fmt --diff` clean, `go test -race` pool/engine/server → ok.
- Rust (boot/init): `cargo fmt --check` ✓, `cargo clippy --all-targets -D warnings` ✓, `cargo test parse_ip_param` → ok.
- Python (sdk/openai): `ruff check` → all passed, `py_compile` ✓; `pytest` blocked by the external `agents` (openai-agents) SDK absent in this env (comment-only change).