### PR TITLE
feat(os-image): browser flavor — headless Chrome for Testing with CDP

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -1,0 +1,79 @@
+# Browser sandboxes
+
+The `browser` flavor boots with headless Chromium (Chrome for Testing)
+already running and its CDP endpoint on guest loopback `9222`. An agent
+claims it and drives it with any CDP client — Playwright `connectOverCDP`,
+Puppeteer, Stagehand — through the existing port relay. Two things no
+hosted browser service offers: checkpoint/branch of a live browser, and
+CDP on the no-network lane over vsock.
+
+```go
+sb, err := client.New(ctx, "ghcr.io/cocoonstack/sandbox/browser:24.04",
+    sandbox.WithNetwork(sandbox.NetEgress), sandbox.WithSize(sandbox.Large))
+```
+
+The claim returns when silkd answers (the usual tiers); Chromium finishes
+starting a beat later — poll `/json/version` until it answers:
+
+```go
+pc, err := sb.DialPort(ctx, 9222)
+// GET /json/version with Host: localhost → {"Browser":"HeadlessChrome/150…"}
+```
+
+## Claim shape
+
+- **Lane**: any. `net=egress` to browse the real web; `net=none` (vsock
+  only, zero NIC) drives local/bundled content — CDP rides the relay either
+  way.
+- **Size**: `large` (4 CPU / 4G) — a persistent Chromium idles at
+  ~150–250 MB RSS and real pages want headroom; `xlarge` for heavy
+  multi-tab work.
+- **Template**: `ghcr.io/cocoonstack/sandbox/browser:24.04` —
+  `base:24.04` plus a pinned Chrome for Testing launched by a systemd
+  unit (`--headless=new`, CDP on `127.0.0.1:9222`).
+
+## CDP access
+
+Chromium M113+ binds the DevTools port to loopback only — here that is a
+feature: silkd's forwarder dials guest loopback, so CDP is reachable only
+through an authorized claim and never sits on a guest NIC.
+
+- **`ProxyPort` (real CDP clients)** — Chrome's Host-header allowlist
+  accepts the IP:
+
+  ```go
+  ln, err := sb.ProxyPort(ctx, "127.0.0.1:0", 9222)
+  // playwright: chromium.connectOverCDP("http://" + ln.Addr().String())
+  ```
+
+- **`DialPort` (raw, works on the no-network lane)** — send HTTP with
+  `Host: localhost`; `GET /json/version`, `PUT /json/new?<url>` to open a
+  target, then a WebSocket to the returned `webSocketDebuggerUrl`.
+
+## Checkpoint / branch a live browser
+
+`sb.Checkpoint` + `ck.New` fork a warmed browser — in-memory tabs,
+cookies, localStorage — in checkpoint-restore time; the branch answers
+`/json/version` without relaunching Chrome. Hosted browser services
+cold-start a browser per session; here a warmed profile is a template you
+branch from.
+
+## What works, what differs
+
+- Everything from the Ubuntu flavors (exec, files, sessions, git, pty)
+  plus the running Chromium.
+- **Preview URLs are not raw CDP**: the preview proxy rewrites `Host` to
+  `sandbox-id:port`, which Chrome's DevTools allowlist rejects. Use
+  `ProxyPort`/`DialPort` for CDP; preview URLs serve human-facing HTTP the
+  workload chooses to expose (a live-view page, a screenshot server).
+- Guest env knobs on the unit: `CDP_PORT` (default 9222),
+  `CHROMIUM_FLAGS` (extra flags).
+- No stealth build in v1: headless Chromium is fingerprintable; this
+  flavor targets automation, not anti-bot evasion.
+- One browser per sandbox by design — the VM is the isolation and
+  checkpoint unit; open tabs via CDP `Target.createTarget`.
+- x86_64 only.
+
+The hardware acceptance is `e2e/cmd/browsersmoke`: claim →
+`/json/version` over the relay → open a target via `PUT /json/new` →
+checkpoint/branch re-verification.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,9 @@ bridge/CNI NIC. Backends are never user-selected.
   inside cocoon microVMs via the custom sandbox-provider interface
 - [Android sandboxes](android.md) — the redroid flavor: claim shape, adb
   access through the relay or the network, checkpoint/branch
+- [Browser sandboxes](browser.md) — headless Chromium with CDP through
+  the relay: Playwright/Puppeteer access, checkpoint/branch of a live
+  browser
 - [silkd](silkd.md) — the in-guest daemon: protocol, verb reference, lanes
   and limits
 - [Performance](performance.md) — measured latencies and the environments

--- a/e2e/cmd/browsersmoke/main.go
+++ b/e2e/cmd/browsersmoke/main.go
@@ -1,0 +1,147 @@
+// browsersmoke is the M7-2 acceptance: claim the browser flavor → CDP
+// /json/version over the relay → open a target → checkpoint/branch of the
+// warmed browser.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	sandbox "github.com/cocoonstack/sandbox/sdk/go"
+)
+
+const (
+	cdpPort = 9222
+	// Chromium starts after silkd, so the claim returns before CDP is up;
+	// a cold first launch on a loaded node can take tens of seconds.
+	cdpWait = 3 * time.Minute
+)
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:7777", "sandboxd address")
+	token := flag.String("token", "", "node api token")
+	template := flag.String("template", "ghcr.io/cocoonstack/sandbox/browser:24.04", "browser template ref")
+	flag.Parse()
+
+	if err := run(*addr, *token, *template); err != nil {
+		fmt.Fprintln(os.Stderr, "browsersmoke:", err)
+		os.Exit(1)
+	}
+	fmt.Println("BROWSERSMOKE PASS")
+}
+
+func run(addr, token, template string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+	var copts []sandbox.ClientOption
+	if token != "" {
+		copts = append(copts, sandbox.WithAPIToken(token))
+	}
+	client, err := sandbox.Connect(addr, copts...)
+	if err != nil {
+		return err
+	}
+
+	start := time.Now()
+	sb, err := client.New(ctx, template,
+		sandbox.WithNetwork(sandbox.NetNone), sandbox.WithSize(sandbox.Large),
+		sandbox.WithTimeout(20*time.Minute))
+	if err != nil {
+		return fmt.Errorf("claim: %w", err)
+	}
+	defer func() { _ = sb.Close() }()
+	fmt.Printf("  claim: browser large up in %.1fs (silkd probed)\n", time.Since(start).Seconds())
+
+	if err = waitCDP(ctx, sb); err != nil {
+		return err
+	}
+	if err = openTarget(ctx, sb); err != nil {
+		return err
+	}
+
+	ckpt, err := sb.Checkpoint(ctx, "browser-warmed")
+	if err != nil {
+		return fmt.Errorf("checkpoint: %w", err)
+	}
+	defer func() { _ = ckpt.Delete(ctx) }()
+	branch, err := ckpt.New(ctx)
+	if err != nil {
+		return fmt.Errorf("branch: %w", err)
+	}
+	defer func() { _ = branch.Close() }()
+	if err := waitCDP(ctx, branch); err != nil {
+		return fmt.Errorf("branch: %w", err)
+	}
+	fmt.Println("  checkpoint: branch of the warmed browser answers /json/version without relaunch")
+	return nil
+}
+
+func waitCDP(ctx context.Context, sb *sandbox.Sandbox) error {
+	deadline := time.Now().Add(cdpWait)
+	for {
+		ver, err := cdpJSON(ctx, sb, "GET", "/json/version")
+		if err == nil {
+			if b, _ := ver["Browser"].(string); strings.Contains(b, "Chrome") {
+				fmt.Printf("  cdp: /json/version → %s (protocol %v)\n", b, ver["Protocol-Version"])
+				return nil
+			}
+			err = fmt.Errorf("unexpected browser %v", ver["Browser"])
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("cdp never answered: %w", err)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// openTarget proves CDP accepts writes, not just liveness.
+func openTarget(ctx context.Context, sb *sandbox.Sandbox) error {
+	tgt, err := cdpJSON(ctx, sb, "PUT", "/json/new?about:blank")
+	if err != nil {
+		return fmt.Errorf("open target: %w", err)
+	}
+	ws, _ := tgt["webSocketDebuggerUrl"].(string)
+	if ws == "" {
+		return fmt.Errorf("open target: no webSocketDebuggerUrl in %v", tgt)
+	}
+	fmt.Println("  cdp: PUT /json/new opened a target (webSocketDebuggerUrl present)")
+	return nil
+}
+
+// cdpJSON hand-rolls one HTTP request over the port relay; Chrome's DevTools
+// Host allowlist accepts "localhost" but not proxied vhosts.
+func cdpJSON(ctx context.Context, sb *sandbox.Sandbox, method, path string) (map[string]any, error) {
+	pc, err := sb.DialPort(ctx, cdpPort)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = pc.Close() }()
+	if _, err = fmt.Fprintf(pc, "%s %s HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n", method, path); err != nil {
+		return nil, err
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(pc), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s %s: %s: %s", method, path, resp.Status, strings.TrimSpace(string(body)))
+	}
+	var out map[string]any
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	return out, nil
+}

--- a/os-image/browser/24.04/Dockerfile
+++ b/os-image/browser/24.04/Dockerfile
@@ -1,0 +1,85 @@
+# browser sandbox flavor: base + headless Chrome for Testing with its CDP
+# endpoint on guest loopback 9222, reached through the silkd port relay.
+# Ubuntu's chromium apt package is a snap stub that cannot install in a
+# Docker build; Chrome for Testing is Google's pinned automation build.
+ARG BASE_IMAGE=ghcr.io/cocoonstack/sandbox/base:24.04
+
+FROM ${BASE_IMAGE}
+ENV DEBIAN_FRONTEND=noninteractive
+# See base: cache-busts the layers below when non-Dockerfile inputs change.
+ARG INPUTS_HASH=
+
+ARG CHROME_VERSION=150.0.7871.115
+ARG CHROME_SHA256=1be2db033133c5e2dd1a4e8664bf67b19a61bcf6ed28d2b00f433b3f0b4f9585
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    unzip \
+    fonts-liberation \
+    libasound2t64 \
+    libatk-bridge2.0-0t64 \
+    libatk1.0-0t64 \
+    libcairo2 \
+    libcups2t64 \
+    libdbus-1-3 \
+    libdrm2 \
+    libexpat1 \
+    libfontconfig1 \
+    libgbm1 \
+    libglib2.0-0t64 \
+    libnspr4 \
+    libnss3 \
+    libpango-1.0-0 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxext6 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    && curl -fsSL -o /tmp/chrome.zip \
+      "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chrome-linux64.zip" \
+    && echo "${CHROME_SHA256}  /tmp/chrome.zip" | sha256sum -c - \
+    && unzip -q /tmp/chrome.zip -d /opt \
+    && mv /opt/chrome-linux64 /opt/chrome \
+    && rm /tmp/chrome.zip \
+    && apt-get purge -y unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/lib/chromium \
+    && printf '%s\n' \
+      '#!/bin/sh' \
+      '# --no-sandbox: the microVM is the isolation boundary; Chrome userns' \
+      '# sandboxing cannot function in-guest. --disable-dev-shm-usage: guest' \
+      '# /dev/shm is small, Chrome crashes under load without it.' \
+      'exec /opt/chrome/chrome \' \
+      '  --headless=new \' \
+      '  --remote-debugging-port=${CDP_PORT:-9222} \' \
+      '  --remote-allow-origins=* \' \
+      '  --no-sandbox \' \
+      '  --disable-dev-shm-usage \' \
+      '  --disable-gpu \' \
+      '  --user-data-dir=/var/lib/chromium \' \
+      '  --window-size=1280,800 \' \
+      '  ${CHROMIUM_FLAGS:-} \' \
+      '  about:blank' \
+      > /usr/local/bin/chromium-cdp \
+    && chmod 0755 /usr/local/bin/chromium-cdp \
+    # Product service, not a readiness gate: claim returns on silkd; CDP
+    # comes up a beat later and is polled by the workload (see docs).
+    && printf '%s\n' \
+      '[Unit]' \
+      'Description=headless Chromium with CDP on loopback' \
+      'After=silkd.service' \
+      '' \
+      '[Service]' \
+      'Type=simple' \
+      'ExecStart=/usr/local/bin/chromium-cdp' \
+      'Restart=always' \
+      'RestartSec=2s' \
+      'LimitNOFILE=65536' \
+      '' \
+      '[Install]' \
+      'WantedBy=multi-user.target' \
+      > /etc/systemd/system/chromium.service \
+    && systemctl enable chromium.service

--- a/os-image/browser/README.md
+++ b/os-image/browser/README.md
@@ -1,0 +1,37 @@
+# browser flavor
+
+Headless-browser guest for CDP automation sandboxes: `base:24.04` plus a
+pinned [Chrome for Testing](https://googlechromelabs.github.io/chrome-for-testing/)
+build launched at boot with its DevTools (CDP) endpoint on guest loopback
+`9222`. An agent claims it and connects any CDP client (Playwright
+`connectOverCDP`, Puppeteer) through the silkd port relay. The intended
+pool shape is `size: large` (4 CPU / 4G) — a persistent Chromium idles at
+~150–250 MB RSS.
+
+## Build
+
+- `24.04/Dockerfile` — `FROM base:24.04`; apt the Chromium shared-lib set;
+  download Chrome for Testing pinned by version + SHA256 (the
+  `install-agent.sh` idiom); bake `/usr/local/bin/chromium-cdp` and
+  `chromium.service` (enabled, `multi-user.target`).
+- `platforms` — `linux/amd64`; the base lineage is amd64-only.
+
+Why Chrome for Testing: Ubuntu 24.04's `chromium` apt package is a
+transitional stub that pulls the snap, and snap cannot install inside a
+Docker build. Chrome for Testing is Google's official automation build
+with machine-readable pinned download URLs per version.
+
+Version bumps: update `CHROME_VERSION` + `CHROME_SHA256` from
+`last-known-good-versions-with-downloads.json`, same operational load as
+`COCOON_AGENT_VERSION`.
+
+## CDP on loopback is intentional
+
+Chromium M113+ binds `--remote-debugging-port` to `127.0.0.1` only. In
+this stack that is exactly right: silkd's forwarder dials guest loopback,
+so CDP is fully reachable through an authorized claim over vsock and never
+exposed on a guest NIC — including on the no-network lane.
+
+`chromium.service` is a product service, not a readiness gate: the claim
+still returns the moment silkd answers; Chromium comes up a beat later and
+is polled by the workload (`e2e/cmd/browsersmoke` shows the pattern).

--- a/os-image/browser/platforms
+++ b/os-image/browser/platforms
@@ -1,0 +1,1 @@
+linux/amd64


### PR DESCRIPTION
M7-2 `browser:24.04` flavor (`cocoon-specs/sandbox/sandbox-m7-2-browser-flavor-research.md`). A claimable Ubuntu sandbox that boots with headless Chrome for Testing running and its CDP endpoint on guest loopback `9222`, reached through the existing silkd port relay. Two differentiators no hosted browser service has: checkpoint/branch of a live browser, and CDP on the no-network lane over vsock.

## What lands (all additive — no sandboxd/silkd/SDK/cocoon changes)
- `os-image/browser/24.04/Dockerfile` — `FROM base:24.04`; the Chromium shared-lib set via apt; **Chrome for Testing pinned by version + SHA256** (the `install-agent.sh` idiom, since Ubuntu's `chromium` apt package is a snap stub that can't install in a Docker build); bakes `/usr/local/bin/chromium-cdp` + `chromium.service` (enabled, `multi-user.target`, product service — not a readiness gate).
- `os-image/browser/{platforms,README.md}`, `docs/browser.md`, `docs/index.md` entry.
- `e2e/cmd/browsersmoke/main.go` — claim → `/json/version` + `PUT /json/new` over `DialPort` → checkpoint/branch re-verify. Stdlib-only, hand-rolled HTTP over the PortConn (mirrors `androidsmoke`).

## Evidence (.79 bare metal)
- Go gate: browsersmoke builds, `go vet`, `golangci-lint` linux+darwin 0 issues.
- Image: `docker build` OK → flatten (874 MB tar) → `cocoon image import browser:24.04` (521.8 MB, 1 layer).
- **In-guest CDP probe** (`cocoon vm exec` curl, so it needs only the `exec` verb): Chrome/150.0.7871.115 CDP up on `127.0.0.1:9222` in ~1s, `/json/version` (protocol 1.3, `webSocketDebuggerUrl` present) **and** `PUT /json/new` (opens a target) both OK; 12 chrome procs. Proves the flavor's core: headless Chrome autostarts with a working read+write CDP endpoint on loopback.

## Known caveat
`browsersmoke`'s relay path (`DialPort`) needs a base image whose baked silkd has the `port_forward` verb. The current published `base:24.04` silkd predates it, so browsersmoke-over-relay fails against a locally-built image on the stale base — an image-staleness issue, not a flavor defect: `rt:24.04`'s current silkd passes `port_forward` in the e2e `port` step. CI rebuilds `base` fresh, so the shipped flavor carries a current silkd. Flagged in ops-audit for a rebake-and-rerun once the flavor image is published.