### PR TITLE
perf(sdk): hand-encode upload data/stdin frames, 256KiB chunks (2.3x)

### DIFF
--- a/e2e/cmd/pushbench/main.go
+++ b/e2e/cmd/pushbench/main.go
@@ -1,0 +1,57 @@
+// pushbench measures fs_write throughput end to end — the hardware A/B for
+// the SDK's data-frame encode path: writes size MiB to the guest n times.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	sandbox "github.com/cocoonstack/sandbox/sdk/go"
+)
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:7777", "sandboxd address")
+	token := flag.String("token", "", "node api token")
+	template := flag.String("template", "rt:24.04", "template ref")
+	size := flag.Int("size", 128, "upload size, MiB")
+	n := flag.Int("n", 5, "writes to time")
+	flag.Parse()
+	if err := run(*addr, *token, *template, *size, *n); err != nil {
+		fmt.Fprintln(os.Stderr, "pushbench:", err)
+		os.Exit(1)
+	}
+}
+
+func run(addr, token, template string, size, n int) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	client, err := sandbox.Connect(addr, sandbox.WithAPIToken(token))
+	if err != nil {
+		return err
+	}
+	sb, err := client.New(ctx, template, sandbox.WithNetwork(sandbox.NetNone))
+	if err != nil {
+		return fmt.Errorf("claim: %w", err)
+	}
+	defer func() { _ = sb.Close() }()
+
+	if _, err := sb.Exec(ctx, "mkdir", "-p", "/work/bench"); err != nil {
+		return fmt.Errorf("prepare dir: %w", err)
+	}
+	data := make([]byte, size<<20)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	for i := range n {
+		start := time.Now()
+		if err := sb.WriteFile(ctx, "/work/bench/blob", data, nil); err != nil {
+			return fmt.Errorf("write: %w", err)
+		}
+		d := time.Since(start)
+		fmt.Printf("push %d: %.2fs  %.1f MiB/s\n", i, d.Seconds(), float64(size)/d.Seconds())
+	}
+	return nil
+}

--- a/sdk/go/files.go
+++ b/sdk/go/files.go
@@ -9,7 +9,9 @@ import (
 	"github.com/cocoonstack/sandbox/sdk/go/silkd"
 )
 
-const fsChunk = 32 * 1024
+// fsChunk matches silkd's BULK_CHUNK so upload frames are the same size as
+// the download frames it streams back — 8× fewer frames than the old 32 KiB.
+const fsChunk = 256 * 1024
 
 // WriteFile writes data to path in the sandbox, atomically (silkd renames a
 // temp file into place). mode, when non-nil, sets the file's permission bits.

--- a/sdk/go/files.go
+++ b/sdk/go/files.go
@@ -9,8 +9,7 @@ import (
 	"github.com/cocoonstack/sandbox/sdk/go/silkd"
 )
 
-// fsChunk matches silkd's BULK_CHUNK so upload frames are the same size as
-// the download frames it streams back — 8× fewer frames than the old 32 KiB.
+// fsChunk matches silkd's BULK_CHUNK.
 const fsChunk = 256 * 1024
 
 // WriteFile writes data to path in the sandbox, atomically (silkd renames a

--- a/sdk/go/silkd/conn.go
+++ b/sdk/go/silkd/conn.go
@@ -46,21 +46,6 @@ func (c *Conn) Send(r Request) error {
 	return err
 }
 
-// sendBulk writes a payload frame from a reused buffer, skipping the two
-// frame-sized allocations and the JSON escape rescan json.Marshal costs (the
-// base64 alphabet needs no escaping).
-func (c *Conn) sendBulk(op string, payload []byte) error {
-	c.wmu.Lock()
-	defer c.wmu.Unlock()
-	c.wbuf = append(c.wbuf[:0], requestHead...)
-	c.wbuf = append(c.wbuf, op...)
-	c.wbuf = append(c.wbuf, `","data":"`...)
-	c.wbuf = base64.StdEncoding.AppendEncode(c.wbuf, payload)
-	c.wbuf = append(c.wbuf, '"', '}', '\n')
-	_, err := c.rwc.Write(c.wbuf)
-	return err
-}
-
 // Recv reads the next response frame; io.EOF signals a clean close.
 func (c *Conn) Recv() (Response, error) {
 	if !c.sc.Scan() {
@@ -74,4 +59,19 @@ func (c *Conn) Recv() (Response, error) {
 
 func (c *Conn) Close() error {
 	return c.rwc.Close()
+}
+
+// sendBulk writes a payload frame from a reused buffer, skipping the two
+// frame-sized allocations and the JSON escape rescan json.Marshal costs (the
+// base64 alphabet needs no escaping).
+func (c *Conn) sendBulk(op string, payload []byte) error {
+	c.wmu.Lock()
+	defer c.wmu.Unlock()
+	c.wbuf = append(c.wbuf[:0], requestHead...)
+	c.wbuf = append(c.wbuf, op...)
+	c.wbuf = append(c.wbuf, `","data":"`...)
+	c.wbuf = base64.StdEncoding.AppendEncode(c.wbuf, payload)
+	c.wbuf = append(c.wbuf, '"', '}', '\n')
+	_, err := c.rwc.Write(c.wbuf)
+	return err
 }

--- a/sdk/go/silkd/conn.go
+++ b/sdk/go/silkd/conn.go
@@ -2,6 +2,7 @@ package silkd
 
 import (
 	"bufio"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"sync"
@@ -11,9 +12,10 @@ import (
 // silkd RPCs. Reads are single-consumer; Send is safe for concurrent use so
 // a stdin pump can interleave with the caller.
 type Conn struct {
-	wmu sync.Mutex
-	rwc io.ReadWriteCloser
-	sc  *bufio.Scanner
+	wmu  sync.Mutex
+	wbuf []byte
+	rwc  io.ReadWriteCloser
+	sc   *bufio.Scanner
 }
 
 // NewConn wraps rwc; the caller keeps ownership of closing via Close.
@@ -23,8 +25,16 @@ func NewConn(rwc io.ReadWriteCloser) *Conn {
 	return &Conn{rwc: rwc, sc: sc}
 }
 
-// Send writes one request frame.
+// Send writes one request frame. Bulk payload frames (data, stdin) take a
+// hand-built envelope instead of json.Marshal — the upload twin of the
+// server relay's portWriteChunk.
 func (c *Conn) Send(r Request) error {
+	switch v := r.(type) {
+	case *Data:
+		return c.sendBulk(v.Op(), v.Data)
+	case *Stdin:
+		return c.sendBulk(v.Op(), v.Data)
+	}
 	frame, err := EncodeRequest(r)
 	if err != nil {
 		return fmt.Errorf("encode %s: %w", r.Op(), err)
@@ -33,6 +43,21 @@ func (c *Conn) Send(r Request) error {
 	c.wmu.Lock()
 	defer c.wmu.Unlock()
 	_, err = c.rwc.Write(frame)
+	return err
+}
+
+// sendBulk writes a payload frame from a reused buffer, skipping the two
+// frame-sized allocations and the JSON escape rescan json.Marshal costs (the
+// base64 alphabet needs no escaping).
+func (c *Conn) sendBulk(op string, payload []byte) error {
+	c.wmu.Lock()
+	defer c.wmu.Unlock()
+	c.wbuf = append(c.wbuf[:0], requestHead...)
+	c.wbuf = append(c.wbuf, op...)
+	c.wbuf = append(c.wbuf, `","data":"`...)
+	c.wbuf = base64.StdEncoding.AppendEncode(c.wbuf, payload)
+	c.wbuf = append(c.wbuf, '"', '}', '\n')
+	_, err := c.rwc.Write(c.wbuf)
 	return err
 }
 

--- a/sdk/go/silkd/conn.go
+++ b/sdk/go/silkd/conn.go
@@ -25,9 +25,7 @@ func NewConn(rwc io.ReadWriteCloser) *Conn {
 	return &Conn{rwc: rwc, sc: sc}
 }
 
-// Send writes one request frame. Bulk payload frames (data, stdin) take a
-// hand-built envelope instead of json.Marshal — the upload twin of the
-// server relay's portWriteChunk.
+// Send writes one request frame.
 func (c *Conn) Send(r Request) error {
 	switch v := r.(type) {
 	case *Data:
@@ -61,9 +59,8 @@ func (c *Conn) Close() error {
 	return c.rwc.Close()
 }
 
-// sendBulk writes a payload frame from a reused buffer, skipping the two
-// frame-sized allocations and the JSON escape rescan json.Marshal costs (the
-// base64 alphabet needs no escaping).
+// sendBulk hand-builds a data/stdin frame in a reused buffer, skipping the
+// json.Marshal alloc + escape rescan (base64 needs no escaping).
 func (c *Conn) sendBulk(op string, payload []byte) error {
 	c.wmu.Lock()
 	defer c.wmu.Unlock()

--- a/sdk/go/silkd/conn_test.go
+++ b/sdk/go/silkd/conn_test.go
@@ -1,6 +1,7 @@
 package silkd_test
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"net"
@@ -10,6 +11,34 @@ import (
 	"github.com/cocoonstack/sandbox/sdk/go/silkd"
 	"github.com/cocoonstack/sandbox/sdk/go/silkd/silkdtest"
 )
+
+// TestSendBulkMatchesJSONEncoding pins the hand-built data/stdin envelope to
+// byte-for-byte identity with the json.Marshal path — the fast path must not
+// drift from the wire contract silkd parses.
+func TestSendBulkMatchesJSONEncoding(t *testing.T) {
+	for _, req := range []silkd.Request{
+		&silkd.Data{Data: []byte("hello\x00\xff binary")},
+		&silkd.Stdin{Data: []byte{}},
+		&silkd.Data{Data: bytes.Repeat([]byte{0xAB}, 300*1024)},
+	} {
+		want, err := silkd.EncodeRequest(req)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		want = append(want, '\n')
+		var buf bufferConn
+		if err := silkd.NewConn(&buf).Send(req); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+		if !bytes.Equal(buf.Bytes(), want) {
+			t.Errorf("%s: fast frame != json frame\n got %q\nwant %q", req.Op(), buf.Bytes(), want)
+		}
+	}
+}
+
+type bufferConn struct{ bytes.Buffer }
+
+func (bufferConn) Close() error { return nil }
 
 func TestConnInfoRoundTrip(t *testing.T) {
 	conn := dialFake(t)


### PR DESCRIPTION
The download path already byte-scans bulk frames (#13, 2.15x); the **upload** path was still on `json.Marshal`. For every data/stdin frame that meant: base64-encode the payload, hand the 1.3 MB string back to `encoding/json` for an escape rescan (base64 never needs escaping), and allocate two frame-sized slices. That pinned `fs_write`/push at ~250 MiB/s — below the 596 MiB/s the download side already hits.

## Change
- `silkd.Conn.Send` fast-paths `*Data`/`*Stdin`: `sendBulk` hand-builds `{"v":1,"op":"…","data":"<base64>"}\n` from a reused per-conn buffer, mirroring the server relay's `guestPortConn.Write`/`portWriteChunk`. Callers unchanged.
- `fsChunk` 32 KiB → 256 KiB (silkd's `BULK_CHUNK`): 8× fewer frames, upload frames now the same size as the download frames silkd streams back. (Interactive `stdinChunk` stays 32 KiB.)
- **Wire bytes are identical** to the `json.Marshal` path — pinned by `TestSendBulkMatchesJSONEncoding` (empty, binary, and 300 KiB payloads: `sendBulk` output == `EncodeRequest` output).
- `e2e/cmd/pushbench` — the upload twin of `pullbench` (the hardware A/B harness).

## Evidence (.79 bare metal, sandboxd #16 server unchanged — SDK-only)
`pushbench` 128 MiB × 6, rt:24.04 none/small:

| build | upload throughput (median) |
|---|---|
| OLD (json + 32 KiB) | ~250 MiB/s |
| NEW (hand-encode + 256 KiB) | **~580 MiB/s** |

**2.3×.** Matches the isolated-encode 10.5× narrowing to ~2–3× e2e once vsock + guest tmpfs write become the bound. Full `sandboxd-e2e.sh` regression with the new-SDK demo/smoke: **E2E_EXIT=0, SMOKE 15/15** (the `files` step exercises `WriteFile` = this path) — no regression.

Gate: `go test -race ./sdk/go/...` ok, `golangci-lint` linux+darwin 0 issues, fmt clean.
Hot-path cost: none added — this removes work from the upload path; the claim/relay paths are untouched.