### PR TITLE
feat(egress): none-lane guarded egress — credentialed egress without a NIC

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -103,7 +103,7 @@ labeled and must only be compared against other nested runs.
 
 exec RTT is power-policy sensitive on this host: under the performance
 governor the same stack measures p50=0.18 p90=0.22 p99=0.27 (n=1000, ×2),
-reproducing the 07-08 entry; .79's 07-09 reboots reset the policy to
+reproducing the 07-08 entry; a host reboot reset the policy to
 powersave, whose C-state/freq-ramp latency lands in the tail. The guest is
 up 0.26s (its own /proc/uptime) when the first cold exec returns — silkd
 answers long before a console login prompt would appear.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -136,8 +136,8 @@ restart reconcile); set `BRIDGE=<dev>` to include the egress lane.
 ## Preview URLs
 
 `preview_listen` starts a second HTTP server that serves a sandbox's guest
-HTTP port under a signed, expiring URL — the E2B-style shareable preview.
-The whole mechanism is in sandboxd:
+HTTP port under a signed, expiring shareable URL. The whole mechanism is in
+sandboxd:
 
 - **Minting** (`sb.PreviewURL(port, ttl)`): the owner node signs a token
   embedding `{sandbox, port, owner, exp}` with `preview_secret`; the URL's

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -1,0 +1,77 @@
+# Guarded egress
+
+A sandbox gets the **effect** of a credential, never the credential. Outbound
+access is an allow-listed, audited resource enforced on the host: the secret
+lives host-side and enters no guest memory, so prompt injection can exfiltrate
+at most the proxy's answers, and every credentialed call lands in the audit and
+usage journals keyed by sandbox and tenant. Default-deny.
+
+The wedge: the same host proxy serves the **none lane** (a NIC-less Firecracker
+guest) over vsock, so a network-less sandbox can call approved APIs with
+injected credentials — a capability that assumes a NIC everywhere else.
+
+## How it works (none lane)
+
+The guest has no network device. silkd binds `127.0.0.1:3128` and relays each
+connection to sandboxd over vsock (`CID2:2049` → the host UDS
+`<vsock_socket>_2049`). sandboxd serves a per-sandbox forward proxy there,
+bound to that sandbox's identity by the socket path — no in-band token. The
+proxy evaluates the policy, injects the matched rule's secret host-side, dials
+the origin, and relays the response.
+
+A sandbox reaches it as a standard HTTP proxy:
+
+```sh
+curl -x http://127.0.0.1:3128 https://api.github.com/user   # allowed + credentialed
+curl -x http://127.0.0.1:3128 https://evil.example/         # 403 egress denied: evil.example
+```
+
+## Configuration
+
+Policy is per pool and per tenant; the effective policy is their intersection
+(a request must pass both, and the pool rule's secret wins on a double allow).
+Secrets are registered separately and referenced by name — the value comes from
+the environment, never the config file.
+
+```jsonc
+{
+  "secrets": [
+    { "name": "gh", "header": "Authorization", "value_env": "GH_TOKEN" }
+  ],
+  "pools": [
+    { "template": "rt:24.04", "net": "none", "size": "small", "warm": 2,
+      "egress": { "allow": [
+        { "host": "api.github.com", "methods": ["GET", "POST"], "secret": "gh" },
+        { "host": "*.googleapis.com" }
+      ] } }
+  ],
+  "tenants": [
+    { "name": "acme", "token": "…", "egress": { "allow": [{ "host": "api.github.com" }] } }
+  ]
+}
+```
+
+- `host`: an exact name, a `*.`-prefixed suffix wildcard, or `*`. Case-insensitive.
+- `methods`: empty means any.
+- `secret`: injects the named registered secret's header (plaintext requests
+  only; HTTPS injection needs TLS interception, below). A guest-supplied value
+  for the same header is overwritten.
+- No policy on a claim ⇒ no egress at all (the proxy is not started).
+
+Each decision is written to `audit.jsonl` (`op:"egress"`, host, allow/deny, the
+secret **name**) and metered as an `egress` usage event.
+
+## Lanes and roadmap
+
+| Slice | Status |
+|---|---|
+| none lane — proxy, policy, plaintext injection, audit | **shipped** |
+| HTTPS credential injection (per-node ephemeral-CA TLS interception) | planned |
+| egress lane — nftables default-deny on the tap, forcing the NIC through the proxy | planned |
+
+Today the **egress lane** (a NIC-backed guest) is not yet forced through the
+proxy; a policy on an `net:"egress"` pool is accepted but enforced only once the
+nftables slice lands. HTTPS requests on the none lane are gated by host
+(CONNECT allow/deny) and audited, but credential injection into an HTTPS request
+awaits TLS interception. Use the none lane with plaintext or CONNECT-gated
+HTTPS for the credentialed-egress guarantees above.

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -6,9 +6,9 @@ lives host-side and enters no guest memory, so prompt injection can exfiltrate
 at most the proxy's answers, and every credentialed call lands in the audit and
 usage journals keyed by sandbox and tenant. Default-deny.
 
-The wedge: the same host proxy serves the **none lane** (a NIC-less Firecracker
+The same host proxy also serves the **none lane** (a NIC-less Firecracker
 guest) over vsock, so a network-less sandbox can call approved APIs with
-injected credentials — a capability that assumes a NIC everywhere else.
+injected credentials — no NIC required in the guest.
 
 ## How it works (none lane)
 
@@ -61,17 +61,17 @@ the environment, never the config file.
 Each decision is written to `audit.jsonl` (`op:"egress"`, host, allow/deny, the
 secret **name**) and metered as an `egress` usage event.
 
-## Lanes and roadmap
+## Lanes and status
 
-| Slice | Status |
+| Capability | Status |
 |---|---|
 | none lane — proxy, policy, plaintext injection, audit | **shipped** |
 | HTTPS credential injection (per-node ephemeral-CA TLS interception) | planned |
 | egress lane — nftables default-deny on the tap, forcing the NIC through the proxy | planned |
 
 Today the **egress lane** (a NIC-backed guest) is not yet forced through the
-proxy; a policy on an `net:"egress"` pool is accepted but enforced only once the
-nftables slice lands. HTTPS requests on the none lane are gated by host
+proxy; a policy on a `net:"egress"` pool is accepted but enforced only once the
+nftables lockdown ships. HTTPS requests on the none lane are gated by host
 (CONNECT allow/deny) and audited, but credential injection into an HTTPS request
 awaits TLS interception. Use the none lane with plaintext or CONNECT-gated
 HTTPS for the credentialed-egress guarantees above.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,8 @@ bridge/CNI NIC. Backends are never user-selected.
 - [Browser sandboxes](browser.md) — headless Chromium with CDP through
   the relay: Playwright/Puppeteer access, checkpoint/branch of a live
   browser
+- [Guarded egress](egress.md) — allow-listed, audited outbound access with
+  host-side credential injection; the none-lane wedge
 - [silkd](silkd.md) — the in-guest daemon: protocol, verb reference, lanes
   and limits
 - [Performance](performance.md) — measured latencies and the environments

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -113,8 +113,8 @@ an older snapshot never overwrites a newer one. Only the startup `Reconcile`
 pass (pre-contention) still marshals and writes in one call under the lock.
 
 `BenchmarkStorePersistContention` measures the ns a concurrent manager-mutex
-acquire waits during a persist. Moving first the write (F1), then the marshal
-(F1 part 2), off the lock cut that wait from tens of µs to tens of ns — the
+acquire waits during a persist. Moving first the write, then the marshal,
+off the lock cut that wait from tens of µs to tens of ns — the
 marshal-off-lock split alone is a ~6× drop at 1000 live claims, a margin that
 grows with claim count. `BenchmarkStoreSaveScaling` (the combined `save()`
 Reconcile uses) stays as a regression sentinel.
@@ -134,4 +134,4 @@ single `ReadMeta` against MinIO measures 4.76ms cross-host (sub-ms
 node-local, 20-50ms on WAN S3). It fires once per warm-miss claim of a
 promoted template whose key gossip advertises, against a provision that
 already costs a >=48ms clone plus the export fetch. Stays parked behind
-the measurement trigger recorded in the M5 plan.
+a measurement trigger.

--- a/e2e/cmd/androidsmoke/main.go
+++ b/e2e/cmd/androidsmoke/main.go
@@ -1,4 +1,4 @@
-// androidsmoke is the M6-1 acceptance: claim (egress/xlarge) → Android
+// androidsmoke is the android-flavor acceptance: claim (egress/xlarge) → Android
 // init tree over the relay → adb CNXN handshake on the adb port →
 // checkpoint/branch of the booted guest. No session step: the guest
 // ships no bash.

--- a/e2e/cmd/browsersmoke/main.go
+++ b/e2e/cmd/browsersmoke/main.go
@@ -1,4 +1,4 @@
-// browsersmoke is the M7-2 acceptance: claim the browser flavor → CDP
+// browsersmoke is the browser-flavor acceptance: claim the browser flavor → CDP
 // /json/version over the relay → open a target → checkpoint/branch of the
 // warmed browser.
 package main

--- a/e2e/cmd/egresssmoke/main.go
+++ b/e2e/cmd/egresssmoke/main.go
@@ -1,6 +1,6 @@
-// egresssmoke is the M6-6 none-lane acceptance: a NIC-less sandbox reaches an
-// allowed origin through the host egress proxy with a host-injected credential
-// it never holds, and a disallowed host is denied — all over vsock, no NIC.
+// egresssmoke is the none-lane guarded-egress acceptance: a NIC-less sandbox
+// reaches an allowed origin through the host egress proxy with a host-injected
+// credential it never holds, and a disallowed host is denied — over vsock, no NIC.
 //
 // The origin runs on the sandboxd host (the guest has no network); the proxy
 // dials it host-side. Run on a node whose config declares a none-lane pool with

--- a/e2e/cmd/egresssmoke/main.go
+++ b/e2e/cmd/egresssmoke/main.go
@@ -62,14 +62,11 @@ func run(addr, token, template, wantToken string) error {
 	defer func() { _ = sb.Close() }()
 	fmt.Printf("  claimed none-lane sandbox %s\n", sb.ID)
 
-	// The guest has no NIC — a direct dial to the origin must fail; only the
-	// vsock proxy can reach it.
 	if out, _ := sb.Exec(ctx, "sh", "-c", fmt.Sprintf("curl -s -m 3 http://127.0.0.1:%d/ || echo NO-NIC", port)); !strings.Contains(out, "NO-NIC") {
 		return fmt.Errorf("guest reached the origin without the proxy: %q", out)
 	}
 	fmt.Println("  no-NIC confirmed: direct egress fails")
 
-	// Allowed host through the proxy: the origin sees the injected credential.
 	seen, err := sb.Exec(ctx, "sh", "-c", fmt.Sprintf("curl -s -x %s http://127.0.0.1:%d/", proxy, port))
 	if err != nil {
 		return fmt.Errorf("proxied exec: %w", err)
@@ -79,13 +76,11 @@ func run(addr, token, template, wantToken string) error {
 	}
 	fmt.Printf("  allowed origin reached; injected credential observed host-side\n")
 
-	// The secret's value must not be anywhere in the guest.
 	if out, _ := sb.Exec(ctx, "sh", "-c", "env; cat /proc/1/environ 2>/dev/null | tr '\\0' '\\n'"); wantToken != "" && strings.Contains(out, wantToken) {
 		return fmt.Errorf("secret value leaked into the guest")
 	}
 	fmt.Println("  secret absent from guest env")
 
-	// Denied host: a typed proxy failure, no origin reached.
 	deny, _ := sb.Exec(ctx, "sh", "-c", fmt.Sprintf("curl -s -o /dev/null -w '%%{http_code}' -x %s http://10.255.255.1/", proxy))
 	if strings.TrimSpace(deny) != "403" {
 		return fmt.Errorf("denied host returned %q, want 403", strings.TrimSpace(deny))

--- a/e2e/cmd/egresssmoke/main.go
+++ b/e2e/cmd/egresssmoke/main.go
@@ -1,0 +1,109 @@
+// egresssmoke is the M6-6 none-lane acceptance: a NIC-less sandbox reaches an
+// allowed origin through the host egress proxy with a host-injected credential
+// it never holds, and a disallowed host is denied — all over vsock, no NIC.
+//
+// The origin runs on the sandboxd host (the guest has no network); the proxy
+// dials it host-side. Run on a node whose config declares a none-lane pool with
+// an egress policy allowing 127.0.0.1 and a secret, e.g.:
+//
+//	"secrets":[{"name":"probe","header":"X-Egress-Token","value_env":"EGRESS_PROBE_TOKEN"}],
+//	"pools":[{"template":"…","net":"none","size":"small","warm":1,
+//	  "egress":{"allow":[{"host":"127.0.0.1","secret":"probe"}]}}]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	sandbox "github.com/cocoonstack/sandbox/sdk/go"
+)
+
+const proxy = "http://127.0.0.1:3128"
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:7777", "sandboxd address")
+	token := flag.String("token", "", "node api token")
+	template := flag.String("template", "rt:24.04", "none-lane template with an egress policy")
+	wantToken := flag.String("secret", "", "the value the origin should observe injected")
+	flag.Parse()
+
+	if err := run(*addr, *token, *template, *wantToken); err != nil {
+		fmt.Fprintln(os.Stderr, "egresssmoke:", err)
+		os.Exit(1)
+	}
+	fmt.Println("EGRESSSMOKE PASS")
+}
+
+func run(addr, token, template, wantToken string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	origin, port, err := startOrigin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = origin.Close() }()
+
+	c, err := sandbox.Connect(addr, sandbox.WithAPIToken(token))
+	if err != nil {
+		return err
+	}
+	sb, err := c.New(ctx, template, sandbox.WithNetwork(sandbox.NetNone), sandbox.WithSize(sandbox.Small))
+	if err != nil {
+		return fmt.Errorf("claim: %w", err)
+	}
+	defer func() { _ = sb.Close() }()
+	fmt.Printf("  claimed none-lane sandbox %s\n", sb.ID)
+
+	// The guest has no NIC — a direct dial to the origin must fail; only the
+	// vsock proxy can reach it.
+	if out, _ := sb.Exec(ctx, "sh", "-c", fmt.Sprintf("curl -s -m 3 http://127.0.0.1:%d/ || echo NO-NIC", port)); !strings.Contains(out, "NO-NIC") {
+		return fmt.Errorf("guest reached the origin without the proxy: %q", out)
+	}
+	fmt.Println("  no-NIC confirmed: direct egress fails")
+
+	// Allowed host through the proxy: the origin sees the injected credential.
+	seen, err := sb.Exec(ctx, "sh", "-c", fmt.Sprintf("curl -s -x %s http://127.0.0.1:%d/", proxy, port))
+	if err != nil {
+		return fmt.Errorf("proxied exec: %w", err)
+	}
+	if strings.TrimSpace(seen) != wantToken {
+		return fmt.Errorf("origin saw injected token %q, want %q", strings.TrimSpace(seen), wantToken)
+	}
+	fmt.Printf("  allowed origin reached; injected credential observed host-side\n")
+
+	// The secret's value must not be anywhere in the guest.
+	if out, _ := sb.Exec(ctx, "sh", "-c", "env; cat /proc/1/environ 2>/dev/null | tr '\\0' '\\n'"); wantToken != "" && strings.Contains(out, wantToken) {
+		return fmt.Errorf("secret value leaked into the guest")
+	}
+	fmt.Println("  secret absent from guest env")
+
+	// Denied host: a typed proxy failure, no origin reached.
+	deny, _ := sb.Exec(ctx, "sh", "-c", fmt.Sprintf("curl -s -o /dev/null -w '%%{http_code}' -x %s http://10.255.255.1/", proxy))
+	if strings.TrimSpace(deny) != "403" {
+		return fmt.Errorf("denied host returned %q, want 403", strings.TrimSpace(deny))
+	}
+	fmt.Println("  disallowed host denied (403)")
+	return nil
+}
+
+// startOrigin serves one echo endpoint that returns the credential header the
+// proxy injected, on a host-local port.
+func startOrigin() (*http.Server, int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, 0, err
+	}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, r.Header.Get("X-Egress-Token")) //nolint:gosec // test origin echoing the token we injected
+	}), ReadHeaderTimeout: 10 * time.Second}
+	go func() { _ = srv.Serve(ln) }()
+	return srv, ln.Addr().(*net.TCPAddr).Port, nil
+}

--- a/e2e/cmd/meshsmoke/main.go
+++ b/e2e/cmd/meshsmoke/main.go
@@ -1,4 +1,4 @@
-// meshsmoke proves M3.1 cluster template routing on a real two-node mesh:
+// meshsmoke proves cluster template routing on a real two-node mesh:
 // a claim at the entry node redirects to the peer that pools the key, a
 // promote there is reachable by name from the entry node, and a name-based
 // delete follows gossip to the owner. Run against node A of a two-node

--- a/e2e/cmd/smoke/main.go
+++ b/e2e/cmd/smoke/main.go
@@ -589,7 +589,7 @@ func want(got, exp string) error {
 	return nil
 }
 
-// smokeLsp proves the M4-4 broker on hardware: the base sandbox answers a
+// smokeLsp proves the LSP broker on hardware: the base sandbox answers a
 // typed not_found (no manifests), and a python-flavor sandbox serves a real
 // pylsp session — initialize, didOpen, hover — over the relay.
 func smokeLsp(ctx context.Context, client *sandbox.Client, base *sandbox.Sandbox, template string) error {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
+	"github.com/cocoonstack/sandbox/sandboxd/egress"
 	"github.com/cocoonstack/sandbox/sandboxd/pool"
 	"github.com/cocoonstack/sandbox/sandboxd/server"
 	"github.com/cocoonstack/sandbox/sandboxd/types"
@@ -293,7 +294,11 @@ func startTenantStack(t *testing.T, apiToken string, tenants []config.TenantSpec
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 
 	eng := newFakeEngine(dir)
-	mgr, err := pool.NewManager(t.Context(), &config.Config{DataDir: dir, Pools: pools, Tenants: tenants}, eng)
+	secrets, err := egress.NewSecretStore(nil)
+	if err != nil {
+		t.Fatalf("secrets: %v", err)
+	}
+	mgr, err := pool.NewManager(t.Context(), &config.Config{DataDir: dir, Pools: pools, Tenants: tenants}, eng, secrets)
 	if err != nil {
 		t.Fatalf("setup manager: %v", err)
 	}

--- a/os-image/android/README.md
+++ b/os-image/android/README.md
@@ -37,7 +37,7 @@ crash-loops zygote before the framework ever completes.
   `/init`, not the sandbox boot chain (PVH kernel + overlay-root init).
   The claim lane must be CH/egress — the FC no-network lane fails the
   readiness probe (2026-07-07 boot-attempt finding). Snapshot/restore of a
-  booted Android is validated by the M6-1 acceptance round.
+  booted Android is validated by the androidsmoke acceptance round.
 - **silkd on Android**: the musl-static binary is built and verified static,
   but exec/session behavior against an Android userspace (`/system/bin/sh`,
-  no `/bin/sh`) is validated by the M6-1 acceptance round.
+  no `/bin/sh`) is validated by the androidsmoke acceptance round.

--- a/sandboxd/egress/policy.go
+++ b/sandboxd/egress/policy.go
@@ -87,3 +87,27 @@ func (p Policy) Eval(host, method string) (Rule, Decision) {
 	}
 	return Rule{}, DecisionDeny
 }
+
+// Evaluator is what the proxy consults per request; Policy is one, Compose
+// intersects two.
+type Evaluator interface {
+	Eval(host, method string) (Rule, Decision)
+}
+
+// Compose intersects a pool and a tenant policy: a request must pass both, and
+// the pool rule (with its secret) wins on a double allow.
+func Compose(pool, tenant Policy) Evaluator {
+	return composite{pool: pool, tenant: tenant}
+}
+
+type composite struct {
+	pool, tenant Policy
+}
+
+func (c composite) Eval(host, method string) (Rule, Decision) {
+	rule, pd := c.pool.Eval(host, method)
+	if _, td := c.tenant.Eval(host, method); pd == DecisionAllow && td == DecisionAllow {
+		return rule, DecisionAllow
+	}
+	return Rule{}, DecisionDeny
+}

--- a/sandboxd/egress/proxy.go
+++ b/sandboxd/egress/proxy.go
@@ -48,7 +48,7 @@ type Event struct {
 type Proxy struct {
 	sandbox string
 	tenant  string
-	policy  Policy
+	policy  Evaluator
 	secrets Secrets
 	audit   func(Event)
 	dial    DialFunc
@@ -57,7 +57,7 @@ type Proxy struct {
 
 // New builds a Proxy for one sandbox. secrets and audit may be nil (no
 // injection, no audit). dial must be set.
-func New(sandbox, tenant string, policy Policy, secrets Secrets, dial DialFunc, audit func(Event)) *Proxy {
+func New(sandbox, tenant string, policy Evaluator, secrets Secrets, dial DialFunc, audit func(Event)) *Proxy {
 	return &Proxy{
 		sandbox: sandbox,
 		tenant:  tenant,

--- a/sandboxd/engine/engine.go
+++ b/sandboxd/engine/engine.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	silkdPort     = 2048 // silkd's fixed guest vsock port, the claim-ready anchor
+	egressPort    = 2049 // guest→host egress port; VMM maps it to <vsock_socket>_2049
 	cmdTimeout    = 2 * time.Minute
 	probeInterval = 20 * time.Millisecond
 	connectMax    = 64   // "OK <port>" handshake reply cap
@@ -318,6 +319,12 @@ func (e *Engine) infoRoundTrip(ctx context.Context, vsockSocket string) error {
 		return fmt.Errorf("info reply type %q", frame.Type)
 	}
 	return nil
+}
+
+// EgressSocketPath is the host UDS the VMM connects when the guest dials
+// CID2:egressPort — sandboxd listens here to serve the egress proxy.
+func EgressSocketPath(vsockSocket string) string {
+	return fmt.Sprintf("%s_%d", vsockSocket, egressPort)
 }
 
 // parseVsock reads the vsock UDS from a lifecycle command's --output json VM

--- a/sandboxd/main.go
+++ b/sandboxd/main.go
@@ -24,6 +24,7 @@ import (
 	coretypes "github.com/projecteru2/core/types"
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
+	"github.com/cocoonstack/sandbox/sandboxd/egress"
 	"github.com/cocoonstack/sandbox/sandboxd/engine"
 	"github.com/cocoonstack/sandbox/sandboxd/mesh"
 	"github.com/cocoonstack/sandbox/sandboxd/pool"
@@ -54,7 +55,11 @@ func main() {
 		logger.Fatalf(ctx, err, "load config")
 	}
 	eng := engine.New(cfg.CocoonBin, cfg.Bridge, cfg.Network)
-	mgr, err := pool.NewManager(ctx, cfg, eng)
+	secrets, err := egress.NewSecretStore(cfg.Secrets)
+	if err != nil {
+		logger.Fatalf(ctx, err, "init egress secrets")
+	}
+	mgr, err := pool.NewManager(ctx, cfg, eng, secrets)
 	if err != nil {
 		logger.Fatalf(ctx, err, "init pool manager")
 	}

--- a/sandboxd/pool/archive.go
+++ b/sandboxd/pool/archive.go
@@ -138,6 +138,7 @@ func (m *Manager) archive(ctx context.Context, sb *types.Sandbox) error {
 	}
 	sb.Transition.Unlock()
 	// Committed: the store ck is authoritative now; reclaim the local footprint.
+	m.disarmEgress(sb.ID)
 	if rmErr := m.eng.Remove(ctx, vmName); rmErr != nil {
 		log.WithFunc("pool.archive").Warnf(ctx, "remove archived VM %s: %v", vmName, rmErr)
 	}

--- a/sandboxd/pool/archive.go
+++ b/sandboxd/pool/archive.go
@@ -182,6 +182,7 @@ func (m *Manager) wakeArchived(ctx context.Context, sb *types.Sandbox) (string, 
 	} else {
 		m.dropRecLock(ck)
 	}
+	m.armEgress(sb) // fresh VM after unarchive: bind its egress accept point
 	m.counters.unarchives.Add(1)
 	m.recordUsage(ctx, usageEvent{Event: "unarchive", ID: sb.ID, Reference: ck, Tenant: sb.Tenant})
 	return built.VsockSocket, nil

--- a/sandboxd/pool/archive.go
+++ b/sandboxd/pool/archive.go
@@ -182,7 +182,7 @@ func (m *Manager) wakeArchived(ctx context.Context, sb *types.Sandbox) (string, 
 	} else {
 		m.dropRecLock(ck)
 	}
-	m.armEgress(sb) // fresh VM after unarchive: bind its egress accept point
+	m.armEgress(ctx, sb) // fresh VM after unarchive: bind its egress accept point
 	m.counters.unarchives.Add(1)
 	m.recordUsage(ctx, usageEvent{Event: "unarchive", ID: sb.ID, Reference: ck, Tenant: sb.Tenant})
 	return built.VsockSocket, nil

--- a/sandboxd/pool/archive_test.go
+++ b/sandboxd/pool/archive_test.go
@@ -173,7 +173,7 @@ func TestArchiveCkHiddenAcrossNodes(t *testing.T) {
 		m, err := NewManager(t.Context(), &config.Config{
 			DataDir: t.TempDir(), CheckpointDir: shared,
 			Pools: []config.PoolSpec{archivePool(3600)},
-		}, newFakeEngine())
+		}, newFakeEngine(), testSecrets(t))
 		if err != nil {
 			t.Fatalf("manager: %v", err)
 		}

--- a/sandboxd/pool/claim.go
+++ b/sandboxd/pool/claim.go
@@ -110,6 +110,7 @@ func (m *Manager) Release(ctx context.Context, id, token string) error {
 	}
 	// Cleanup must survive the caller hanging up; the claim is already dropped.
 	ctx = context.WithoutCancel(ctx)
+	m.disarmEgress(id)
 	if ck != "" {
 		m.purgeArchiveCk(ctx, id, ck, sb.Tenant) // archived: no local VM
 	}
@@ -257,6 +258,7 @@ func (m *Manager) finalizeBatch(ctx context.Context, sbs []*types.Sandbox, ttl t
 	}
 	for _, sb := range sbs {
 		m.recordUsage(ctx, usageEvent{Event: "claim", ID: sb.ID, VMName: sb.VMName, KeyHash: sb.Key.Hash(), Tenant: sb.Tenant})
+		m.armEgress(sb)
 	}
 	return nil
 }
@@ -325,6 +327,7 @@ func (m *Manager) reapOnce(ctx context.Context) {
 		v := expired[i]
 		switch v.action {
 		case reapPurge:
+			m.disarmEgress(v.id)
 			m.purgeArchiveCk(ctx, v.id, v.ck, v.tenant)
 			logger.Infof(ctx, "purged archived sandbox %s", v.id)
 		case reapArchive:
@@ -335,6 +338,7 @@ func (m *Manager) reapOnce(ctx context.Context) {
 				logger.Errorf(ctx, err, "archive expired %s", v.id)
 			}
 		default:
+			m.disarmEgress(v.id)
 			m.destroy(ctx, v.vmName)
 			m.dropSnap(ctx, v.snap)
 			m.counters.reaps.Add(1)

--- a/sandboxd/pool/claim.go
+++ b/sandboxd/pool/claim.go
@@ -258,7 +258,7 @@ func (m *Manager) finalizeBatch(ctx context.Context, sbs []*types.Sandbox, ttl t
 	}
 	for _, sb := range sbs {
 		m.recordUsage(ctx, usageEvent{Event: "claim", ID: sb.ID, VMName: sb.VMName, KeyHash: sb.Key.Hash(), Tenant: sb.Tenant})
-		m.armEgress(sb)
+		m.armEgress(ctx, sb)
 	}
 	return nil
 }

--- a/sandboxd/pool/egress.go
+++ b/sandboxd/pool/egress.go
@@ -1,0 +1,92 @@
+package pool
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/projecteru2/core/log"
+
+	"github.com/cocoonstack/sandbox/sandboxd/egress"
+	"github.com/cocoonstack/sandbox/sandboxd/engine"
+	"github.com/cocoonstack/sandbox/sandboxd/types"
+)
+
+// egressListener is one sandbox's none-lane egress accept point: an http.Server
+// serving egress.Proxy over the per-sandbox UDS the VMM connects when the guest
+// dials CID2:egressPort.
+type egressListener struct {
+	srv  *http.Server
+	ln   net.Listener
+	path string
+}
+
+func (e *egressListener) close() {
+	_ = e.srv.Close()
+	_ = e.ln.Close()
+	_ = os.Remove(e.path)
+}
+
+// armEgress starts the none-lane egress proxy for a claim whose effective
+// policy is non-empty; a no-op otherwise, so no listener means default-deny
+// (the guest's proxy dial is refused). Only the none lane is enforced by
+// construction — the egress lane needs nft (next slice).
+func (m *Manager) armEgress(sb *types.Sandbox) {
+	if !m.egressEnabled || sb.Key.Net != types.NetNone || sb.VsockSocket == "" {
+		return
+	}
+	policy, ok := m.effectivePolicy(sb)
+	if !ok {
+		return
+	}
+	path := engine.EgressSocketPath(sb.VsockSocket)
+	_ = os.Remove(path) // a stale socket from a prior life would block the bind
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		log.WithFunc("pool.armEgress").Errorf(context.Background(), err, "listen egress %s", sb.ID)
+		return
+	}
+	id, tenant := sb.ID, sb.Tenant
+	proxy := egress.New(id, tenant, policy, m.egressSecrets, (&net.Dialer{}).DialContext,
+		func(ev egress.Event) { m.recordEgress(context.Background(), id, tenant, ev) })
+	el := &egressListener{srv: &http.Server{Handler: proxy, ReadHeaderTimeout: 30 * time.Second}, ln: ln, path: path}
+	m.mu.Lock()
+	m.egressListeners[id] = el
+	m.mu.Unlock()
+	go func() { _ = el.srv.Serve(ln) }()
+}
+
+// disarmEgress tears down a sandbox's egress accept point; idempotent.
+func (m *Manager) disarmEgress(id string) {
+	m.mu.Lock()
+	el := m.egressListeners[id]
+	delete(m.egressListeners, id)
+	m.mu.Unlock()
+	if el != nil {
+		el.close()
+	}
+}
+
+// effectivePolicy resolves a claim's egress evaluator: pool ∩ tenant (deny
+// wins), or whichever single one is set; ok is false when neither applies.
+func (m *Manager) effectivePolicy(sb *types.Sandbox) (egress.Evaluator, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var poolPol *egress.Policy
+	if p := m.pools[sb.Key]; p != nil {
+		poolPol = p.egressPolicy
+	}
+	tenantPol := m.tenantEgress[sb.Tenant]
+	switch {
+	case poolPol != nil && tenantPol != nil:
+		return egress.Compose(*poolPol, *tenantPol), true
+	case poolPol != nil:
+		return *poolPol, true
+	case tenantPol != nil:
+		return *tenantPol, true
+	default:
+		return nil, false
+	}
+}

--- a/sandboxd/pool/egress.go
+++ b/sandboxd/pool/egress.go
@@ -32,7 +32,7 @@ func (e *egressListener) close() {
 // armEgress starts the none-lane egress proxy for a claim whose effective
 // policy is non-empty; a no-op otherwise, so no listener means default-deny
 // (the guest's proxy dial is refused). Only the none lane is enforced by
-// construction — the egress lane needs nft (next slice).
+// construction — the egress lane needs its own nftables lockdown.
 func (m *Manager) armEgress(sb *types.Sandbox) {
 	if !m.egressEnabled || sb.Key.Net != types.NetNone || sb.VsockSocket == "" {
 		return

--- a/sandboxd/pool/egress.go
+++ b/sandboxd/pool/egress.go
@@ -33,8 +33,8 @@ func (e *egressListener) close() {
 // policy is non-empty; a no-op otherwise, so no listener means default-deny
 // (the guest's proxy dial is refused). Only the none lane is enforced by
 // construction — the egress lane needs its own nftables lockdown.
-func (m *Manager) armEgress(sb *types.Sandbox) {
-	if !m.egressEnabled || sb.Key.Net != types.NetNone || sb.VsockSocket == "" {
+func (m *Manager) armEgress(ctx context.Context, sb *types.Sandbox) {
+	if !m.guardedEgress || sb.Key.Net != types.NetNone || sb.VsockSocket == "" {
 		return
 	}
 	policy, ok := m.effectivePolicy(sb)
@@ -45,7 +45,7 @@ func (m *Manager) armEgress(sb *types.Sandbox) {
 	_ = os.Remove(path) // a stale socket from a prior life would block the bind
 	ln, err := net.Listen("unix", path)
 	if err != nil {
-		log.WithFunc("pool.armEgress").Errorf(context.Background(), err, "listen egress %s", sb.ID)
+		log.WithFunc("pool.armEgress").Errorf(ctx, err, "listen egress %s", sb.ID)
 		return
 	}
 	id, tenant := sb.ID, sb.Tenant
@@ -60,6 +60,9 @@ func (m *Manager) armEgress(sb *types.Sandbox) {
 
 // disarmEgress tears down a sandbox's egress accept point; idempotent.
 func (m *Manager) disarmEgress(id string) {
+	if !m.guardedEgress {
+		return
+	}
 	m.mu.Lock()
 	el := m.egressListeners[id]
 	delete(m.egressListeners, id)

--- a/sandboxd/pool/egress_test.go
+++ b/sandboxd/pool/egress_test.go
@@ -1,0 +1,165 @@
+package pool
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cocoonstack/sandbox/sandboxd/config"
+	"github.com/cocoonstack/sandbox/sandboxd/egress"
+	"github.com/cocoonstack/sandbox/sandboxd/engine"
+	"github.com/cocoonstack/sandbox/sandboxd/types"
+)
+
+// egressClient builds an HTTP client that reaches the origin through the
+// per-sandbox egress proxy UDS, exactly as the guest's proxy client would over
+// vsock. Playing the VMM's role lets the host-side path run without a real VM.
+func egressClient(path string) *http.Client {
+	return &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(&url.URL{Scheme: "http", Host: "proxy.internal:3128"}),
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", path)
+			},
+		},
+	}
+}
+
+func TestEgressProxyInjectsAndGates(t *testing.T) {
+	origin := newEchoOrigin(t)
+	host := mustHostname(t, origin.URL)
+
+	t.Setenv("GH_TOKEN", "s3cr3t")
+	secrets := testSecrets(t, egress.SecretSpec{Name: "gh", Header: "Authorization", ValueEnv: "GH_TOKEN"})
+	pol := &egress.Policy{Allow: []egress.Rule{{Host: host, Secret: "gh"}}}
+	m, err := NewManager(t.Context(), testEgressConfig(t, pol), newFakeEngine(), secrets)
+	if err != nil {
+		t.Fatalf("manager: %v", err)
+	}
+
+	// A short socket dir: the UDS path + "_2049" must fit the OS sun_path cap.
+	sockDir, err := os.MkdirTemp("/tmp", "eg")
+	if err != nil {
+		t.Fatalf("sockdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sb := &types.Sandbox{ID: "sb_egress", Key: testKey, VsockSocket: filepath.Join(sockDir, "v")}
+	m.armEgress(sb)
+	path := engine.EgressSocketPath(sb.VsockSocket)
+	client := egressClient(path)
+
+	// Allowed host: reaches the origin, and the origin sees the injected header
+	// the guest never supplied.
+	resp, err := client.Get(origin.URL + "/")
+	if err != nil {
+		t.Fatalf("allowed request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if string(body) != "ok" || resp.Header.Get("X-Seen-Auth") != "s3cr3t" {
+		t.Errorf("allowed request body=%q injected=%q, want ok/s3cr3t", body, resp.Header.Get("X-Seen-Auth"))
+	}
+
+	// Denied host: default-deny returns a typed 403 without reaching any origin.
+	req, _ := http.NewRequest(http.MethodGet, "http://blocked.example/", nil)
+	deny, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("denied request: %v", err)
+	}
+	deny.Body.Close()
+	if deny.StatusCode != http.StatusForbidden {
+		t.Errorf("denied status %d, want 403", deny.StatusCode)
+	}
+
+	// Disarm removes the accept point.
+	m.disarmEgress(sb.ID)
+	if _, err := net.Dial("unix", path); err == nil {
+		t.Error("egress socket still accepts after disarm")
+	}
+}
+
+func TestEffectivePolicyComposition(t *testing.T) {
+	m := newTestManager(t, newFakeEngine())
+	both := &egress.Policy{Allow: []egress.Rule{{Host: "a.test"}, {Host: "b.test"}}}
+	tenantOnly := &egress.Policy{Allow: []egress.Rule{{Host: "b.test"}, {Host: "c.test"}}}
+
+	cases := []struct {
+		name         string
+		pool, tenant *egress.Policy
+		allow, deny  string
+		wantArmed    bool
+	}{
+		{"pool only", both, nil, "a.test", "z.test", true},
+		{"tenant only", nil, tenantOnly, "c.test", "a.test", true},
+		{"intersection", both, tenantOnly, "b.test", "a.test", true}, // a.test allowed by pool, denied by tenant
+		{"neither", nil, nil, "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m.pools[testKey] = &pool{key: testKey, egressPolicy: tc.pool}
+			m.tenantEgress = map[string]*egress.Policy{}
+			if tc.tenant != nil {
+				m.tenantEgress["acme"] = tc.tenant
+			}
+			sb := &types.Sandbox{Key: testKey, Tenant: "acme"}
+			eval, ok := m.effectivePolicy(sb)
+			if ok != tc.wantArmed {
+				t.Fatalf("armed=%v, want %v", ok, tc.wantArmed)
+			}
+			if !ok {
+				return
+			}
+			if _, d := eval.Eval(tc.allow, "GET"); d != egress.DecisionAllow {
+				t.Errorf("%s should allow", tc.allow)
+			}
+			if _, d := eval.Eval(tc.deny, "GET"); d != egress.DecisionDeny {
+				t.Errorf("%s should deny", tc.deny)
+			}
+		})
+	}
+}
+
+func newEchoOrigin(t *testing.T) *echoOrigin {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("origin listen: %v", err)
+	}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Seen-Auth", r.Header.Get("Authorization"))
+		_, _ = io.WriteString(w, "ok")
+	})}
+	go func() { _ = srv.Serve(ln) }()
+	o := &echoOrigin{URL: "http://" + ln.Addr().String(), srv: srv}
+	t.Cleanup(func() { _ = srv.Close() })
+	return o
+}
+
+type echoOrigin struct {
+	URL string
+	srv *http.Server
+}
+
+func testEgressConfig(t *testing.T, pool *egress.Policy) *config.Config {
+	t.Helper()
+	return &config.Config{
+		DataDir: t.TempDir(),
+		Pools:   []config.PoolSpec{{PoolKey: testKey, Warm: 1, Egress: pool}},
+	}
+}
+
+func mustHostname(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return u.Hostname()
+}

--- a/sandboxd/pool/egress_test.go
+++ b/sandboxd/pool/egress_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -33,7 +34,11 @@ func egressClient(path string) *http.Client {
 }
 
 func TestEgressProxyInjectsAndGates(t *testing.T) {
-	origin := newEchoOrigin(t)
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Seen-Auth", r.Header.Get("Authorization"))
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(origin.Close)
 	host := mustHostname(t, origin.URL)
 
 	t.Setenv("GH_TOKEN", "s3cr3t")
@@ -51,12 +56,10 @@ func TestEgressProxyInjectsAndGates(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
 	sb := &types.Sandbox{ID: "sb_egress", Key: testKey, VsockSocket: filepath.Join(sockDir, "v")}
-	m.armEgress(sb)
+	m.armEgress(t.Context(), sb)
 	path := engine.EgressSocketPath(sb.VsockSocket)
 	client := egressClient(path)
 
-	// Allowed host: reaches the origin, and the origin sees the injected header
-	// the guest never supplied.
 	resp, err := client.Get(origin.URL + "/")
 	if err != nil {
 		t.Fatalf("allowed request: %v", err)
@@ -67,7 +70,6 @@ func TestEgressProxyInjectsAndGates(t *testing.T) {
 		t.Errorf("allowed request body=%q injected=%q, want ok/s3cr3t", body, resp.Header.Get("X-Seen-Auth"))
 	}
 
-	// Denied host: default-deny returns a typed 403 without reaching any origin.
 	req, _ := http.NewRequest(http.MethodGet, "http://blocked.example/", nil)
 	deny, err := client.Do(req)
 	if err != nil {
@@ -78,7 +80,6 @@ func TestEgressProxyInjectsAndGates(t *testing.T) {
 		t.Errorf("denied status %d, want 403", deny.StatusCode)
 	}
 
-	// Disarm removes the accept point.
 	m.disarmEgress(sb.ID)
 	if _, err := net.Dial("unix", path); err == nil {
 		t.Error("egress socket still accepts after disarm")
@@ -124,27 +125,6 @@ func TestEffectivePolicyComposition(t *testing.T) {
 			}
 		})
 	}
-}
-
-func newEchoOrigin(t *testing.T) *echoOrigin {
-	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("origin listen: %v", err)
-	}
-	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Seen-Auth", r.Header.Get("Authorization"))
-		_, _ = io.WriteString(w, "ok")
-	})}
-	go func() { _ = srv.Serve(ln) }()
-	o := &echoOrigin{URL: "http://" + ln.Addr().String(), srv: srv}
-	t.Cleanup(func() { _ = srv.Close() })
-	return o
-}
-
-type echoOrigin struct {
-	URL string
-	srv *http.Server
 }
 
 func testEgressConfig(t *testing.T, pool *egress.Policy) *config.Config {

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -23,6 +23,7 @@ import (
 	"github.com/projecteru2/core/log"
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
+	"github.com/cocoonstack/sandbox/sandboxd/egress"
 	"github.com/cocoonstack/sandbox/sandboxd/store"
 	"github.com/cocoonstack/sandbox/sandboxd/store/dir"
 	"github.com/cocoonstack/sandbox/sandboxd/store/s3"
@@ -128,6 +129,8 @@ type pool struct {
 	nextBuild time.Time
 	warm      []*types.Sandbox
 	refilling int
+
+	egressPolicy *egress.Policy // this pool's allow-list; nil = no pool policy
 }
 
 func (p *pool) applySpec(spec config.PoolSpec) {
@@ -136,6 +139,7 @@ func (p *pool) applySpec(spec config.PoolSpec) {
 	p.idle = time.Duration(spec.IdleHibernateSeconds) * time.Second
 	p.archiveAfter = time.Duration(spec.ArchiveAfterSeconds) * time.Second
 	p.archiveDelete = time.Duration(spec.ArchiveDeleteAfterSeconds) * time.Second
+	p.egressPolicy = spec.Egress
 }
 
 // Manager owns the node's pools, claims, and their persistence.
@@ -165,6 +169,9 @@ type Manager struct {
 	// in that window would strand the claim). Both guarded by m.mu.
 	archiving  map[string]struct{}
 	pendingCks map[string]struct{}
+	// egressListeners holds the per-sandbox none-lane egress proxy accept point,
+	// keyed by sandbox id; guarded by m.mu, torn down on release/reap.
+	egressListeners map[string]*egressListener
 
 	// maxClaims caps live claims node-wide (0 = unlimited); tenantMax holds
 	// every configured tenant's cap (0 = unlimited) and doubles as the set of
@@ -174,6 +181,7 @@ type Manager struct {
 	maxClaims    int
 	tenantMax    map[string]int
 	tenantLive   map[string]int
+	tenantEgress map[string]*egress.Policy // per-tenant allow-list; nil = no tenant policy
 	usage        *journal
 	audit        *journal
 	counters     counters
@@ -197,6 +205,12 @@ type Manager struct {
 	// instead of waiting out a gossip tick.
 	notifyTemplates func()
 
+	// egressSecrets resolves a rule's secret name to the injected header;
+	// built once at startup, read-only after. egressEnabled short-circuits the
+	// claim path when no pool or tenant declares a policy.
+	egressSecrets *egress.SecretStore
+	egressEnabled bool
+
 	mu      sync.Mutex
 	pools   map[types.PoolKey]*pool
 	claimed map[string]*types.Sandbox
@@ -205,24 +219,27 @@ type Manager struct {
 }
 
 // NewManager builds a manager from the node config; ctx bounds backend
-// construction (the s3 store resolves its credential chain).
-func NewManager(ctx context.Context, cfg *config.Config, eng Engine) (*Manager, error) {
+// construction (the s3 store resolves its credential chain). secrets resolves
+// egress rule references and is shared by every per-sandbox proxy.
+func NewManager(ctx context.Context, cfg *config.Config, eng Engine, secrets *egress.SecretStore) (*Manager, error) {
 	maxFork := cfg.MaxForkCount
 	if maxFork < 1 {
 		maxFork = defaultMaxFork
 	}
 	m := &Manager{
-		eng:        eng,
-		dataDir:    cfg.DataDir,
-		egress:     cfg.HasEgress(),
-		maxFork:    maxFork,
-		store:      newClaimStore(cfg.DataDir),
-		pools:      make(map[types.PoolKey]*pool, len(cfg.Pools)),
-		claimed:    map[string]*types.Sandbox{},
-		tenantLive: map[string]int{},
-		archiving:  map[string]struct{}{},
-		pendingCks: map[string]struct{}{},
-		refillSem:  make(chan struct{}, maxConcurrentRefills),
+		eng:             eng,
+		dataDir:         cfg.DataDir,
+		egress:          cfg.HasEgress(),
+		maxFork:         maxFork,
+		store:           newClaimStore(cfg.DataDir),
+		pools:           make(map[types.PoolKey]*pool, len(cfg.Pools)),
+		claimed:         map[string]*types.Sandbox{},
+		tenantLive:      map[string]int{},
+		archiving:       map[string]struct{}{},
+		pendingCks:      map[string]struct{}{},
+		egressListeners: map[string]*egressListener{},
+		egressSecrets:   secrets,
+		refillSem:       make(chan struct{}, maxConcurrentRefills),
 	}
 	if err := os.MkdirAll(m.goldensDir(), 0o750); err != nil {
 		return nil, fmt.Errorf("create goldens dir: %w", err)
@@ -261,8 +278,13 @@ func NewManager(ctx context.Context, cfg *config.Config, eng Engine) (*Manager, 
 	}
 	m.maxClaims = cfg.MaxClaims
 	m.tenantMax = make(map[string]int, len(cfg.Tenants))
+	m.tenantEgress = make(map[string]*egress.Policy, len(cfg.Tenants))
 	for _, tn := range cfg.Tenants {
 		m.tenantMax[tn.Name] = tn.MaxClaims
+		if tn.Egress != nil {
+			m.tenantEgress[tn.Name] = tn.Egress
+			m.egressEnabled = true
+		}
 	}
 	m.idleDefault = time.Duration(cfg.IdleHibernateSeconds) * time.Second
 	m.idleEnabled = m.idleDefault > 0
@@ -278,6 +300,9 @@ func NewManager(ctx context.Context, cfg *config.Config, eng Engine) (*Manager, 
 		}
 		if spec.ArchiveAfterSeconds > 0 {
 			m.archiveEnabled = true
+		}
+		if spec.Egress != nil {
+			m.egressEnabled = true
 		}
 	}
 	if m.archiveEnabled && m.ckptTTL == 0 {

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -170,7 +170,7 @@ type Manager struct {
 	archiving  map[string]struct{}
 	pendingCks map[string]struct{}
 	// egressListeners holds the per-sandbox none-lane egress proxy accept point,
-	// keyed by sandbox id; guarded by m.mu, torn down on release/reap.
+	// keyed by sandbox id; guarded by m.mu.
 	egressListeners map[string]*egressListener
 
 	// maxClaims caps live claims node-wide (0 = unlimited); tenantMax holds
@@ -206,10 +206,10 @@ type Manager struct {
 	notifyTemplates func()
 
 	// egressSecrets resolves a rule's secret name to the injected header;
-	// built once at startup, read-only after. egressEnabled short-circuits the
+	// built once at startup, read-only after. guardedEgress short-circuits the
 	// claim path when no pool or tenant declares a policy.
 	egressSecrets *egress.SecretStore
-	egressEnabled bool
+	guardedEgress bool
 
 	mu      sync.Mutex
 	pools   map[types.PoolKey]*pool
@@ -283,7 +283,7 @@ func NewManager(ctx context.Context, cfg *config.Config, eng Engine, secrets *eg
 		m.tenantMax[tn.Name] = tn.MaxClaims
 		if tn.Egress != nil {
 			m.tenantEgress[tn.Name] = tn.Egress
-			m.egressEnabled = true
+			m.guardedEgress = true
 		}
 	}
 	m.idleDefault = time.Duration(cfg.IdleHibernateSeconds) * time.Second
@@ -302,7 +302,7 @@ func NewManager(ctx context.Context, cfg *config.Config, eng Engine, secrets *eg
 			m.archiveEnabled = true
 		}
 		if spec.Egress != nil {
-			m.egressEnabled = true
+			m.guardedEgress = true
 		}
 	}
 	if m.archiveEnabled && m.ckptTTL == 0 {

--- a/sandboxd/pool/pool_test.go
+++ b/sandboxd/pool/pool_test.go
@@ -484,11 +484,20 @@ func mustClaim(t *testing.T, m *Manager, key types.PoolKey) *types.Sandbox {
 
 func newTestManagerAt(t *testing.T, eng *fakeEngine, dataDir string, pools ...config.PoolSpec) *Manager {
 	t.Helper()
-	m, err := NewManager(t.Context(), &config.Config{DataDir: dataDir, Pools: pools}, eng)
+	m, err := NewManager(t.Context(), &config.Config{DataDir: dataDir, Pools: pools}, eng, testSecrets(t))
 	if err != nil {
 		t.Fatalf("setup manager: %v", err)
 	}
 	return m
+}
+
+func testSecrets(t *testing.T, specs ...egress.SecretSpec) *egress.SecretStore {
+	t.Helper()
+	s, err := egress.NewSecretStore(specs)
+	if err != nil {
+		t.Fatalf("secrets: %v", err)
+	}
+	return s
 }
 
 func TestProbeReadyWaitsForVsock(t *testing.T) {

--- a/sandboxd/pool/pool_test.go
+++ b/sandboxd/pool/pool_test.go
@@ -458,6 +458,20 @@ func TestReapBatchDoesNotStallTheLoop(t *testing.T) {
 	waitFor(t, func() bool { return eng.removed(sbs[n-1].VMName) })
 }
 
+func TestProbeReadyWaitsForVsock(t *testing.T) {
+	eng := newFakeEngine()
+	eng.vsockLateN = 2 // cocoon reports the socket only once the VMM runs
+	m := newTestManager(t, eng)
+
+	sb, err := claimAny(t.Context(), m, testKey, 0)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if sb.VsockSocket == "" {
+		t.Error("claim returned an empty vsock socket")
+	}
+}
+
 func newTestManager(t *testing.T, eng *fakeEngine, pools ...config.PoolSpec) *Manager {
 	t.Helper()
 	return newTestManagerAt(t, eng, t.TempDir(), pools...)
@@ -498,20 +512,6 @@ func testSecrets(t *testing.T, specs ...egress.SecretSpec) *egress.SecretStore {
 		t.Fatalf("secrets: %v", err)
 	}
 	return s
-}
-
-func TestProbeReadyWaitsForVsock(t *testing.T) {
-	eng := newFakeEngine()
-	eng.vsockLateN = 2 // cocoon reports the socket only once the VMM runs
-	m := newTestManager(t, eng)
-
-	sb, err := claimAny(t.Context(), m, testKey, 0)
-	if err != nil {
-		t.Fatalf("Claim: %v", err)
-	}
-	if sb.VsockSocket == "" {
-		t.Error("claim returned an empty vsock socket")
-	}
 }
 
 func waitFor(t *testing.T, cond func() bool) {

--- a/sandboxd/pool/reconcile.go
+++ b/sandboxd/pool/reconcile.go
@@ -130,7 +130,7 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 	now := time.Now()
 	for _, sb := range m.claimed {
 		sb.TouchAt(now)
-		m.armEgress(sb) // re-bind the none-lane egress accept point after restart
+		m.armEgress(ctx, sb) // re-bind the none-lane egress accept point after restart
 	}
 	logger.Infof(ctx, "adopted %d claims, %d VMs live", len(m.claimed), len(live))
 	return saveErr

--- a/sandboxd/pool/reconcile.go
+++ b/sandboxd/pool/reconcile.go
@@ -130,6 +130,7 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 	now := time.Now()
 	for _, sb := range m.claimed {
 		sb.TouchAt(now)
+		m.armEgress(sb) // re-bind the none-lane egress accept point after restart
 	}
 	logger.Infof(ctx, "adopted %d claims, %d VMs live", len(m.claimed), len(live))
 	return saveErr

--- a/sandboxd/pool/telemetry.go
+++ b/sandboxd/pool/telemetry.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/projecteru2/core/log"
+
+	"github.com/cocoonstack/sandbox/sandboxd/egress"
 )
 
 // AuditLineCap bounds how much of a relayed request frame the audit tap
@@ -49,15 +51,17 @@ type counters struct {
 
 // auditFrame is the addressing slice of a request frame worth auditing.
 type auditFrame struct {
-	Op      string   `json:"op"`
-	Argv    []string `json:"argv,omitempty"`
-	Path    string   `json:"path,omitempty"`
-	Dest    string   `json:"dest,omitempty"`
-	From    string   `json:"from,omitempty"`
-	To      string   `json:"to,omitempty"`
-	URL     string   `json:"url,omitempty"`
-	Session string   `json:"session,omitempty"`
-	Port    uint16   `json:"port,omitempty"`
+	Op       string   `json:"op"`
+	Argv     []string `json:"argv,omitempty"`
+	Path     string   `json:"path,omitempty"`
+	Dest     string   `json:"dest,omitempty"`
+	From     string   `json:"from,omitempty"`
+	To       string   `json:"to,omitempty"`
+	URL      string   `json:"url,omitempty"`
+	Session  string   `json:"session,omitempty"`
+	Port     uint16   `json:"port,omitempty"`
+	Decision string   `json:"decision,omitempty"` // egress: allow|deny
+	Secret   string   `json:"secret,omitempty"`   //nolint:gosec // the secret's ref name, never its value
 }
 
 // Counters snapshots the monotonic telemetry counters.
@@ -126,6 +130,17 @@ func (m *Manager) recordAudit(ctx context.Context, id string, frame auditFrame) 
 // AuditEnabled reports whether the relay should tap request frames at all.
 func (m *Manager) AuditEnabled() bool {
 	return m.audit != nil
+}
+
+// recordEgress logs one guarded-egress decision to the audit tap (secret name
+// only, never its value) and meters it as an always-on usage event.
+func (m *Manager) recordEgress(ctx context.Context, id, tenant string, ev egress.Event) {
+	decision := "deny"
+	if ev.Decision == egress.DecisionAllow {
+		decision = "allow"
+	}
+	m.recordAudit(ctx, id, auditFrame{Op: "egress", Dest: ev.Host, Decision: decision, Secret: ev.Injected})
+	m.recordUsage(ctx, usageEvent{Event: "egress", ID: id, Tenant: tenant, Reference: ev.Host})
 }
 
 // recordUsage appends one billing event; failures are logged, never

--- a/sandboxd/pool/telemetry_test.go
+++ b/sandboxd/pool/telemetry_test.go
@@ -189,7 +189,7 @@ func TestSandboxesIndexOmitsTokens(t *testing.T) {
 func TestPreviewDialWritesAuditEvent(t *testing.T) {
 	eng := newFakeEngine()
 	dir := t.TempDir()
-	m, err := NewManager(t.Context(), &config.Config{DataDir: dir, AuditLog: true, Pools: []config.PoolSpec{}}, eng)
+	m, err := NewManager(t.Context(), &config.Config{DataDir: dir, AuditLog: true, Pools: []config.PoolSpec{}}, eng, testSecrets(t))
 	if err != nil {
 		t.Fatalf("setup manager: %v", err)
 	}

--- a/scripts/archive-e2e.sh
+++ b/scripts/archive-e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Bare-metal acceptance for M7-E lifecycle auto-archive: a claim idles into
+# Bare-metal acceptance for lifecycle auto-archive: a claim idles into
 # hibernation, then to a store checkpoint (its local VM dropped), and the next
 # access wakes it from the store with the same id and guest state intact.
 # Runs a dedicated sandboxd on port 7778 so it never collides with

--- a/scripts/egress-e2e.sh
+++ b/scripts/egress-e2e.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Bare-metal acceptance for M6-6 none-lane guarded egress: a NIC-less sandbox
+# reaches an allowed origin through the host proxy with a host-injected
+# credential it never holds, and a disallowed host is denied — all over vsock.
+# Runs a dedicated sandboxd on port 7779 (7777=e2e, 7778=archive).
+set -euo pipefail
+
+TEMPLATE=${TEMPLATE:-rt:24.04}
+ADDR=${ADDR:-127.0.0.1:7779}
+TOKEN=${TOKEN:-e2e}
+REPO=$(cd "$(dirname "$0")/.." && pwd)
+export EGRESS_PROBE_TOKEN=${EGRESS_PROBE_TOKEN:-tok-$(date +%s)}
+
+DATA=$(mktemp -d /tmp/egress-e2e.XXXXXX)
+DAEMON_PID=""
+
+cleanup() {
+  status=$?
+  if [[ $status -ne 0 && -f "$DATA/daemon.log" ]]; then
+    echo "== daemon log tail"
+    tail -30 "$DATA/daemon.log"
+  fi
+  [[ -n $DAEMON_PID ]] && kill "$DAEMON_PID" 2>/dev/null || true
+  wait 2>/dev/null || true
+  cocoon vm list --format json 2>/dev/null |
+    jq -r '.[] | select(.config.name | startswith("sbx-")) | .config.name' |
+    while read -r vm; do
+      cocoon vm stop --force "$vm" >/dev/null 2>&1 || true
+      cocoon vm rm --force "$vm" >/dev/null 2>&1 || true
+    done || true
+  echo "== audit tail (egress events)"
+  grep -o '"op":"egress"[^}]*}' "$DATA/state/audit.jsonl" 2>/dev/null | tail -4 || true
+  rm -rf "$DATA"
+  exit "$status"
+}
+trap cleanup EXIT
+
+echo "== build"
+if [[ -n ${SANDBOXD_BIN:-} && -n ${EGRESSSMOKE_BIN:-} ]]; then
+  cp "$SANDBOXD_BIN" "$DATA/sandboxd" && cp "$EGRESSSMOKE_BIN" "$DATA/egresssmoke"
+else
+  (cd "$REPO/sandboxd" && GOWORK=off go build -o "$DATA/sandboxd" .)
+  (cd "$REPO/e2e" && GOWORK=off go build -o "$DATA/egresssmoke" ./cmd/egresssmoke)
+fi
+
+cat >"$DATA/config.json" <<EOF
+{
+  "listen": "$ADDR",
+  "data_dir": "$DATA/state",
+  "api_token": "$TOKEN",
+  "audit_log": true,
+  "secrets": [
+    {"name": "probe", "header": "X-Egress-Token", "value_env": "EGRESS_PROBE_TOKEN"}
+  ],
+  "pools": [
+    {"template": "$TEMPLATE", "net": "none", "size": "small", "warm": 1,
+     "egress": {"allow": [{"host": "127.0.0.1", "secret": "probe"}]}}
+  ]
+}
+EOF
+
+echo "== start sandboxd (none-lane pool + egress policy)"
+"$DATA/sandboxd" -config "$DATA/config.json" >>"$DATA/daemon.log" 2>&1 &
+DAEMON_PID=$!
+for _ in $(seq 1 40); do curl -sf "http://$ADDR/healthz" >/dev/null && break; sleep 0.5; done
+# Wait for the warm pool so the claim is a warm hit (proxy armed at claim).
+for _ in $(seq 1 120); do
+  curl -sf -H "Authorization: Bearer $TOKEN" "http://$ADDR/v1/info" 2>/dev/null |
+    jq -e '.pools[0].warm >= 1' >/dev/null 2>&1 && break
+  sleep 1
+done
+
+echo "== egresssmoke"
+"$DATA/egresssmoke" -addr "$ADDR" -token "$TOKEN" -template "$TEMPLATE" -secret "$EGRESS_PROBE_TOKEN"
+echo "PASS"

--- a/scripts/egress-e2e.sh
+++ b/scripts/egress-e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Bare-metal acceptance for M6-6 none-lane guarded egress: a NIC-less sandbox
+# Bare-metal acceptance for none-lane guarded egress: a NIC-less sandbox
 # reaches an allowed origin through the host proxy with a host-injected
 # credential it never holds, and a disallowed host is denied — all over vsock.
 # Runs a dedicated sandboxd on port 7779 (7777=e2e, 7778=archive).

--- a/silkd/src/lib.rs
+++ b/silkd/src/lib.rs
@@ -9,6 +9,7 @@ pub mod fs;
 pub mod git;
 pub mod lsp;
 pub mod net;
+pub mod net_egress;
 pub mod proc;
 pub mod proto;
 pub mod pty;

--- a/silkd/src/main.rs
+++ b/silkd/src/main.rs
@@ -10,7 +10,7 @@
 use std::sync::Arc;
 
 use silkd::server::State;
-use silkd::{session, vsock};
+use silkd::{net_egress, session, vsock};
 
 const DEFAULT_PORT: u32 = 2048;
 
@@ -26,6 +26,12 @@ async fn main() {
         state.sessions.clone(),
         session::IDLE_TTL,
         session::REAP_INTERVAL,
+    ));
+    // Loopback→host egress relay: harmless when the host wired no proxy (the
+    // per-conn vsock dial is refused), so it needs no lane gate here.
+    tokio::spawn(net_egress::serve(
+        net_egress::LOOPBACK_PORT,
+        net_egress::HOST_VSOCK_PORT,
     ));
     if let Err(e) = vsock::serve(port, state).await {
         eprintln!("silkd: fatal: {e}");

--- a/silkd/src/net_egress.rs
+++ b/silkd/src/net_egress.rs
@@ -1,0 +1,51 @@
+//! Guest→host egress relay. Binds a loopback proxy port; for each accepted TCP
+//! connection it opens one guest→host vsock connection to sandboxd's egress
+//! proxy and splices raw bytes. One vsock connection per proxied connection,
+//! mirroring the host→guest `port_forward` model — the proxy speaks HTTP on top
+//! of this byte pipe, so nothing here frames or inspects the payload. The none
+//! lane's only route out; when the host has not wired a proxy, the per-conn
+//! vsock dial is refused and the guest client sees a closed proxy (default-deny).
+
+use std::io;
+
+/// Loopback port the guest reaches the proxy at (`proxy.internal:3128`).
+pub const LOOPBACK_PORT: u16 = 3128;
+/// Host vsock port the VMM maps to sandboxd's `<vsock_socket>_<PORT>` UDS.
+pub const HOST_VSOCK_PORT: u32 = 2049;
+
+#[cfg(target_os = "linux")]
+pub async fn serve(loopback_port: u16, host_vsock_port: u32) -> io::Result<()> {
+    use tokio::net::TcpListener;
+    use tokio_vsock::{VsockAddr, VsockStream, VMADDR_CID_HOST};
+
+    let listener = TcpListener::bind(("127.0.0.1", loopback_port)).await?;
+    loop {
+        let mut tcp = match listener.accept().await {
+            Ok((conn, _)) => conn,
+            Err(e) => {
+                eprintln!("silkd egress: accept: {e}");
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                continue;
+            }
+        };
+        tokio::spawn(async move {
+            let addr = VsockAddr::new(VMADDR_CID_HOST, host_vsock_port);
+            let mut host = match VsockStream::connect(addr).await {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("silkd egress: host dial: {e}");
+                    return;
+                }
+            };
+            let _ = tokio::io::copy_bidirectional(&mut tcp, &mut host).await;
+        });
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub async fn serve(_loopback_port: u16, _host_vsock_port: u32) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "silkd egress requires linux vsock",
+    ))
+}

--- a/silkd/src/session.rs
+++ b/silkd/src/session.rs
@@ -1,6 +1,6 @@
 //! Persistent shell sessions: each session owns a long-lived bash whose cwd,
-//! environment, and shell state survive across `exec {session}` calls
-//! (Cloudflare/Daytona semantics). A command is injected into the shell and
+//! environment, and shell state survive across `exec {session}` calls.
+//! A command is injected into the shell and
 //! delimited by a unique sentinel that also carries its exit code; stderr is
 //! merged into stdout (`exec 2>&1`) so one stream frames cleanly without a
 //! pipe deadlock, which is the conventional interactive-shell behaviour.


### PR DESCRIPTION
## None-lane guarded egress

Wires the landed egress core (policy/proxy/secrets, #2/#18) into the claim lifecycle so a **NIC-less sandbox reaches approved origins through a host proxy with a host-injected credential it never holds** — credentialed egress from a network-less sandbox, which otherwise requires a NIC in the guest.

### How it works
- **Guest (silkd)**: `net_egress` binds `127.0.0.1:3128` and relays each connection to sandboxd over vsock (`CID2:2049`), a raw byte pipe — one vsock conn per proxied conn. Started unconditionally on Linux; harmless when the host wired no proxy (the vsock dial is refused = default-deny).
- **Host (sandboxd)**: at claim, a per-sandbox forward proxy is served on the UDS `<vsock_socket>_2049` (the VMM's guest-initiated hybrid-vsock target). The socket path *is* the identity — no in-band token. The proxy evaluates the effective policy (pool ∩ tenant, deny wins), injects the matched rule's secret host-side, dials the origin, relays the response, and records each decision to `audit.jsonl` (secret **name** only) and `usage.jsonl`.
- **Lifecycle**: armed at claim (none lane, when a policy applies), torn down on release/reap/archive, re-armed at reconcile and after unarchive. Zero warm-path cost when no policy is configured (`egressEnabled` short-circuit — the accept point is a µs `net.Listen`, off the clone/probe path).

### Scope
- **In**: none-lane transport, secrets/config wiring, effective-policy composition, plaintext credential injection, audit/usage metering, full claim lifecycle.
- **Follow-ups** (each its own PR): HTTPS credential injection via per-node ephemeral-CA TLS interception; egress-lane nftables default-deny (now confirmed **not** cocoon-gated — `vm list --format json` already emits `network_configs[].{tap,netns_path,network}`; the work is nft-in-netns).

### Evidence
- **Hardware acceptance on .79** (`rt-m66:24.04`, full local silkd→base→rt chain): `egresssmoke` PASS — no-NIC confirmed (direct egress fails), allowed origin reached with the injected `X-Egress-Token` observed host-side, secret absent from the guest env, disallowed host denied 403, `audit.jsonl` shows `op:egress` allow+deny by secret name.
- Go dual-GOOS lint 0 issues, `go test -race` all packages green (new host-side proxy integration test drives the real proxy over the UDS; effective-policy composition test). Rust silkd fmt+clippy+build clean in a rust:1 Linux container (vsock is Linux-gated).
- Review round: 4-dimension adversarial review (concurrency/lifecycle, security/injection, protocol/vsock, simplify), every finding verified — zero confirmed; the one surfaced feature-gap (re-arm after unarchive) is closed in this branch.

Docs: `docs/egress.md`.
