### PR TITLE
fix(egress): close egress hardening gaps found by the completeness audit + review

### DIFF
--- a/docs/egress.md
+++ b/docs/egress.md
@@ -47,9 +47,9 @@ lock unbroken from claim to release; those operations are refused (409) on the
 lane.
 
 The proxy also refuses to connect to internal addresses — loopback, link-local
-(including cloud metadata), private, carrier-grade NAT, and NAT64-embedded
-ranges — so an allow-listed host that resolves, or is rebound, to one cannot
-reach the sandboxd host or a sibling VM.
+(including cloud metadata), private, carrier-grade NAT, reserved, and
+IPv4-embedding IPv6 (NAT64, 6to4, Teredo) ranges — so an allow-listed host that
+resolves, or is rebound, to one cannot reach the sandboxd host or a sibling VM.
 
 ### Deployment constraints
 
@@ -64,6 +64,12 @@ reach the sandboxd host or a sibling VM.
   and is rejected on a CNI `network`. None-lane policies ride the proxy and work
   on either. A bridge egress lane locks every NIC default-deny, even with no
   policy configured.
+- **No custom NAT64/DNS64 prefix routed to the host.** The SSRF guard folds the
+  standard NAT64 forms (RFC 6052 well-known `64:ff9b::/96`, RFC 8215 local-use
+  `64:ff9b:1::/48`), but an operator-specific network-specific prefix (RFC 6052
+  allows any /32–/96) is opaque — its embedded IPv4 reads as public. If the host
+  routes such a translator, an allow-listed or DNS-rebound host could reach an
+  internal IPv4 through it; do not route a custom NAT64 prefix on a sandboxd host.
 
 ## Configuration
 

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -47,8 +47,9 @@ lock unbroken from claim to release; those operations are refused (409) on the
 lane.
 
 The proxy also refuses to connect to internal addresses — loopback, link-local
-(including cloud metadata), and private ranges — so an allow-listed host that
-resolves, or is rebound, to one cannot reach the sandboxd host or a sibling VM.
+(including cloud metadata), private, carrier-grade NAT, and NAT64-embedded
+ranges — so an allow-listed host that resolves, or is rebound, to one cannot
+reach the sandboxd host or a sibling VM.
 
 ### Deployment constraints
 

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -49,9 +49,10 @@ lane.
 The proxy also refuses to connect to internal addresses — every IANA
 special-purpose range that is not globally reachable (loopback, link-local
 incl. cloud metadata, private, carrier-grade NAT, benchmarking, documentation,
-reserved) plus the IPv4-embedding IPv6 forms (NAT64, 6to4, Teredo) — so an
-allow-listed host that resolves, or is rebound, to one cannot reach the
-sandboxd host or a sibling VM.
+reserved, per the registry snapshot in `egress.go`) plus the IPv4-embedding
+IPv6 forms (NAT64, 6to4, Teredo, IPv4-compatible) — so an allow-listed host
+that resolves, or is rebound, to one cannot reach the sandboxd host or a
+sibling VM.
 
 ### Deployment constraints
 

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -46,10 +46,12 @@ a snapshot would open an unlocked-NIC window. Keeping the lane live holds the
 lock unbroken from claim to release; those operations are refused (409) on the
 lane.
 
-The proxy also refuses to connect to internal addresses — loopback, link-local
-(including cloud metadata), private, carrier-grade NAT, reserved, and
-IPv4-embedding IPv6 (NAT64, 6to4, Teredo) ranges — so an allow-listed host that
-resolves, or is rebound, to one cannot reach the sandboxd host or a sibling VM.
+The proxy also refuses to connect to internal addresses — every IANA
+special-purpose range that is not globally reachable (loopback, link-local
+incl. cloud metadata, private, carrier-grade NAT, benchmarking, documentation,
+reserved) plus the IPv4-embedding IPv6 forms (NAT64, 6to4, Teredo) — so an
+allow-listed host that resolves, or is rebound, to one cannot reach the
+sandboxd host or a sibling VM.
 
 ### Deployment constraints
 

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -40,9 +40,15 @@ remove keeps an existing lock in place; the next restart retries the remove). A
 lock that never applied plus a failed remove leaves the VM unguarded until a
 later remove succeeds.
 
-Egress-lane sandboxes do not hibernate or archive: cocoon resumes a guest before
-its fresh tap can be re-locked, so suspending would open an unlocked-NIC window.
-Keeping the lane live holds the lock unbroken from claim to release.
+Egress-lane sandboxes do not hibernate, archive, fork, checkpoint, or promote:
+cocoon resumes a guest before its fresh tap can be re-locked, so any resume from
+a snapshot would open an unlocked-NIC window. Keeping the lane live holds the
+lock unbroken from claim to release; those operations are refused (409) on the
+lane.
+
+The proxy also refuses to connect to internal addresses — loopback, link-local
+(including cloud metadata), and private ranges — so an allow-listed host that
+resolves, or is rebound, to one cannot reach the sandboxd host or a sibling VM.
 
 ### Deployment constraints
 
@@ -52,8 +58,11 @@ Keeping the lane live holds the lock unbroken from claim to release.
   matched by header fields, not payload, so a broadcast in that shape can still
   reach the local L2 segment (never routed off-link). Give egress-lane VMs a
   bridge they do not share with an untrusted listener.
-- **Bridge lane only.** A CNI network's tap lives in the VM netns, out of reach
-  of the root-netns lock; guarded egress on a CNI `network` is rejected at load.
+- **Bridge lane only (egress lane).** A CNI network's tap lives in the VM netns,
+  out of reach of the root-netns lock, so a guarded egress *lane* needs a bridge
+  and is rejected on a CNI `network`. None-lane policies ride the proxy and work
+  on either. A bridge egress lane locks every NIC default-deny, even with no
+  policy configured.
 
 ## Configuration
 

--- a/docs/sandboxd-api.md
+++ b/docs/sandboxd-api.md
@@ -78,7 +78,8 @@ snapshot point and the stop coincident). Idempotent on an already-hibernated
 sandbox. The TTL keeps running: a hibernated sandbox is still reaped (VM and
 snapshot) at its deadline. When to hibernate is the caller's policy — the
 node only provides the transition. 204 on success, 404 unknown id or wrong
-token.
+token, 409 on the egress lane (egress-lane sandboxes never hibernate; see
+[egress](egress.md)).
 
 ## POST /v1/sandboxes/{id}/fork
 
@@ -104,7 +105,9 @@ All-or-nothing: on error no child survived. 200 with one claim per child:
 
 Children inherit the parent's tenant and count against its `max_claims`,
 whoever calls. 400 invalid count or body, 401 bad api token, 404 unknown id
-or wrong sandbox token, 429 node or the parent's tenant at `max_claims`.
+or wrong sandbox token, 409 egress-lane parent (the lane never forks,
+checkpoints, or promotes; see [egress](egress.md)), 429 node or the parent's
+tenant at `max_claims`.
 
 ## POST /v1/sandboxes/{id}/promote
 
@@ -130,8 +133,9 @@ exactly this key:
 ```
 
 400 invalid name, 401 bad api token, 409 when the name collides with a
-configured pool or the template is owned by another tenant, 404
-unknown id or wrong sandbox token.
+configured pool, the template is owned by another tenant, or the sandbox is
+on the egress lane (see [egress](egress.md)), 404 unknown id or wrong
+sandbox token.
 
 ## DELETE /v1/templates?template=…&net=…&size=…
 
@@ -180,15 +184,16 @@ Auth: node API token; body `{"token": "<sandbox token>", "name": "..."}`
 answers `200 {"checkpoint": {id, name, sandbox_id, key, tenant?,
 created_at}}` — `tenant` records the calling tenant, absent for root.
 400 bad body or name, 401 bad api token, 404 unknown id or wrong sandbox
-token.
+token, 409 egress-lane sandbox (see [egress](egress.md)).
 
 ## POST /v1/checkpoints/{id}/claim
 
 Auth: node API token; body `{"ttl_seconds": 0}`. Claims a fresh sandbox
 branched from the checkpoint (a normal claim response, attributed to the
 caller); the checkpoint's recorded key applies — the unguessable id is the
-capability to branch. 404 for an unknown checkpoint, 429 node or calling
-tenant at `max_claims`.
+capability to branch. 404 for an unknown checkpoint, 409 for an egress-lane
+checkpoint (see [egress](egress.md)), 429 node or calling tenant at
+`max_claims`.
 
 ## GET /v1/checkpoints
 

--- a/sandboxd/config/config.go
+++ b/sandboxd/config/config.go
@@ -186,10 +186,8 @@ func (c *Config) HasEgress() bool {
 	return c.Bridge != "" || c.Network != ""
 }
 
-// guardsEgressLane reports whether a policy could apply to an egress-lane claim:
-// a tenant policy (which rides any lane, including an unpooled egress claim) or
-// an egress-lane pool's own. A none-lane pool policy locks no tap, so it does
-// not count. No declared egress pool is required — claims mint keys directly.
+// guardsEgressLane: any tenant policy counts (claims mint egress keys without a
+// pool), a none-lane pool policy does not (it locks no tap).
 func (c *Config) guardsEgressLane() bool {
 	return slices.ContainsFunc(c.Tenants, func(t TenantSpec) bool { return t.Egress != nil }) ||
 		slices.ContainsFunc(c.Pools, func(p PoolSpec) bool { return p.Net == types.NetEgress && p.Egress != nil })

--- a/sandboxd/config/config.go
+++ b/sandboxd/config/config.go
@@ -186,9 +186,13 @@ func (c *Config) HasEgress() bool {
 	return c.Bridge != "" || c.Network != ""
 }
 
-func (c *Config) hasEgressPolicy() bool {
-	return slices.ContainsFunc(c.Pools, func(p PoolSpec) bool { return p.Egress != nil }) ||
-		slices.ContainsFunc(c.Tenants, func(t TenantSpec) bool { return t.Egress != nil })
+// guardsEgressLane reports whether a policy could apply to an egress-lane claim:
+// a tenant policy (which rides any lane, including an unpooled egress claim) or
+// an egress-lane pool's own. A none-lane pool policy locks no tap, so it does
+// not count. No declared egress pool is required — claims mint keys directly.
+func (c *Config) guardsEgressLane() bool {
+	return slices.ContainsFunc(c.Tenants, func(t TenantSpec) bool { return t.Egress != nil }) ||
+		slices.ContainsFunc(c.Pools, func(p PoolSpec) bool { return p.Net == types.NetEgress && p.Egress != nil })
 }
 
 func (c *Config) applyDefaults() {
@@ -223,7 +227,7 @@ func (c *Config) validate() error {
 	}
 	// A CNI network's tap lives in the VM netns, unreachable from the root-netns
 	// nft lock; guarded egress needs a bridge.
-	if c.Network != "" && c.hasEgressPolicy() {
+	if c.Network != "" && c.guardsEgressLane() {
 		return fmt.Errorf("guarded egress needs a bridge lane, not a CNI network: the tap lives in the VM netns and cannot be locked")
 	}
 	if c.MaxForkCount < 1 {

--- a/sandboxd/config/config_test.go
+++ b/sandboxd/config/config_test.go
@@ -63,6 +63,7 @@ func TestLoadRejectsInvalid(t *testing.T) {
 		{"tenant egress unknown secret", `{"api_token":"root","pools":[],"tenants":[{"name":"acme","token":"t1","egress":{"allow":[{"host":"x","secret":"gh"}]}}]}`, "unknown secret"},
 		{"guarded egress on cni pool", `{"network":"cni","pools":[{"template":"rt:24.04","net":"egress","size":"small","egress":{"allow":[{"host":"x"}]}}]}`, "needs a bridge lane"},
 		{"guarded egress on cni tenant", `{"api_token":"root","network":"cni","pools":[{"template":"rt:24.04","net":"egress","size":"small"}],"tenants":[{"name":"acme","token":"t1","egress":{"allow":[{"host":"x"}]}}]}`, "needs a bridge lane"},
+		{"cni tenant egress no egress pool", `{"api_token":"root","network":"cni","pools":[{"template":"rt:24.04","net":"none","size":"small"}],"tenants":[{"name":"acme","token":"t1","egress":{"allow":[{"host":"x"}]}}]}`, "needs a bridge lane"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := Load(writeConfig(t, tt.body))
@@ -110,6 +111,19 @@ func TestLoadAcceptsUnguardedCNINetwork(t *testing.T) {
 	path := writeConfig(t, `{"network":"cni","pools":[{"template":"rt:24.04","net":"egress","size":"small"}]}`)
 	if _, err := Load(path); err != nil {
 		t.Fatalf("Load: %v", err)
+	}
+}
+
+func TestLoadAcceptsNoneLanePolicyOnCNI(t *testing.T) {
+	// A none-lane policy rides the vsock proxy and locks no tap, so it is valid on
+	// a CNI network — the bridge requirement is only for a guarded egress lane.
+	for _, body := range []string{
+		`{"network":"cni","pools":[{"template":"rt:24.04","net":"none","size":"small","egress":{"allow":[{"host":"x"}]}}]}`,
+		`{"network":"cni","pools":[{"template":"rt:24.04","net":"egress","size":"small"},{"template":"rt:24.04","net":"none","size":"medium","egress":{"allow":[{"host":"x"}]}}]}`,
+	} {
+		if _, err := Load(writeConfig(t, body)); err != nil {
+			t.Errorf("Load rejected a none-lane policy on CNI: %v", err)
+		}
 	}
 }
 

--- a/sandboxd/pool/archive.go
+++ b/sandboxd/pool/archive.go
@@ -138,7 +138,7 @@ func (m *Manager) archive(ctx context.Context, sb *types.Sandbox) error {
 	}
 	// Disarm under Transition so a wake that runs the instant we release it
 	// re-arms cleanly instead of being clobbered by a late disarm.
-	m.disarmEgress(sb.ID)
+	m.disarmEgress(sb.ID, true)
 	sb.Transition.Unlock()
 	// Committed: the store ck is authoritative now; reclaim the local footprint.
 	if rmErr := m.eng.Remove(ctx, vmName); rmErr != nil {

--- a/sandboxd/pool/archive_test.go
+++ b/sandboxd/pool/archive_test.go
@@ -123,6 +123,16 @@ func breakStore(t *testing.T, m *Manager) {
 	m.store.path = filepath.Join(t.TempDir(), "gone", "claims.json")
 }
 
+// healStore repairs breakStore's path and waits for the detached recommit to
+// converge, so its retry loop does not outlive the test.
+func healStore(t *testing.T, m *Manager) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(m.store.path), 0o750); err != nil {
+		t.Fatalf("heal store: %v", err)
+	}
+	waitFor(t, m.store.synced)
+}
+
 func archivedCount(m *Manager) int {
 	_, g := m.Info()
 	return g.Archived
@@ -492,6 +502,7 @@ func TestArchivePersistFailureRollsBack(t *testing.T) {
 	if ckpts, err := m.Checkpoints(t.Context(), ""); err != nil || len(ckpts) != 0 {
 		t.Errorf("orphaned archive ck not cleaned up: %d records (%v)", len(ckpts), err)
 	}
+	healStore(t, m)
 }
 
 // pinnedHidden reports whether the store holds exactly one checkpoint and it is
@@ -523,6 +534,7 @@ func TestReleaseArchivedRollsBackOnPersistFailure(t *testing.T) {
 	if !pinnedHidden(t, m, ck) {
 		t.Error("kept ck is not pinned after a failed release")
 	}
+	healStore(t, m)
 }
 
 // TestWakeArchivedRollsBackOnPersistFailure guards the durability fix where a
@@ -549,6 +561,7 @@ func TestWakeArchivedRollsBackOnPersistFailure(t *testing.T) {
 	if !pinnedHidden(t, m, ck) {
 		t.Error("kept ck is not pinned after a failed wake")
 	}
+	healStore(t, m)
 }
 
 // TestReapPurgeRollsBackOnPersistFailure guards the same rollback on the reaper:
@@ -575,6 +588,7 @@ func TestReapPurgeRollsBackOnPersistFailure(t *testing.T) {
 	if !pinnedHidden(t, m, ck) {
 		t.Error("kept ck is not pinned after a failed reap purge")
 	}
+	healStore(t, m)
 }
 
 // TestArchiveOnceSkipsInFlight guards the in-flight dedup: a sandbox already

--- a/sandboxd/pool/checkpoint.go
+++ b/sandboxd/pool/checkpoint.go
@@ -33,6 +33,9 @@ func (m *Manager) Checkpoint(ctx context.Context, id, token, name, tenant string
 	if !ok {
 		return types.Checkpoint{}, ErrUnknownSandbox
 	}
+	if sb.Key.Net == types.NetEgress {
+		return types.Checkpoint{}, ErrNoEgressFork
+	}
 	// See Hibernate: a started capture must finish even if the caller hangs up.
 	ctx = context.WithoutCancel(ctx)
 	ckpt, _, err := m.publishCheckpoint(ctx, sb, store.CheckpointID(randHex(8)), name, tenant, false)
@@ -109,6 +112,9 @@ func (m *Manager) ClaimCheckpoint(ctx context.Context, ckptID string, ttl time.D
 	}
 	if ckpt.Archive {
 		return nil, ErrUnknownCheckpoint // a wake image, not a branchable checkpoint
+	}
+	if ckpt.Key.Net == types.NetEgress {
+		return nil, ErrNoEgressFork
 	}
 	sb, err := m.provision(ctx, ckpt.Key, dir)
 	if err != nil {

--- a/sandboxd/pool/claim.go
+++ b/sandboxd/pool/claim.go
@@ -117,11 +117,7 @@ func (m *Manager) Release(ctx context.Context, id, token string) error {
 	if vmName != "" {
 		err = m.eng.Remove(ctx, vmName)
 	}
-	// Unlock only once the VM is gone, else a failed remove hands its NIC back
-	// unguarded; the restart stale sweep reclaims a VM left locked.
-	if err == nil {
-		m.disarmEgress(id)
-	}
+	m.disarmEgress(id, vmName == "" || err == nil)
 	m.dropSnap(ctx, snap)
 	m.counters.releases.Add(1)
 	m.recordUsage(ctx, usageEvent{Event: "release", ID: id, VMName: vmName})
@@ -277,10 +273,7 @@ func (m *Manager) rollbackClaim(ctx context.Context, sbs []*types.Sandbox) {
 	m.mu.Unlock()
 	m.recommit(ctx, rb)
 	for _, sb := range sbs {
-		// Unlock only after the VM is gone (see Release).
-		if m.removeVM(ctx, sb.VMName) {
-			m.disarmEgress(sb.ID)
-		}
+		m.disarmEgress(sb.ID, m.removeVM(ctx, sb.VMName))
 	}
 }
 
@@ -348,7 +341,7 @@ func (m *Manager) reapOnce(ctx context.Context) {
 		v := expired[i]
 		switch v.action {
 		case reapPurge:
-			m.disarmEgress(v.id)
+			m.disarmEgress(v.id, true)
 			m.purgeArchiveCk(ctx, v.id, v.ck, v.tenant)
 			logger.Infof(ctx, "purged archived sandbox %s", v.id)
 		case reapArchive:
@@ -359,10 +352,7 @@ func (m *Manager) reapOnce(ctx context.Context) {
 				logger.Errorf(ctx, err, "archive expired %s", v.id)
 			}
 		default:
-			// Unlock only after the VM is gone (see Release).
-			if m.removeVM(ctx, v.vmName) {
-				m.disarmEgress(v.id)
-			}
+			m.disarmEgress(v.id, m.removeVM(ctx, v.vmName))
 			m.dropSnap(ctx, v.snap)
 			m.counters.reaps.Add(1)
 			m.recordUsage(ctx, usageEvent{Event: "reap", ID: v.id, VMName: v.vmName})

--- a/sandboxd/pool/claim.go
+++ b/sandboxd/pool/claim.go
@@ -117,7 +117,7 @@ func (m *Manager) Release(ctx context.Context, id, token string) error {
 	if vmName != "" {
 		err = m.eng.Remove(ctx, vmName)
 	}
-	m.disarmEgress(id, vmName == "" || err == nil)
+	m.disarmEgress(id, err == nil)
 	m.dropSnap(ctx, snap)
 	m.counters.releases.Add(1)
 	m.recordUsage(ctx, usageEvent{Event: "release", ID: id, VMName: vmName})

--- a/sandboxd/pool/egress.go
+++ b/sandboxd/pool/egress.go
@@ -18,9 +18,18 @@ import (
 )
 
 var (
-	cgnatRange      = netip.MustParsePrefix("100.64.0.0/10")  // RFC 6598 CGNAT; some clouds host metadata here
-	nat64Range      = netip.MustParsePrefix("64:ff9b::/96")   // RFC 6052 NAT64; v4 in the low 32 bits
-	nat64LocalRange = netip.MustParsePrefix("64:ff9b:1::/48") // RFC 8215 local-use NAT64
+	nat64Range = netip.MustParsePrefix("64:ff9b::/96") // RFC 6052 NAT64; the embedded v4 is checked instead
+
+	// internalRanges are reserved or v4-embedding ranges IsGlobalUnicast would pass.
+	internalRanges = []netip.Prefix{
+		netip.MustParsePrefix("100.64.0.0/10"),  // RFC 6598 CGNAT; some clouds host metadata here
+		netip.MustParsePrefix("0.0.0.0/8"),      // "this network"
+		netip.MustParsePrefix("240.0.0.0/4"),    // reserved; some clouds use it as internal fabric
+		netip.MustParsePrefix("64:ff9b:1::/48"), // RFC 8215 local-use NAT64
+		netip.MustParsePrefix("::/96"),          // deprecated IPv4-compatible; embeds a v4 unmapped
+		netip.MustParsePrefix("2002::/16"),      // 6to4; embeds a v4
+		netip.MustParsePrefix("2001::/32"),      // Teredo; embeds a v4
+	}
 
 	// egressDialer blocks internal-address targets so the proxy cannot be an SSRF.
 	egressDialer = &net.Dialer{Control: func(_, address string, _ syscall.RawConn) error {
@@ -38,7 +47,7 @@ var (
 			ip = netip.AddrFrom4([4]byte{b[12], b[13], b[14], b[15]})
 		}
 		if !ip.IsGlobalUnicast() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
-			cgnatRange.Contains(ip) || nat64LocalRange.Contains(ip) {
+			slices.ContainsFunc(internalRanges, func(p netip.Prefix) bool { return p.Contains(ip) }) {
 			return fmt.Errorf("egress: blocked internal address %s", ip)
 		}
 		return nil

--- a/sandboxd/pool/egress.go
+++ b/sandboxd/pool/egress.go
@@ -18,13 +18,11 @@ import (
 )
 
 var (
-	cgnatRange = netip.MustParsePrefix("100.64.0.0/10") // RFC 6598; some clouds host metadata here
-	nat64Range = netip.MustParsePrefix("64:ff9b::/96")  // RFC 6052; DNS64 embeds an IPv4 in the low 32 bits
+	cgnatRange      = netip.MustParsePrefix("100.64.0.0/10")  // RFC 6598 CGNAT; some clouds host metadata here
+	nat64Range      = netip.MustParsePrefix("64:ff9b::/96")   // RFC 6052 NAT64; v4 in the low 32 bits
+	nat64LocalRange = netip.MustParsePrefix("64:ff9b:1::/48") // RFC 8215 local-use NAT64
 
-	// egressDialer refuses connections to internal addresses so an allow-listed
-	// host that resolves (or is rebound) to loopback, link-local (incl. cloud
-	// metadata), or a private/CGNAT/sibling address cannot turn the proxy into
-	// an SSRF.
+	// egressDialer blocks internal-address targets so the proxy cannot be an SSRF.
 	egressDialer = &net.Dialer{Control: func(_, address string, _ syscall.RawConn) error {
 		host, _, err := net.SplitHostPort(address)
 		if err != nil {
@@ -34,12 +32,13 @@ var (
 		if err != nil {
 			return fmt.Errorf("egress: unresolved address %q", host)
 		}
-		ip = ip.Unmap() // fold ::ffff:127.0.0.1 so the v4 checks apply
+		ip = ip.Unmap()
 		if nat64Range.Contains(ip) {
-			b := ip.As16() // a DNS64-synthesized metadata/private v4 hides in the low 32 bits
+			b := ip.As16()
 			ip = netip.AddrFrom4([4]byte{b[12], b[13], b[14], b[15]})
 		}
-		if !ip.IsGlobalUnicast() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || cgnatRange.Contains(ip) {
+		if !ip.IsGlobalUnicast() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+			cgnatRange.Contains(ip) || nat64LocalRange.Contains(ip) {
 			return fmt.Errorf("egress: blocked internal address %s", ip)
 		}
 		return nil
@@ -126,7 +125,7 @@ func (m *Manager) armEgressProxy(_ context.Context, sb *types.Sandbox) error {
 		return fmt.Errorf("listen egress %s: %w", sb.ID, err)
 	}
 	id, tenant := sb.ID, sb.Tenant
-	proxy := egress.New(id, tenant, policy, m.egressSecrets, egressDialer.DialContext,
+	proxy := egress.New(id, tenant, policy, m.egressSecrets, m.dial,
 		func(ev egress.Event) { m.recordEgress(context.Background(), id, tenant, ev) })
 	el := &egressListener{srv: &http.Server{Handler: proxy, ReadHeaderTimeout: 30 * time.Second}, ln: ln, path: path}
 	m.mu.Lock()
@@ -149,9 +148,7 @@ func (m *Manager) disarmIfReleased(sb *types.Sandbox) bool {
 }
 
 // disarmEgress tears down a sandbox's egress proxy listener, and its NIC lock
-// only when removed is true — a failed VM removal keeps the lock (the guest is
-// still running) but still stops the dropped claim's credential injection.
-// Idempotent.
+// only when removed (a failed removal keeps a running guest locked). Idempotent.
 func (m *Manager) disarmEgress(id string, removed bool) {
 	if !m.guardedEgress && !m.lockEgress {
 		return
@@ -178,10 +175,7 @@ func (m *Manager) disarmEgress(id string, removed bool) {
 func (m *Manager) effectivePolicy(sb *types.Sandbox) (egress.Evaluator, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	var poolPol *egress.Policy
-	if p := m.pools[sb.Key]; p != nil {
-		poolPol = p.egressPolicy
-	}
+	poolPol := m.poolEgress[sb.Key]
 	tenantPol := m.tenantEgress[sb.Tenant]
 	switch {
 	case poolPol != nil && tenantPol != nil:

--- a/sandboxd/pool/egress.go
+++ b/sandboxd/pool/egress.go
@@ -5,14 +5,45 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/netip"
 	"os"
 	"slices"
+	"syscall"
 	"time"
 
 	"github.com/cocoonstack/sandbox/sandboxd/egress"
 	"github.com/cocoonstack/sandbox/sandboxd/engine"
 	"github.com/cocoonstack/sandbox/sandboxd/netfilter"
 	"github.com/cocoonstack/sandbox/sandboxd/types"
+)
+
+var (
+	cgnatRange = netip.MustParsePrefix("100.64.0.0/10") // RFC 6598; some clouds host metadata here
+	nat64Range = netip.MustParsePrefix("64:ff9b::/96")  // RFC 6052; DNS64 embeds an IPv4 in the low 32 bits
+
+	// egressDialer refuses connections to internal addresses so an allow-listed
+	// host that resolves (or is rebound) to loopback, link-local (incl. cloud
+	// metadata), or a private/CGNAT/sibling address cannot turn the proxy into
+	// an SSRF.
+	egressDialer = &net.Dialer{Control: func(_, address string, _ syscall.RawConn) error {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return err
+		}
+		ip, err := netip.ParseAddr(host)
+		if err != nil {
+			return fmt.Errorf("egress: unresolved address %q", host)
+		}
+		ip = ip.Unmap() // fold ::ffff:127.0.0.1 so the v4 checks apply
+		if nat64Range.Contains(ip) {
+			b := ip.As16() // a DNS64-synthesized metadata/private v4 hides in the low 32 bits
+			ip = netip.AddrFrom4([4]byte{b[12], b[13], b[14], b[15]})
+		}
+		if !ip.IsGlobalUnicast() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || cgnatRange.Contains(ip) {
+			return fmt.Errorf("egress: blocked internal address %s", ip)
+		}
+		return nil
+	}}
 )
 
 // egressListener is one sandbox's egress accept point: an http.Server serving
@@ -43,7 +74,7 @@ func (m *Manager) armEgress(ctx context.Context, sb *types.Sandbox) error {
 // lockEgressNIC nft-locks the egress-lane NIC and records the tap for unlock;
 // the engine lookup is the fallback for claims from pre-tap journals.
 func (m *Manager) lockEgressNIC(ctx context.Context, sb *types.Sandbox) error {
-	if !m.guardedEgress || sb.Key.Net != types.NetEgress {
+	if !m.lockEgress || sb.Key.Net != types.NetEgress {
 		return nil
 	}
 	tap := sb.TAP
@@ -95,7 +126,7 @@ func (m *Manager) armEgressProxy(_ context.Context, sb *types.Sandbox) error {
 		return fmt.Errorf("listen egress %s: %w", sb.ID, err)
 	}
 	id, tenant := sb.ID, sb.Tenant
-	proxy := egress.New(id, tenant, policy, m.egressSecrets, (&net.Dialer{}).DialContext,
+	proxy := egress.New(id, tenant, policy, m.egressSecrets, egressDialer.DialContext,
 		func(ev egress.Event) { m.recordEgress(context.Background(), id, tenant, ev) })
 	el := &egressListener{srv: &http.Server{Handler: proxy, ReadHeaderTimeout: 30 * time.Second}, ln: ln, path: path}
 	m.mu.Lock()
@@ -112,21 +143,27 @@ func (m *Manager) disarmIfReleased(sb *types.Sandbox) bool {
 	live := m.claimed[sb.ID] == sb
 	m.mu.Unlock()
 	if !live {
-		m.disarmEgress(sb.ID)
+		m.disarmEgress(sb.ID, true)
 	}
 	return !live
 }
 
-// disarmEgress tears down a sandbox's egress proxy and NIC lock; idempotent.
-func (m *Manager) disarmEgress(id string) {
-	if !m.guardedEgress {
+// disarmEgress tears down a sandbox's egress proxy listener, and its NIC lock
+// only when removed is true — a failed VM removal keeps the lock (the guest is
+// still running) but still stops the dropped claim's credential injection.
+// Idempotent.
+func (m *Manager) disarmEgress(id string, removed bool) {
+	if !m.guardedEgress && !m.lockEgress {
 		return
 	}
 	m.mu.Lock()
 	el := m.egressListeners[id]
 	delete(m.egressListeners, id)
-	tap := m.egressTaps[id]
-	delete(m.egressTaps, id)
+	var tap string
+	if removed {
+		tap = m.egressTaps[id]
+		delete(m.egressTaps, id)
+	}
 	m.mu.Unlock()
 	if el != nil {
 		el.close()

--- a/sandboxd/pool/egress.go
+++ b/sandboxd/pool/egress.go
@@ -20,27 +20,31 @@ import (
 var (
 	nat64Range = netip.MustParsePrefix("64:ff9b::/96") // RFC 6052 NAT64; the embedded v4 is checked instead
 
-	// internalRanges are IANA special-purpose prefixes with Globally Reachable =
-	// false (plus deprecated v4-in-v6 embeddings) that IsGlobalUnicast/IsPrivate
-	// do not already exclude — a table so the denylist tracks the registry, not
-	// one-off additions.
+	// internalRanges is every IANA special-purpose prefix with Globally Reachable =
+	// false that IsGlobalUnicast/IsPrivate do not already exclude, plus the
+	// deprecated IPv4-compatible embedding, mirrored from the IPv4/IPv6
+	// Special-Purpose registries (snapshot 2026-07-11). 2001::/23 is blocked whole
+	// (its handful of globally-reachable anycast carve-outs are not egress targets).
 	internalRanges = []netip.Prefix{
-		netip.MustParsePrefix("0.0.0.0/8"),       // "this host on this network"
+		netip.MustParsePrefix("0.0.0.0/8"),       // "this network"
 		netip.MustParsePrefix("100.64.0.0/10"),   // RFC 6598 CGNAT; some clouds host metadata here
 		netip.MustParsePrefix("192.0.0.0/24"),    // IETF protocol assignments
-		netip.MustParsePrefix("192.0.2.0/24"),    // TEST-NET-1 documentation
+		netip.MustParsePrefix("192.0.2.0/24"),    // TEST-NET-1
+		netip.MustParsePrefix("192.88.99.2/32"),  // 6a44-relay anycast
 		netip.MustParsePrefix("198.18.0.0/15"),   // benchmarking
-		netip.MustParsePrefix("198.51.100.0/24"), // TEST-NET-2 documentation
-		netip.MustParsePrefix("203.0.113.0/24"),  // TEST-NET-3 documentation
-		netip.MustParsePrefix("240.0.0.0/4"),     // reserved; some clouds use it as internal fabric
+		netip.MustParsePrefix("198.51.100.0/24"), // TEST-NET-2
+		netip.MustParsePrefix("203.0.113.0/24"),  // TEST-NET-3
+		netip.MustParsePrefix("240.0.0.0/4"),     // reserved
 
 		netip.MustParsePrefix("::/96"),          // deprecated IPv4-compatible; embeds a v4 unmapped
 		netip.MustParsePrefix("64:ff9b:1::/48"), // RFC 8215 local-use NAT64; embeds a v4
 		netip.MustParsePrefix("100::/64"),       // discard-only
-		netip.MustParsePrefix("2001::/32"),      // Teredo; embeds a v4
-		netip.MustParsePrefix("2001:2::/48"),    // benchmarking
+		netip.MustParsePrefix("100:0:0:1::/64"), // dummy prefix
+		netip.MustParsePrefix("2001::/23"),      // IETF protocol assignments (Teredo, benchmarking, ORCHID)
 		netip.MustParsePrefix("2001:db8::/32"),  // documentation
 		netip.MustParsePrefix("2002::/16"),      // 6to4; embeds a v4
+		netip.MustParsePrefix("3fff::/20"),      // documentation
+		netip.MustParsePrefix("5f00::/16"),      // SRv6 SIDs
 	}
 
 	// egressDialer blocks internal-address targets so the proxy cannot be an SSRF.

--- a/sandboxd/pool/egress.go
+++ b/sandboxd/pool/egress.go
@@ -20,15 +20,27 @@ import (
 var (
 	nat64Range = netip.MustParsePrefix("64:ff9b::/96") // RFC 6052 NAT64; the embedded v4 is checked instead
 
-	// internalRanges are reserved or v4-embedding ranges IsGlobalUnicast would pass.
+	// internalRanges are IANA special-purpose prefixes with Globally Reachable =
+	// false (plus deprecated v4-in-v6 embeddings) that IsGlobalUnicast/IsPrivate
+	// do not already exclude — a table so the denylist tracks the registry, not
+	// one-off additions.
 	internalRanges = []netip.Prefix{
-		netip.MustParsePrefix("100.64.0.0/10"),  // RFC 6598 CGNAT; some clouds host metadata here
-		netip.MustParsePrefix("0.0.0.0/8"),      // "this network"
-		netip.MustParsePrefix("240.0.0.0/4"),    // reserved; some clouds use it as internal fabric
-		netip.MustParsePrefix("64:ff9b:1::/48"), // RFC 8215 local-use NAT64
+		netip.MustParsePrefix("0.0.0.0/8"),       // "this host on this network"
+		netip.MustParsePrefix("100.64.0.0/10"),   // RFC 6598 CGNAT; some clouds host metadata here
+		netip.MustParsePrefix("192.0.0.0/24"),    // IETF protocol assignments
+		netip.MustParsePrefix("192.0.2.0/24"),    // TEST-NET-1 documentation
+		netip.MustParsePrefix("198.18.0.0/15"),   // benchmarking
+		netip.MustParsePrefix("198.51.100.0/24"), // TEST-NET-2 documentation
+		netip.MustParsePrefix("203.0.113.0/24"),  // TEST-NET-3 documentation
+		netip.MustParsePrefix("240.0.0.0/4"),     // reserved; some clouds use it as internal fabric
+
 		netip.MustParsePrefix("::/96"),          // deprecated IPv4-compatible; embeds a v4 unmapped
-		netip.MustParsePrefix("2002::/16"),      // 6to4; embeds a v4
+		netip.MustParsePrefix("64:ff9b:1::/48"), // RFC 8215 local-use NAT64; embeds a v4
+		netip.MustParsePrefix("100::/64"),       // discard-only
 		netip.MustParsePrefix("2001::/32"),      // Teredo; embeds a v4
+		netip.MustParsePrefix("2001:2::/48"),    // benchmarking
+		netip.MustParsePrefix("2001:db8::/32"),  // documentation
+		netip.MustParsePrefix("2002::/16"),      // 6to4; embeds a v4
 	}
 
 	// egressDialer blocks internal-address targets so the proxy cannot be an SSRF.

--- a/sandboxd/pool/egress_test.go
+++ b/sandboxd/pool/egress_test.go
@@ -50,7 +50,7 @@ func TestEgressProxyInjectsAndGates(t *testing.T) {
 
 	pol := &egress.Policy{Allow: []egress.Rule{{Host: host, Secret: "gh"}}}
 	m := egressManager(t, newFakeEngine(), config.PoolSpec{PoolKey: testKey, Warm: 1, Egress: pol})
-	defer swapEgressDialer(&net.Dialer{})() // the test origin is on loopback, which the SSRF guard blocks
+	m.dial = (&net.Dialer{}).DialContext // the test origin is on loopback, which the SSRF guard blocks
 
 	// A short socket dir: the UDS path + "_2049" must fit the OS sun_path cap.
 	sockDir, err := os.MkdirTemp("/tmp", "eg")
@@ -165,7 +165,10 @@ func TestEffectivePolicyComposition(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m.pools[testKey] = &pool{key: testKey, egressPolicy: tc.pool}
+			m.poolEgress = map[types.PoolKey]*egress.Policy{}
+			if tc.pool != nil {
+				m.poolEgress[testKey] = tc.pool
+			}
 			m.tenantEgress = map[string]*egress.Policy{}
 			if tc.tenant != nil {
 				m.tenantEgress["acme"] = tc.tenant
@@ -304,13 +307,11 @@ func TestQuarantineFailedRemoveStaysUnswept(t *testing.T) {
 	m.mu.Lock()
 	m.claimed[sb.ID] = sb
 	m.mu.Unlock()
-	// The live record names no tap, so the claim quarantines; its remove fails.
 	live := map[string]types.VMRecord{"sbx-q1": {Config: types.VMConfig{Name: "sbx-q1"}, State: vmStateRunning}}
 	removed := map[string]bool{}
 
 	var gotKeep map[string]bool
-	restore := swapSweepExcept(func(keep map[string]bool) error { gotKeep = keep; return nil })
-	defer restore()
+	m.sweep = func(keep map[string]bool) error { gotKeep = keep; return nil }
 	m.resyncEgress(t.Context(), live, removed)
 
 	if removed["sbx-q1"] {
@@ -324,18 +325,6 @@ func TestQuarantineFailedRemoveStaysUnswept(t *testing.T) {
 	if _, ok := m.claimed["sb_q1"]; ok {
 		t.Error("quarantined claim still in service")
 	}
-}
-
-func swapSweepExcept(f func(map[string]bool) error) func() {
-	old := sweepExcept
-	sweepExcept = f
-	return func() { sweepExcept = old }
-}
-
-func swapEgressDialer(d *net.Dialer) func() {
-	old := egressDialer
-	egressDialer = d
-	return func() { egressDialer = old }
 }
 
 func TestEgressLaneLocksWithNoPolicyAnywhere(t *testing.T) {
@@ -366,7 +355,7 @@ func TestDisarmKeepsLockWhenRemoveFailed(t *testing.T) {
 	// A failed VM removal must tear down the proxy listener (stop credential
 	// injection for the dropped claim) but keep the NIC lock (the guest runs on).
 	m := egressManager(t, newFakeEngine(), config.PoolSpec{PoolKey: testKey, Egress: egPolicy})
-	defer swapEgressDialer(&net.Dialer{})()
+	m.dial = (&net.Dialer{}).DialContext
 	sockDir, err := os.MkdirTemp("/tmp", "eg")
 	if err != nil {
 		t.Fatalf("sockdir: %v", err)
@@ -394,25 +383,34 @@ func TestDisarmKeepsLockWhenRemoveFailed(t *testing.T) {
 }
 
 func TestSetPoolsPreservesEgressPolicy(t *testing.T) {
-	// The pool API cannot carry egress (config-only); applying a warm change to
-	// an existing pool must not wipe its policy, which would widen egress to
-	// tenant-only for every later claim.
+	// The pool API cannot carry egress (config-only), so no SetPools call — warm
+	// change or drain-then-re-add — may widen the effective policy to tenant-only.
 	m := egressManager(t, newFakeEngine(), config.PoolSpec{PoolKey: egKey, Egress: egPolicy})
 	gd := filepath.Join(m.goldensDir(), egKey.Hash())
-	if err := os.MkdirAll(gd, 0o750); err != nil {
+	if err := os.MkdirAll(gd, 0o750); err != nil { // on disk so re-add adopts it, sparing an async build
 		t.Fatalf("golden dir: %v", err)
 	}
 	m.mu.Lock()
-	m.pools[egKey].goldenDir = gd // adopt a golden so SetPools' refill spawns no async build
+	m.pools[egKey].goldenDir = gd
 	m.mu.Unlock()
-	if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: egKey, WarmMax: 3}}); err != nil {
-		t.Fatalf("SetPools: %v", err)
+	policyLive := func() bool {
+		_, ok := m.effectivePolicy(&types.Sandbox{Key: egKey})
+		return ok
 	}
-	m.mu.Lock()
-	pol := m.pools[egKey].egressPolicy
-	m.mu.Unlock()
-	if pol == nil {
-		t.Fatal("SetPools wiped the pool egress policy")
+	if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: egKey, WarmMax: 3}}); err != nil {
+		t.Fatalf("SetPools warm change: %v", err)
+	}
+	if !policyLive() {
+		t.Fatal("a warm change wiped the pool egress policy")
+	}
+	if err := m.SetPools(t.Context(), nil); err != nil { // drain: the pool object is deleted
+		t.Fatalf("SetPools drain: %v", err)
+	}
+	if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: egKey}}); err != nil {
+		t.Fatalf("SetPools re-add: %v", err)
+	}
+	if !policyLive() {
+		t.Fatal("drain + re-add wiped the pool egress policy")
 	}
 }
 
@@ -422,6 +420,7 @@ func TestEgressDialerBlocksInternal(t *testing.T) {
 		"[::1]:80", "100.100.100.200:80", "[::ffff:127.0.0.1]:80",
 		"[64:ff9b::a9fe:a9fe]:80", // NAT64-embedded 169.254.169.254
 		"[64:ff9b::a00:1]:80",     // NAT64-embedded 10.0.0.1
+		"[64:ff9b:1::8.8.8.8]:80", // RFC 8215 local-use NAT64
 	}
 	for _, addr := range blocked {
 		if err := egressDialer.Control("tcp", addr, nil); err == nil {

--- a/sandboxd/pool/egress_test.go
+++ b/sandboxd/pool/egress_test.go
@@ -416,15 +416,21 @@ func TestSetPoolsPreservesEgressPolicy(t *testing.T) {
 
 func TestEgressDialerBlocksInternal(t *testing.T) {
 	blocked := []string{
+		// Caught by IsGlobalUnicast/IsPrivate/IsLinkLocal.
 		"127.0.0.1:80", "169.254.169.254:80", "10.0.0.5:443", "192.168.1.1:22",
-		"[::1]:80", "100.100.100.200:80", "[::ffff:127.0.0.1]:80",
-		"[64:ff9b::a9fe:a9fe]:80", // NAT64-embedded 169.254.169.254
-		"[64:ff9b::a00:1]:80",     // NAT64-embedded 10.0.0.1
+		"172.16.0.1:80", "255.255.255.255:80", "[::1]:80", "[::ffff:127.0.0.1]:80",
+		"[fe80::1]:80", "[fc00::1]:80", "[ff02::1]:80",
+		// IANA IPv4 special-purpose, Globally Reachable = false.
+		"0.6.6.6:80", "100.100.100.200:80", "192.0.0.1:80", "192.0.2.1:80",
+		"198.18.0.1:80", "198.19.255.255:80", "198.51.100.1:80", "203.0.113.1:80",
+		"240.1.2.3:80",
+		// IANA IPv6 special-purpose + deprecated v4-in-v6 embeddings.
+		"[100::1]:80", "[2001:2::1]:80", "[2001:db8::1]:80", "[::127.0.0.1]:80",
 		"[64:ff9b:1::8.8.8.8]:80", // RFC 8215 local-use NAT64
-		"[::127.0.0.1]:80",        // deprecated IPv4-compatible loopback
 		"[2002:a9fe:a9fe::]:80",   // 6to4-embedded 169.254.169.254
 		"[2001::a9fe:a9fe]:80",    // Teredo space
-		"0.6.6.6:80", "240.1.2.3:80",
+		"[64:ff9b::a9fe:a9fe]:80", // NAT64-embedded 169.254.169.254
+		"[64:ff9b::a00:1]:80",     // NAT64-embedded 10.0.0.1
 	}
 	for _, addr := range blocked {
 		if err := egressDialer.Control("tcp", addr, nil); err == nil {

--- a/sandboxd/pool/egress_test.go
+++ b/sandboxd/pool/egress_test.go
@@ -421,6 +421,10 @@ func TestEgressDialerBlocksInternal(t *testing.T) {
 		"[64:ff9b::a9fe:a9fe]:80", // NAT64-embedded 169.254.169.254
 		"[64:ff9b::a00:1]:80",     // NAT64-embedded 10.0.0.1
 		"[64:ff9b:1::8.8.8.8]:80", // RFC 8215 local-use NAT64
+		"[::127.0.0.1]:80",        // deprecated IPv4-compatible loopback
+		"[2002:a9fe:a9fe::]:80",   // 6to4-embedded 169.254.169.254
+		"[2001::a9fe:a9fe]:80",    // Teredo space
+		"0.6.6.6:80", "240.1.2.3:80",
 	}
 	for _, addr := range blocked {
 		if err := egressDialer.Control("tcp", addr, nil); err == nil {

--- a/sandboxd/pool/egress_test.go
+++ b/sandboxd/pool/egress_test.go
@@ -420,15 +420,18 @@ func TestEgressDialerBlocksInternal(t *testing.T) {
 		"127.0.0.1:80", "169.254.169.254:80", "10.0.0.5:443", "192.168.1.1:22",
 		"172.16.0.1:80", "255.255.255.255:80", "[::1]:80", "[::ffff:127.0.0.1]:80",
 		"[fe80::1]:80", "[fc00::1]:80", "[ff02::1]:80",
-		// IANA IPv4 special-purpose, Globally Reachable = false.
+		// IANA IPv4 special-purpose, Globally Reachable = false (one per table prefix).
 		"0.6.6.6:80", "100.100.100.200:80", "192.0.0.1:80", "192.0.2.1:80",
-		"198.18.0.1:80", "198.19.255.255:80", "198.51.100.1:80", "203.0.113.1:80",
-		"240.1.2.3:80",
+		"192.88.99.2:80", "198.18.0.1:80", "198.19.255.255:80", "198.51.100.1:80",
+		"203.0.113.1:80", "240.1.2.3:80",
 		// IANA IPv6 special-purpose + deprecated v4-in-v6 embeddings.
-		"[100::1]:80", "[2001:2::1]:80", "[2001:db8::1]:80", "[::127.0.0.1]:80",
+		"[100::1]:80", "[100:0:0:1::1]:80", "[2001:db8::1]:80", "[3fff::1]:80",
+		"[5f00::1]:80", "[::127.0.0.1]:80",
+		"[2001::a9fe:a9fe]:80",    // Teredo, within 2001::/23
+		"[2001:2::1]:80",          // benchmarking, within 2001::/23
+		"[2001:10::1]:80",         // ORCHID, within 2001::/23
 		"[64:ff9b:1::8.8.8.8]:80", // RFC 8215 local-use NAT64
 		"[2002:a9fe:a9fe::]:80",   // 6to4-embedded 169.254.169.254
-		"[2001::a9fe:a9fe]:80",    // Teredo space
 		"[64:ff9b::a9fe:a9fe]:80", // NAT64-embedded 169.254.169.254
 		"[64:ff9b::a00:1]:80",     // NAT64-embedded 10.0.0.1
 	}
@@ -437,7 +440,8 @@ func TestEgressDialerBlocksInternal(t *testing.T) {
 			t.Errorf("dial to internal %s allowed; SSRF not blocked", addr)
 		}
 	}
-	for _, addr := range []string{"93.184.216.34:443", "[64:ff9b::5db8:d822]:443"} { // public v4 direct + via NAT64
+	// public v4 direct, public v6, and a public v4 via the NAT64 well-known prefix
+	for _, addr := range []string{"93.184.216.34:443", "[2606:4700:4700::1111]:443", "[64:ff9b::5db8:d822]:443"} {
 		if err := egressDialer.Control("tcp", addr, nil); err != nil {
 			t.Errorf("dial to public %s blocked: %v", addr, err)
 		}

--- a/sandboxd/pool/egress_test.go
+++ b/sandboxd/pool/egress_test.go
@@ -50,6 +50,7 @@ func TestEgressProxyInjectsAndGates(t *testing.T) {
 
 	pol := &egress.Policy{Allow: []egress.Rule{{Host: host, Secret: "gh"}}}
 	m := egressManager(t, newFakeEngine(), config.PoolSpec{PoolKey: testKey, Warm: 1, Egress: pol})
+	defer swapEgressDialer(&net.Dialer{})() // the test origin is on loopback, which the SSRF guard blocks
 
 	// A short socket dir: the UDS path + "_2049" must fit the OS sun_path cap.
 	sockDir, err := os.MkdirTemp("/tmp", "eg")
@@ -84,7 +85,7 @@ func TestEgressProxyInjectsAndGates(t *testing.T) {
 		t.Errorf("denied status %d, want 403", deny.StatusCode)
 	}
 
-	m.disarmEgress(sb.ID)
+	m.disarmEgress(sb.ID, true)
 	if _, err := net.Dial("unix", path); err == nil {
 		t.Error("egress socket still accepts after disarm")
 	}
@@ -303,13 +304,20 @@ func TestQuarantineFailedRemoveStaysUnswept(t *testing.T) {
 	m.mu.Lock()
 	m.claimed[sb.ID] = sb
 	m.mu.Unlock()
+	// The live record names no tap, so the claim quarantines; its remove fails.
 	live := map[string]types.VMRecord{"sbx-q1": {Config: types.VMConfig{Name: "sbx-q1"}, State: vmStateRunning}}
 	removed := map[string]bool{}
 
+	var gotKeep map[string]bool
+	restore := swapSweepExcept(func(keep map[string]bool) error { gotKeep = keep; return nil })
+	defer restore()
 	m.resyncEgress(t.Context(), live, removed)
 
 	if removed["sbx-q1"] {
 		t.Error("failed remove marked the VM gone; the sweep would drop its lock table")
+	}
+	if !gotKeep["tap-q1"] {
+		t.Error("failed-remove VM's journal tap not kept; the sweep would unlock a running guest")
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -318,11 +326,137 @@ func TestQuarantineFailedRemoveStaysUnswept(t *testing.T) {
 	}
 }
 
+func swapSweepExcept(f func(map[string]bool) error) func() {
+	old := sweepExcept
+	sweepExcept = f
+	return func() { sweepExcept = old }
+}
+
+func swapEgressDialer(d *net.Dialer) func() {
+	old := egressDialer
+	egressDialer = d
+	return func() { egressDialer = old }
+}
+
+func TestEgressLaneLocksWithNoPolicyAnywhere(t *testing.T) {
+	// A bridge egress lane with zero policy on the node: guardedEgress is false,
+	// but the NIC must still be nft-locked (default-deny), never handed out free.
+	eng := newFakeEngine()
+	eng.tap = "tap-nopol"
+	m := egressManager(t, eng, config.PoolSpec{PoolKey: egKey}) // egress lane, no policy
+	if m.guardedEgress {
+		t.Fatal("no policy configured; guardedEgress should be false")
+	}
+	sb := &types.Sandbox{ID: "sb_np", Key: egKey, VMName: "sbx-np", TAP: "tap-nopol"}
+	lockErr := m.lockEgressNIC(t.Context(), sb)
+	m.mu.Lock()
+	attempted := m.egressTaps[sb.ID] == "tap-nopol"
+	m.mu.Unlock()
+	if lockErr != nil {
+		// nft is linux-only; off Linux the lock fails but must name the tap it
+		// tried, proving lockEgressNIC ran rather than short-circuiting as before.
+		attempted = strings.Contains(lockErr.Error(), "tap-nopol")
+	}
+	if !attempted {
+		t.Fatalf("policyless egress lane skipped the NIC lock: err=%v", lockErr)
+	}
+}
+
+func TestDisarmKeepsLockWhenRemoveFailed(t *testing.T) {
+	// A failed VM removal must tear down the proxy listener (stop credential
+	// injection for the dropped claim) but keep the NIC lock (the guest runs on).
+	m := egressManager(t, newFakeEngine(), config.PoolSpec{PoolKey: testKey, Egress: egPolicy})
+	defer swapEgressDialer(&net.Dialer{})()
+	sockDir, err := os.MkdirTemp("/tmp", "eg")
+	if err != nil {
+		t.Fatalf("sockdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+	sb := &types.Sandbox{ID: "sb_dz", Key: testKey, VsockSocket: filepath.Join(sockDir, "v")}
+	if armErr := m.armEgressProxy(t.Context(), sb); armErr != nil {
+		t.Fatalf("arm proxy: %v", armErr)
+	}
+	m.mu.Lock()
+	m.egressTaps[sb.ID] = "tap-dz" // as lockEgressNIC would record at claim
+	m.mu.Unlock()
+	path := engine.EgressSocketPath(sb.VsockSocket)
+
+	m.disarmEgress(sb.ID, false)
+	if _, err := net.Dial("unix", path); err == nil {
+		t.Error("proxy listener still accepts after a failed-remove disarm")
+	}
+	m.mu.Lock()
+	tap := m.egressTaps[sb.ID]
+	m.mu.Unlock()
+	if tap != "tap-dz" {
+		t.Error("failed remove dropped the NIC lock; a still-running VM must stay locked")
+	}
+}
+
+func TestSetPoolsPreservesEgressPolicy(t *testing.T) {
+	// The pool API cannot carry egress (config-only); applying a warm change to
+	// an existing pool must not wipe its policy, which would widen egress to
+	// tenant-only for every later claim.
+	m := egressManager(t, newFakeEngine(), config.PoolSpec{PoolKey: egKey, Egress: egPolicy})
+	gd := filepath.Join(m.goldensDir(), egKey.Hash())
+	if err := os.MkdirAll(gd, 0o750); err != nil {
+		t.Fatalf("golden dir: %v", err)
+	}
+	m.mu.Lock()
+	m.pools[egKey].goldenDir = gd // adopt a golden so SetPools' refill spawns no async build
+	m.mu.Unlock()
+	if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: egKey, WarmMax: 3}}); err != nil {
+		t.Fatalf("SetPools: %v", err)
+	}
+	m.mu.Lock()
+	pol := m.pools[egKey].egressPolicy
+	m.mu.Unlock()
+	if pol == nil {
+		t.Fatal("SetPools wiped the pool egress policy")
+	}
+}
+
+func TestEgressDialerBlocksInternal(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1:80", "169.254.169.254:80", "10.0.0.5:443", "192.168.1.1:22",
+		"[::1]:80", "100.100.100.200:80", "[::ffff:127.0.0.1]:80",
+		"[64:ff9b::a9fe:a9fe]:80", // NAT64-embedded 169.254.169.254
+		"[64:ff9b::a00:1]:80",     // NAT64-embedded 10.0.0.1
+	}
+	for _, addr := range blocked {
+		if err := egressDialer.Control("tcp", addr, nil); err == nil {
+			t.Errorf("dial to internal %s allowed; SSRF not blocked", addr)
+		}
+	}
+	for _, addr := range []string{"93.184.216.34:443", "[64:ff9b::5db8:d822]:443"} { // public v4 direct + via NAT64
+		if err := egressDialer.Control("tcp", addr, nil); err != nil {
+			t.Errorf("dial to public %s blocked: %v", addr, err)
+		}
+	}
+}
+
+func TestEgressLaneCannotForkOrCheckpoint(t *testing.T) {
+	m := egressManager(t, newFakeEngine(), config.PoolSpec{PoolKey: egKey, Egress: egPolicy})
+	sb := &types.Sandbox{ID: "sb_egb", Key: egKey, Token: "tok", VMName: "sbx-egb"}
+	m.mu.Lock()
+	m.claimed[sb.ID] = sb
+	m.mu.Unlock()
+	if _, err := m.Fork(t.Context(), sb.ID, "tok", 1, time.Minute); !errors.Is(err, ErrNoEgressFork) {
+		t.Errorf("Fork on egress lane: got %v, want ErrNoEgressFork", err)
+	}
+	if _, err := m.Checkpoint(t.Context(), sb.ID, "tok", "", ""); !errors.Is(err, ErrNoEgressFork) {
+		t.Errorf("Checkpoint on egress lane: got %v, want ErrNoEgressFork", err)
+	}
+	if _, err := m.Promote(t.Context(), sb.ID, "tok", "tpl", ""); !errors.Is(err, ErrNoEgressFork) {
+		t.Errorf("Promote on egress lane: got %v, want ErrNoEgressFork", err)
+	}
+}
+
 func egressManager(t *testing.T, eng *fakeEngine, pools ...config.PoolSpec) *Manager {
 	t.Helper()
 	t.Setenv("GH_TOKEN", "s3cr3t")
 	secrets := testSecrets(t, egress.SecretSpec{Name: "gh", Header: "Authorization", ValueEnv: "GH_TOKEN"})
-	m, err := NewManager(t.Context(), &config.Config{DataDir: t.TempDir(), Pools: pools}, eng, secrets)
+	m, err := NewManager(t.Context(), &config.Config{DataDir: t.TempDir(), Bridge: "sbxbr0", Pools: pools}, eng, secrets)
 	if err != nil {
 		t.Fatalf("manager: %v", err)
 	}

--- a/sandboxd/pool/fork.go
+++ b/sandboxd/pool/fork.go
@@ -24,6 +24,9 @@ func (m *Manager) Fork(ctx context.Context, id, token string, count int, ttl tim
 	if !ok {
 		return nil, ErrUnknownSandbox
 	}
+	if sb.Key.Net == types.NetEgress {
+		return nil, ErrNoEgressFork
+	}
 	if err := m.overQuota(count, sb.Tenant); err != nil {
 		return nil, err
 	}

--- a/sandboxd/pool/hibernate.go
+++ b/sandboxd/pool/hibernate.go
@@ -56,7 +56,7 @@ func (m *Manager) hibernateLocked(ctx context.Context, sb *types.Sandbox) error 
 		return resolveErr
 	}
 	if sb.HibernateSnap != "" {
-		m.disarmEgress(sb.ID)
+		m.disarmEgress(sb.ID, true)
 		if err := m.syncClaims(ctx, sb); err != nil {
 			return fmt.Errorf("hibernate %s: persist claims: %w", sb.ID, err)
 		}
@@ -83,7 +83,7 @@ func (m *Manager) hibernateLocked(ctx context.Context, sb *types.Sandbox) error 
 		adopted, resolveErr := m.resolvePendingSnap(ctx, sb)
 		if adopted {
 			m.recordHibernate(ctx, sb)
-			m.disarmEgress(sb.ID)
+			m.disarmEgress(sb.ID, true)
 			if resolveErr != nil {
 				return fmt.Errorf("hibernate %s: persist claims: %w", sb.ID, resolveErr)
 			}
@@ -102,7 +102,7 @@ func (m *Manager) hibernateLocked(ctx context.Context, sb *types.Sandbox) error 
 	}
 	// The VM is hibernated either way, so the billing window closes here.
 	m.recordHibernate(ctx, sb)
-	m.disarmEgress(sb.ID)
+	m.disarmEgress(sb.ID, true)
 	if err != nil {
 		return fmt.Errorf("hibernate %s: persist claims: %w", sb.ID, err)
 	}

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -63,6 +63,7 @@ var (
 	ErrTemplateOwned     = errors.New("template owned by another tenant")
 	ErrNoEgress          = errors.New("node has no egress attachment (bridge or network)")
 	ErrNoEgressHibernate = errors.New("egress-lane sandboxes do not hibernate")
+	ErrNoEgressFork      = errors.New("egress-lane sandboxes cannot fork, checkpoint, or promote: a resumed guest egresses before its fresh tap can be locked")
 	ErrQuota             = errors.New("node claim quota reached")
 
 	errWokeMeanwhile = errors.New("woke between sweep and hibernate")
@@ -141,7 +142,9 @@ func (p *pool) applySpec(spec config.PoolSpec) {
 	p.idle = time.Duration(spec.IdleHibernateSeconds) * time.Second
 	p.archiveAfter = time.Duration(spec.ArchiveAfterSeconds) * time.Second
 	p.archiveDelete = time.Duration(spec.ArchiveDeleteAfterSeconds) * time.Second
-	p.egressPolicy = spec.Egress
+	if spec.Egress != nil {
+		p.egressPolicy = spec.Egress // config-only; a nil SetPools spec must not clear it
+	}
 }
 
 // Manager owns the node's pools, claims, and their persistence.
@@ -211,11 +214,12 @@ type Manager struct {
 	// instead of waiting out a gossip tick.
 	notifyTemplates func()
 
-	// egressSecrets resolves a rule's secret name to the injected header;
-	// built once at startup, read-only after. guardedEgress short-circuits the
-	// claim path when no pool or tenant declares a policy.
+	// egressSecrets resolves a rule's secret name to the injected header, read-only
+	// after startup. guardedEgress arms the proxy (some policy exists); lockEgress
+	// nft-locks every egress-lane NIC default-deny (a bridge lane exists).
 	egressSecrets *egress.SecretStore
 	guardedEgress bool
+	lockEgress    bool
 
 	mu      sync.Mutex
 	pools   map[types.PoolKey]*pool
@@ -236,6 +240,7 @@ func NewManager(ctx context.Context, cfg *config.Config, eng Engine, secrets *eg
 		eng:             eng,
 		dataDir:         cfg.DataDir,
 		egress:          cfg.HasEgress(),
+		lockEgress:      cfg.Bridge != "",
 		maxFork:         maxFork,
 		store:           newClaimStore(cfg.DataDir),
 		pools:           make(map[types.PoolKey]*pool, len(cfg.Pools)),

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
 	"github.com/cocoonstack/sandbox/sandboxd/egress"
+	"github.com/cocoonstack/sandbox/sandboxd/netfilter"
 	"github.com/cocoonstack/sandbox/sandboxd/store"
 	"github.com/cocoonstack/sandbox/sandboxd/store/dir"
 	"github.com/cocoonstack/sandbox/sandboxd/store/s3"
@@ -132,8 +133,6 @@ type pool struct {
 	nextBuild time.Time
 	warm      []*types.Sandbox
 	refilling int
-
-	egressPolicy *egress.Policy // this pool's allow-list; nil = no pool policy
 }
 
 func (p *pool) applySpec(spec config.PoolSpec) {
@@ -142,9 +141,6 @@ func (p *pool) applySpec(spec config.PoolSpec) {
 	p.idle = time.Duration(spec.IdleHibernateSeconds) * time.Second
 	p.archiveAfter = time.Duration(spec.ArchiveAfterSeconds) * time.Second
 	p.archiveDelete = time.Duration(spec.ArchiveDeleteAfterSeconds) * time.Second
-	if spec.Egress != nil {
-		p.egressPolicy = spec.Egress // config-only; a nil SetPools spec must not clear it
-	}
 }
 
 // Manager owns the node's pools, claims, and their persistence.
@@ -191,6 +187,7 @@ type Manager struct {
 	tenantMax    map[string]int
 	tenantLive   map[string]int
 	tenantEgress map[string]*egress.Policy // per-tenant allow-list; nil = no tenant policy
+	poolEgress   map[types.PoolKey]*egress.Policy
 	usage        *journal
 	audit        *journal
 	counters     counters
@@ -220,6 +217,10 @@ type Manager struct {
 	egressSecrets *egress.SecretStore
 	guardedEgress bool
 	lockEgress    bool
+	// dial and sweep are fields as test seams: the SSRF guard blocks loopback
+	// test origins, and the nft sweep is netlink-only.
+	dial  egress.DialFunc
+	sweep func(map[string]bool) error
 
 	mu      sync.Mutex
 	pools   map[types.PoolKey]*pool
@@ -251,6 +252,8 @@ func NewManager(ctx context.Context, cfg *config.Config, eng Engine, secrets *eg
 		egressListeners: map[string]*egressListener{},
 		egressTaps:      map[string]string{},
 		egressSecrets:   secrets,
+		dial:            egressDialer.DialContext,
+		sweep:           netfilter.SweepExcept,
 		refillSem:       make(chan struct{}, maxConcurrentRefills),
 	}
 	if err := os.MkdirAll(m.goldensDir(), 0o750); err != nil {
@@ -291,6 +294,7 @@ func NewManager(ctx context.Context, cfg *config.Config, eng Engine, secrets *eg
 	m.maxClaims = cfg.MaxClaims
 	m.tenantMax = make(map[string]int, len(cfg.Tenants))
 	m.tenantEgress = make(map[string]*egress.Policy, len(cfg.Tenants))
+	m.poolEgress = make(map[types.PoolKey]*egress.Policy, len(cfg.Pools))
 	for _, tn := range cfg.Tenants {
 		m.tenantMax[tn.Name] = tn.MaxClaims
 		if tn.Egress != nil {
@@ -314,6 +318,7 @@ func NewManager(ctx context.Context, cfg *config.Config, eng Engine, secrets *eg
 			m.archiveEnabled = true
 		}
 		if spec.Egress != nil {
+			m.poolEgress[spec.PoolKey] = spec.Egress
 			m.guardedEgress = true
 		}
 	}

--- a/sandboxd/pool/promote_test.go
+++ b/sandboxd/pool/promote_test.go
@@ -136,6 +136,31 @@ func TestReconcileSweepsGoldenTmpDirs(t *testing.T) {
 	}
 }
 
+func TestResolveGoldenSkipsPromotedEgressTemplate(t *testing.T) {
+	// A template promoted before the egress guard existed must never be resumed:
+	// resolveGolden returns "" for the egress lane so the claim cold-boots.
+	m := newTestManager(t, newFakeEngine())
+	id := store.TemplateID(egKey.Hash())
+	staging, err := m.tpls.Stage(id)
+	if err != nil {
+		t.Fatalf("stage: %v", err)
+	}
+	if err = os.MkdirAll(filepath.Join(staging, store.ExportDir), 0o750); err != nil {
+		t.Fatalf("mkdir export: %v", err)
+	}
+	if err = m.commitTemplate(t.Context(), staging, id, ""); err != nil {
+		t.Fatalf("seed template: %v", err)
+	}
+	dir, release, err := m.resolveGolden(t.Context(), egKey)
+	if err != nil {
+		t.Fatalf("resolveGolden: %v", err)
+	}
+	release()
+	if dir != "" {
+		t.Errorf("resolveGolden resumed a promoted egress template %q; want cold-boot", dir)
+	}
+}
+
 func TestReconcileMigratesLegacyTemplates(t *testing.T) {
 	eng := newFakeEngine()
 	m := newTestManager(t, eng)

--- a/sandboxd/pool/reconcile.go
+++ b/sandboxd/pool/reconcile.go
@@ -16,10 +16,6 @@ import (
 	"github.com/cocoonstack/sandbox/sandboxd/types"
 )
 
-// sweepExcept is a seam so a test can observe the keep set (netfilter is a
-// no-op off Linux and an unmockable netlink call on it).
-var sweepExcept = netfilter.SweepExcept
-
 // Reconcile aligns state after a daemon restart: re-adopt persisted claims
 // whose VMs are still running (or hibernated), drop the rest, and remove any
 // sbx-prefixed VM nobody owns (stale pool VMs and golden builders from a
@@ -193,7 +189,7 @@ func (m *Manager) resyncEgress(ctx context.Context, live map[string]types.VMReco
 			keep[tap] = true
 		}
 	}
-	if sweepErr := sweepExcept(keep); sweepErr != nil {
+	if sweepErr := m.sweep(keep); sweepErr != nil {
 		logger.Warnf(ctx, "sweep orphan egress tables: %v", sweepErr)
 	}
 }

--- a/sandboxd/pool/reconcile.go
+++ b/sandboxd/pool/reconcile.go
@@ -16,6 +16,10 @@ import (
 	"github.com/cocoonstack/sandbox/sandboxd/types"
 )
 
+// sweepExcept is a seam so a test can observe the keep set (netfilter is a
+// no-op off Linux and an unmockable netlink call on it).
+var sweepExcept = netfilter.SweepExcept
+
 // Reconcile aligns state after a daemon restart: re-adopt persisted claims
 // whose VMs are still running (or hibernated), drop the rest, and remove any
 // sbx-prefixed VM nobody owns (stale pool VMs and golden builders from a
@@ -157,7 +161,7 @@ func (m *Manager) resyncEgress(ctx context.Context, live map[string]types.VMReco
 	var quarantine []*types.Sandbox
 	for _, sb := range m.claimed {
 		sb.TouchAt(now)
-		if m.guardedEgress && sb.Key.Net == types.NetEgress {
+		if m.lockEgress && sb.Key.Net == types.NetEgress {
 			tap := m.readoptEgressTap(sb, live)
 			if tap == "" {
 				logger.Errorf(ctx, errNoEgressTap, "egress claim %s has no lockable tap; quarantining", sb.ID)
@@ -189,7 +193,7 @@ func (m *Manager) resyncEgress(ctx context.Context, live map[string]types.VMReco
 			keep[tap] = true
 		}
 	}
-	if sweepErr := netfilter.SweepExcept(keep); sweepErr != nil {
+	if sweepErr := sweepExcept(keep); sweepErr != nil {
 		logger.Warnf(ctx, "sweep orphan egress tables: %v", sweepErr)
 	}
 }

--- a/sandboxd/pool/setpools.go
+++ b/sandboxd/pool/setpools.go
@@ -23,8 +23,8 @@ func (m *Manager) SetPools(ctx context.Context, specs []config.PoolSpec) error {
 		if err := spec.ValidateLimits(); err != nil {
 			return fmt.Errorf("%w: %v", ErrBadCount, err)
 		}
-		// The manager neither validates nor keeps egress policy yet;
-		// accepting it here would silently drop it.
+		// Egress is config-owned (validated at load); accepting it here would
+		// silently drop it.
 		if spec.Egress != nil {
 			return fmt.Errorf("%w: pool %q: egress is set in the config file, not via the API", ErrBadKey, spec.Template)
 		}

--- a/sandboxd/pool/template.go
+++ b/sandboxd/pool/template.go
@@ -39,6 +39,9 @@ func (m *Manager) Promote(ctx context.Context, id, token, template, tenant strin
 	if !ok {
 		return types.PoolKey{}, ErrUnknownSandbox
 	}
+	if sb.Key.Net == types.NetEgress {
+		return types.PoolKey{}, ErrNoEgressFork
+	}
 	key := types.PoolKey{Template: template, Net: sb.Key.Net, Size: sb.Key.Size}
 	if m.pooledHash(key.Hash()) {
 		// A configured pool owns this key — promoting over it would

--- a/sandboxd/pool/template.go
+++ b/sandboxd/pool/template.go
@@ -225,6 +225,9 @@ func (m *Manager) resolveGolden(ctx context.Context, key types.PoolKey) (string,
 	if dir != "" {
 		return dir, func() {}, nil
 	}
+	if key.Net == types.NetEgress {
+		return "", func() {}, nil // never resume a live-captured template on the egress lane; cold-boot instead
+	}
 	id := store.TemplateID(key.Hash())
 	l := m.recLock(id)
 	l.RLock()

--- a/sandboxd/server/server.go
+++ b/sandboxd/server/server.go
@@ -42,6 +42,7 @@ var poolErrHTTP = []struct {
 	{pool.ErrBadCount, http.StatusBadRequest, ""},
 	{pool.ErrNoEgress, http.StatusConflict, ""},
 	{pool.ErrNoEgressHibernate, http.StatusConflict, ""},
+	{pool.ErrNoEgressFork, http.StatusConflict, ""},
 	{pool.ErrQuota, http.StatusTooManyRequests, ""},
 	{pool.ErrPooledTemplate, http.StatusConflict, ""},
 	{pool.ErrTemplateOwned, http.StatusConflict, ""},


### PR DESCRIPTION
A whole-subsystem audit of the egress lane (after #24/#25 landed) plus an
adversarial review round surfaced six gaps beyond the known fork/checkpoint
window — two of them fail-open. This closes all of them.

## Fixes

- **Policy-free egress lane ran an open NIC (fail-open).** The nft lock was
  gated on `guardedEgress` (some policy exists) rather than on being a bridge
  lane, so an egress pool with no policy anywhere got a fully open, never-locked
  NIC. Introduce `m.lockEgress = cfg.Bridge != ""`; a bridge egress lane now
  locks default-deny regardless of policy. `guardedEgress` still gates only the
  proxy.
- **Proxy SSRF.** The per-sandbox proxy authorized by hostname but dialed
  whatever that host resolved to. Add a `net.Dialer.Control` that blocks
  loopback, link-local (incl. cloud metadata), private, RFC 6598 CGNAT
  (`100.64.0.0/10`), and NAT64-embedded targets — the RFC 6052 well-known
  `64:ff9b::/96` (unwrapped to its inner v4) and the RFC 8215 local-use
  `64:ff9b:1::/48` — so an allow-listed or DNS-rebound host cannot reach the
  host, metadata, or a peer. Applies to both lanes.
- **Listener leak on a failed removal.** Teardown gated the proxy listener and
  the NIC unlock together on `removeVM` success, so a failed removal left the
  listener injecting credentials for a dropped claim. `disarmEgress` now tears
  the listener down unconditionally and unlocks only when the VM is confirmed
  gone (a failed removal keeps the NIC locked, fail-safe).
- **`SetPools` wiped a pool's egress policy.** The pool API cannot carry egress
  (config-only), so a routine warm-count change reset the policy to nil and
  widened the effective policy to tenant-only. Config pool policies now live in
  a startup-immutable `poolEgress` map (like `tenantEgress`) that `SetPools`
  never touches, instead of a mutable pool-struct field.
- **`fork`/`checkpoint`/`promote` refused on the egress lane (409).** A resumed
  guest egresses before its fresh tap can be locked — the same reason
  hibernate/archive are already refused.
- **CNI validation.** Reject guarded egress on a CNI network only when a policy
  could apply to an egress-lane claim (a tenant policy, or an egress pool's
  own), since claims mint keys directly. A none-lane policy on a CNI network now
  loads.

## Follow-up (review round 2)

- **Promoted egress-lane template could resume on an unlocked tap.** A template
  promoted before the fork/checkpoint guard existed would clone-resume a
  live-captured image whose fresh tap is not yet locked. `resolveGolden` now
  refuses a promoted template on the egress lane and cold-boots instead.

## Verification

- `go test -race -count=1 ./...` green; `make lint` clean on `GOOS=linux` and
  `GOOS=darwin`. New tests cover each fix.
- Hardware (bare metal, sandboxd at this branch): a claimed policy-free egress
  sandbox now shows its `sandbox_egress_<tap>` nft table (previously none);
  fork/checkpoint/promote return 409 on the egress lane.
