### PR TITLE
release: version flag, tagged binary releases, systemd unit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+# Binary releases: a v* tag builds the static server binaries and publishes
+# a GitHub release with checksums and generated notes. SDK packages release
+# separately via sdk-*-v* tags (publish-pypi.yml).
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: sandboxd/go.mod
+      - name: Build
+        env:
+          CGO_ENABLED: "0"
+          GOOS: linux
+          GOARCH: amd64
+          GOWORK: off
+        run: |
+          mkdir -p dist
+          (cd sandboxd && go build -trimpath -ldflags "-s -w -X main.version=${GITHUB_REF_NAME}" -o ../dist/sandboxd-linux-amd64 .)
+          (cd mcp && go build -trimpath -ldflags "-s -w" -o ../dist/sandbox-mcp-linux-amd64 .)
+          (cd dist && sha256sum sandboxd-linux-amd64 sandbox-mcp-linux-amd64 > SHA256SUMS)
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" --generate-notes \
+            dist/sandboxd-linux-amd64 dist/sandbox-mcp-linux-amd64 dist/SHA256SUMS

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ BOOT_IMAGE ?= sandbox-boot:$(KERNEL_VERSION)
 SILKD_VERSION := $(shell sed -n 's/^version = "\(.*\)"/\1/p' silkd/Cargo.toml | head -1)
 SILKD_IMAGE ?= sandbox-silkd:$(SILKD_VERSION)
 
+# Match only v* (binary releases); sdk-*-v* tags belong to the SDK packages.
+SANDBOXD_VERSION ?= $(shell git describe --tags --match 'v*' --always --dirty)
+
 EXTRACT_IMAGE ?= $(BOOT_IMAGE)
 
 # The parent workspace's go.work excludes these modules; GOWORK=off keeps
@@ -28,7 +31,7 @@ lint: ## Rust fmt --check + clippy -D warnings: boot/init + silkd
 
 sandboxd: ## build dist/sandboxd
 	mkdir -p dist
-	cd sandboxd && GOWORK=off go build -o ../dist/sandboxd .
+	cd sandboxd && GOWORK=off go build -ldflags "-X main.version=$(SANDBOXD_VERSION)" -o ../dist/sandboxd .
 
 go-test: ## go test -race across the Go modules
 	for m in $(GO_MODULES); do (cd $$m && GOWORK=off go test -race ./...) || exit 1; done

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -14,7 +14,11 @@ the cocoon CLI and needs a template image with silkd baked in.
 - A silkd-baked template image, e.g. `ghcr.io/cocoonstack/sandbox/base:24.04`
   (pull via cocoon, or `cocoon image import` a tar)
 
-Build from source: `make sandboxd` produces `dist/sandboxd`.
+Prebuilt static linux/amd64 binaries (`sandboxd`, `sandbox-mcp`, with
+`SHA256SUMS`) ship with every
+[GitHub release](https://github.com/cocoonstack/sandbox/releases). Build
+from source with `make sandboxd` (produces `dist/sandboxd`); either way
+`sandboxd -version` reports what you are running.
 
 ## Configuration
 
@@ -176,7 +180,8 @@ tens of seconds) and keeps each pool topped up with claim-ready clones.
 `GET /v1/info` shows `"golden": true` and `warm` at target when the node is
 ready to serve warm claims.
 
-A minimal systemd unit:
+A minimal systemd unit (shipped as
+[`packaging/sandboxd.service`](https://github.com/cocoonstack/sandbox/blob/main/packaging/sandboxd.service)):
 
 ```ini
 [Unit]

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -186,6 +186,7 @@ A minimal systemd unit (shipped as
 ```ini
 [Unit]
 Description=sandboxd
+Wants=network-online.target
 After=network-online.target
 
 [Service]

--- a/packaging/sandboxd.service
+++ b/packaging/sandboxd.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=sandboxd
+After=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/sandboxd -config /etc/sandboxd/config.json
+Restart=on-failure
+Environment=SANDBOXD_LOG_LEVEL=info
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/sandboxd.service
+++ b/packaging/sandboxd.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=sandboxd
+Wants=network-online.target
 After=network-online.target
 
 [Service]

--- a/sandboxd/main.go
+++ b/sandboxd/main.go
@@ -15,6 +15,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime/debug"
+	"slices"
 	"strconv"
 	"syscall"
 	"time"
@@ -39,6 +41,10 @@ const (
 	readHeaderTimeout = 5 * time.Second
 )
 
+// version is stamped via -ldflags at build; devel builds fall back to the
+// VCS revision Go embeds.
+var version = "devel"
+
 func main() {
 	if len(os.Args) > 1 && os.Args[1] == "ca" {
 		if err := runCA(os.Args[2:]); err != nil {
@@ -48,7 +54,12 @@ func main() {
 		return
 	}
 	configPath := flag.String("config", "/etc/sandboxd/config.json", "node config file")
+	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
+	if *showVersion {
+		fmt.Println("sandboxd", versionString())
+		return
+	}
 
 	ctx := context.Background()
 	logLevel := cmp.Or(os.Getenv("SANDBOXD_LOG_LEVEL"), "info")
@@ -56,6 +67,7 @@ func main() {
 	if err := log.SetupLog(ctx, &coretypes.ServerLogConfig{Level: logLevel}, ""); err != nil {
 		logger.Fatalf(ctx, err, "setup log")
 	}
+	logger.Infof(ctx, "sandboxd %s", versionString())
 
 	cfg, err := config.Load(*configPath)
 	if err != nil {
@@ -193,4 +205,19 @@ func gossipNodeState(ctx context.Context, msh *mesh.Mesh, mgr *pool.Manager) {
 			msh.UpdateSelf(mgr.WarmCounts(), mgr.TemplateHashes())
 		}
 	}
+}
+
+func versionString() string {
+	if version != "devel" {
+		return version
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return version
+	}
+	i := slices.IndexFunc(info.Settings, func(s debug.BuildSetting) bool { return s.Key == "vcs.revision" })
+	if i < 0 || len(info.Settings[i].Value) < 12 {
+		return version
+	}
+	return version + "-" + info.Settings[i].Value[:12]
 }


### PR DESCRIPTION
The "single static binary" story gets its last mile: a way to know what you are running, a place to download it, and a unit to run it under.

- **`sandboxd -version`**: stamped via `-ldflags -X main.version` (`make sandboxd` uses `git describe --match 'v*'`, so SDK tags don't leak in); untagged builds fall back to the Go-embedded VCS revision. The version is also logged once at startup, so journals identify the running build.
- **`release.yml`**: a `v*` tag builds static linux/amd64 `sandboxd` + `sandbox-mcp` (`CGO_ENABLED=0 -trimpath -s -w`), writes `SHA256SUMS`, and publishes a GitHub release with generated notes. SDK packages keep their separate `sdk-*-v*` → PyPI path.
- **`packaging/sandboxd.service`**: the minimal unit from deploy.md, shipped as a file; deploy.md now points at releases and the unit.

Hot-path cost: zero — a startup log line and a flag.

Evidence: `make sandboxd && dist/sandboxd -version` → `sandboxd 6615de0-dirty` (VCS fallback path, no v* tag yet); module tests green; dual-GOOS lint 0 issues; the workflow first fires on the first `v*` tag.