### PR TITLE
engine: require cocoon v0.5.2 — startup version probe + deploy prerequisite

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -6,8 +6,14 @@ the cocoon CLI and needs a template image with silkd baked in.
 ## Prerequisites
 
 - Linux with KVM (`/dev/kvm`)
-- [cocoon](https://github.com/cocoonstack/cocoon) installed and working
-  (`cocoon vm run` boots a VM), with Cloud Hypervisor and/or Firecracker
+- [cocoon](https://github.com/cocoonstack/cocoon) **v0.5.2 or newer** installed
+  and working (`cocoon vm run` boots a VM), with Cloud Hypervisor and/or
+  Firecracker. Older cocoon fails or degrades — **v0.5.0 silently breaks the
+  Firecracker clone-from-snapshot path** (warm-pool refill and fork), fixed in
+  v0.5.1, and v0.5.2 adds the parallel-clone and snapshot/store perf work the
+  [performance](performance.md) numbers assume. sandboxd logs a warning at
+  startup when the detected cocoon is below v0.5.2 (a dev/`master-<sha>` build
+  is assumed current)
 - The sandbox boot artifact installed where cocoon finds it
   (`/boot/vmlinuz-sandbox`, `/boot/initrd.img-sandbox` — from
   `ghcr.io/cocoonstack/sandbox/boot:<kernel-ver>`)

--- a/sandboxd/engine/engine.go
+++ b/sandboxd/engine/engine.go
@@ -26,6 +26,12 @@ import (
 )
 
 const (
+	// RequiredCocoon is the minimum supported cocoon release: v0.5.0 silently
+	// breaks FC clone-from-snapshot (warm-pool refill + fork), fixed in v0.5.1;
+	// v0.5.2 carries the parallel-clone and snapshot/store perf work sandbox's
+	// latency numbers assume.
+	RequiredCocoon = "v0.5.2"
+
 	silkdPort     = 2048 // silkd's fixed guest vsock port, the claim-ready anchor
 	egressPort    = 2049 // guest→host egress port; VMM maps it to <vsock_socket>_2049
 	cmdTimeout    = 2 * time.Minute
@@ -52,6 +58,37 @@ type Engine struct {
 // egress-lane attachment.
 func New(bin, bridge, network string) *Engine {
 	return &Engine{bin: bin, bridge: bridge, network: network}
+}
+
+// Version reports cocoon's version string — a "vX.Y.Z" release or a
+// "master-<sha>" dev build.
+func (e *Engine) Version(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, e.bin, "version").Output() //nolint:gosec // bin is node config, arg is a literal
+	if err != nil {
+		return "", fmt.Errorf("cocoon version: %w", err)
+	}
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if v, ok := strings.CutPrefix(strings.TrimSpace(line), "Version:"); ok {
+			return strings.TrimSpace(v), nil
+		}
+	}
+	return "", fmt.Errorf("cocoon version: no Version line in output")
+}
+
+// VersionWarning probes cocoon and returns a non-empty warning when its
+// version is below RequiredCocoon (or unreadable); version is set when known.
+// A dev build (no vX.Y.Z) is assumed current.
+func (e *Engine) VersionWarning(ctx context.Context) (version, warning string) {
+	v, err := e.Version(ctx)
+	if err != nil {
+		return "", fmt.Sprintf("cannot determine cocoon version (need >= %s): %v", RequiredCocoon, err)
+	}
+	if below, comparable := belowFloor(v); comparable && below {
+		return v, fmt.Sprintf("cocoon %s is below the required %s: v0.5.0 breaks FC clone/fork — upgrade cocoon", v, RequiredCocoon)
+	}
+	return v, ""
 }
 
 // Clone restores a VM from an exported golden directory, returning its
@@ -345,6 +382,42 @@ func parseRecord(ctx context.Context, out []byte) types.VMRecord {
 		return types.VMRecord{}
 	}
 	return rec
+}
+
+// belowFloor reports whether cocoon version v is below RequiredCocoon;
+// comparable is false for a non-release build (no vX.Y.Z), assumed current.
+func belowFloor(v string) (below, comparable bool) {
+	cur, ok := parseSemver(v)
+	if !ok {
+		return false, false
+	}
+	floor, _ := parseSemver(RequiredCocoon)
+	for i := range 3 {
+		if cur[i] != floor[i] {
+			return cur[i] < floor[i], true
+		}
+	}
+	return false, true
+}
+
+func parseSemver(s string) ([3]int, bool) {
+	s = strings.TrimPrefix(s, "v")
+	if i := strings.IndexAny(s, "-+"); i >= 0 {
+		s = s[:i]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return [3]int{}, false
+	}
+	var out [3]int
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return [3]int{}, false
+		}
+		out[i] = n
+	}
+	return out, true
 }
 
 // readLine reads byte-wise so nothing past the newline is consumed —

--- a/sandboxd/engine/engine.go
+++ b/sandboxd/engine/engine.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net"
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -392,12 +393,7 @@ func belowFloor(v string) (below, comparable bool) {
 		return false, false
 	}
 	floor, _ := parseSemver(RequiredCocoon)
-	for i := range 3 {
-		if cur[i] != floor[i] {
-			return cur[i] < floor[i], true
-		}
-	}
-	return false, true
+	return slices.Compare(cur[:], floor[:]) < 0, true
 }
 
 func parseSemver(s string) ([3]int, bool) {

--- a/sandboxd/engine/version_test.go
+++ b/sandboxd/engine/version_test.go
@@ -1,0 +1,30 @@
+package engine
+
+import "testing"
+
+func TestBelowFloor(t *testing.T) {
+	tests := []struct {
+		v          string
+		below      bool
+		comparable bool
+	}{
+		{"v0.5.2", false, true},
+		{"v0.5.3", false, true},
+		{"v0.6.0", false, true},
+		{"v0.5.1", true, true},
+		{"v0.5.0", true, true},
+		{"v0.4.9", true, true},
+		{"v1.0.0", false, true},
+		{"master-82e5902", false, false},
+		{"unknown", false, false},
+		{"v0.5", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.v, func(t *testing.T) {
+			below, comparable := belowFloor(tt.v)
+			if below != tt.below || comparable != tt.comparable {
+				t.Errorf("belowFloor(%q) = (%v, %v), want (%v, %v)", tt.v, below, comparable, tt.below, tt.comparable)
+			}
+		})
+	}
+}

--- a/sandboxd/main.go
+++ b/sandboxd/main.go
@@ -73,6 +73,11 @@ func main() {
 		logger.Fatalf(ctx, err, "load config")
 	}
 	eng := engine.New(cfg.CocoonBin, cfg.Bridge, cfg.Network)
+	if v, warn := eng.VersionWarning(ctx); warn != "" {
+		logger.Warn(ctx, warn)
+	} else {
+		logger.Infof(ctx, "cocoon %s", v)
+	}
 	secrets, err := egress.NewSecretStore(cfg.Secrets)
 	if err != nil {
 		logger.Fatalf(ctx, err, "init egress secrets")


### PR DESCRIPTION
Adopts cocoon **v0.5.2** as the supported floor, with a startup probe so an out-of-date cocoon fails loud instead of silently.

## Why
Gap audit found sandbox pinned no cocoon version (docs said v0.4.8) while cocoon had moved well ahead. The load-bearing reason to require a floor:

- **cocoon v0.5.0 silently breaks the Firecracker clone-from-snapshot path** (warm-pool refill + fork) — fixed only in v0.5.1.
- **v0.5.2** carries the parallel-clone + snapshot/store perf work the [performance](../blob/main/docs/performance.md) numbers assume.

Running an old cocoon surfaced today only as an opaque runtime `cocoon vm clone: ...` failure.

## What
- `engine.RequiredCocoon = "v0.5.2"` + `Engine.Version` (parses `cocoon version`) + `Engine.VersionWarning` (semver compare; a `master-<sha>` dev build is assumed current).
- sandboxd probes cocoon at startup: logs a loud warning below the floor (naming the v0.5.0 FC break), else `cocoon <ver>` at info.
- `docs/deploy.md` prerequisite now states cocoon ≥ v0.5.2, the v0.5.0 landmine, and the perf work.
- `belowFloor`/`parseSemver` unit-tested (10 cases incl. dev-build non-comparable).

## Not in this batch
- **Persistent volumes (M7-1)** — untouched by request.
- **restore-mode mmap/ondemand (#40)** — deferred; the measured 6x (CH egress claim 104ms→17ms) is not wired here.
- **#107/#108 inline vsock_socket** — already consumed by `engine.parseRecord`; the `vm list` poll remains only as the cold-boot bind-race fallback, so no change was needed (confirmed, not churned).

## Evidence
`go build` + `go test -race` (engine + main) + dual-GOOS lint all green; `belowFloor` table test passes. Live startup-log confirmation on the .79 testbed is pending (host went down mid-check) and will be captured when it is back.