### PR TITLE
sandboxd: run both lanes on Cloud Hypervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,14 @@ snapshot in tens of milliseconds; cold boot is ~200ms on bare metal.
 
 ```
 SDK (Go)                sandboxd (per node)              guest microVM
-sandbox.New() ── HTTP ─► claim: warm pool / golden clone  CH (egress) | FC (none)
+sandbox.New() ── HTTP ─► claim: warm pool / golden clone  Cloud Hypervisor
 sb.Exec/Files/… ─ HTTP upgrade ─► byte relay ── vsock ──► silkd :2048
                         memberlist mesh: warm-count gossip,
                         MOVED-style redirect to the owning node
 ```
 
-Two network lanes, derived from the claim (never user-selected backend):
-`net=none` → Firecracker, no NIC, vsock-only (hardened default);
-`net=egress` → Cloud Hypervisor with a bridge/CNI NIC.
+Cloud Hypervisor serves both network lanes. `net=none` has no NIC and uses
+vsock-only I/O (hardened default); `net=egress` attaches a bridge/CNI NIC.
 
 **Documentation**: [cocoonstack.github.io/sandbox](https://cocoonstack.github.io/sandbox/)
 (deployment, clusters, HTTP API, Go + Python SDK references, the MCP server,
@@ -128,7 +127,7 @@ On a fresh repo run build-boot first — images build `FROM` the boot artifact.
 ## Boot chain
 
 ```
-cloud-hypervisor / firecracker
+cloud-hypervisor
   → vmlinux (PVH ELF, everything =y, no decompress stage)
   → uncompressed ~1.5MB cpio: /init = sandbox-init (static Rust)
   → resolve virtio-blk serials via sysfs (2ms poll, no udev)
@@ -140,7 +139,7 @@ Boot contract (cmdline keys consumed by sandbox-init):
 
 | cmdline key | meaning |
 |---|---|
-| `cocoon.layers=a,b,…` | EROFS layer disks: virtio-blk serials (CH) or `/dev/vdX` (FC), lowerdir order |
+| `cocoon.layers=a,b,…` | EROFS layer disks resolved from virtio-blk serials, lowerdir order |
 | `cocoon.cow=x` | writable ext4 COW disk (same resolution rules) |
 | `cocoon.timeout=10` | per-disk wait budget, seconds |
 | `cocoon.hostname=h` | set via `sethostname(2)` before handoff |

--- a/boot/Dockerfile
+++ b/boot/Dockerfile
@@ -42,20 +42,20 @@ COPY kernel/sandbox-arm64.config /tmp/sandbox-arm64.config
 # merge_config only warns and olddefconfig silently drops renamed or
 # dependency-orphaned symbols — assert the boot- and container-critical set
 # so a kernel bump cannot lose one with a green build. Boot entry and console
-# are per-arch: amd64 = PVH + 8250, arm64 = direct Image boot + PL011.
+# are per-arch: amd64 = PVH, arm64 = direct Image boot + PL031 RTC.
 RUN set -e; \
     case "$TARGETARCH" in \
       amd64) make x86_64_defconfig kvm_guest.config; \
              ./scripts/kconfig/merge_config.sh -m .config /tmp/sandbox.config; \
-             arch_asserts="PVH SERIAL_8250_CONSOLE" ;; \
+             arch_asserts="PVH VIRTIO_CONSOLE" ;; \
       arm64) make defconfig; \
              ./scripts/kconfig/merge_config.sh -m .config /tmp/sandbox.config /tmp/sandbox-arm64.config; \
-             arch_asserts="SERIAL_AMBA_PL011_CONSOLE RTC_DRV_PL031" ;; \
+             arch_asserts="RTC_DRV_PL031" ;; \
       *) echo "unsupported TARGETARCH: $TARGETARCH"; exit 1 ;; \
     esac; \
     make olddefconfig; \
     for s in $arch_asserts DEVTMPFS BLK_DEV_INITRD \
-             VIRTIO_PCI VIRTIO_MMIO_CMDLINE_DEVICES VIRTIO_BLK VIRTIO_NET \
+             VIRTIO_PCI VIRTIO_BLK VIRTIO_NET \
              VIRTIO_CONSOLE VIRTIO_VSOCKETS \
              EROFS_FS EROFS_FS_ZIP OVERLAY_FS EXT4_FS \
              NAMESPACES USER_NS SECCOMP_FILTER \
@@ -67,8 +67,7 @@ RUN set -e; \
     if grep -q "^CONFIG_MODULES=y" .config; then \
         echo "CONFIG_MODULES must be off"; exit 1; \
     fi
-# amd64 ships the uncompressed ELF vmlinux (no bzImage); arm64 ships the flat
-# Image — both direct-boot in CH and FC on their arch.
+# amd64 ships the uncompressed ELF vmlinux; arm64 ships the flat Image.
 RUN set -e; \
     if [ "$TARGETARCH" = amd64 ]; then \
         make -j"$(nproc)" vmlinux && cp vmlinux /linux/boot-kernel; \
@@ -117,7 +116,7 @@ EOF
 
 # Names keep cocoon's scanBootFiles discovery working: base name prefixes
 # "vmlinuz" / "initrd.img" under /boot. The "vmlinuz" is an ELF vmlinux on
-# amd64 and a flat Image on arm64 — CH and FC content-detect both.
+# amd64 and a flat Image on arm64.
 FROM scratch
 COPY --from=kbuild /linux/boot-kernel /boot/vmlinuz-sandbox
 COPY --from=pack /pack/initrd.img-sandbox /boot/initrd.img-sandbox

--- a/boot/init/src/boot.rs
+++ b/boot/init/src/boot.rs
@@ -193,22 +193,12 @@ fn mkdir_all(path: &str) -> Result<(), String> {
     fs::create_dir_all(path).map_err(|err| format!("mkdir {path}: {err}"))
 }
 
-/// Resolves every disk in one sysfs sweep per poll iteration instead of a
-/// scan per disk. CH disks carry a virtio-blk serial; FC has no serials, so
-/// cocoon passes /dev/vdX paths there. 2ms polling — virtio probe completes
-/// a few ms into boot, so the first or second try normally hits.
+/// Resolves every virtio-blk serial in one sysfs sweep per poll iteration.
 fn resolve_disks(ids: &[&str], timeout: Duration) -> Result<Vec<String>, String> {
     let deadline = Instant::now() + timeout;
     let mut found: Vec<Option<String>> = vec![None; ids.len()];
     loop {
-        for (i, id) in ids.iter().enumerate() {
-            if found[i].is_none() && id.starts_with("/dev/") && sys::is_block_dev(id) {
-                found[i] = Some((*id).to_string());
-            }
-        }
-        if found.iter().any(Option::is_none) {
-            scan_serials(ids, &mut found);
-        }
+        scan_serials(ids, &mut found);
         if found.iter().all(Option::is_some) {
             return Ok(found.into_iter().flatten().collect());
         }

--- a/boot/init/src/cfg.rs
+++ b/boot/init/src/cfg.rs
@@ -12,8 +12,7 @@ const MAX_TIMEOUT_SECS: u64 = 86_400;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct BootCfg {
-    /// Layer disk IDs in lowerdir order (first = uppermost lower layer):
-    /// virtio-blk serials on CH, /dev/vdX paths on FC.
+    /// Layer disk serials in lowerdir order (first = uppermost lower layer).
     pub layers: Vec<String>,
     /// Writable ext4 COW disk ID (same resolution rules as layers).
     pub cow: String,

--- a/boot/init/src/sys.rs
+++ b/boot/init/src/sys.rs
@@ -2,9 +2,7 @@
 //! unsafe lives here.
 
 use std::ffi::CString;
-use std::fs;
 use std::io;
-use std::os::unix::fs::FileTypeExt;
 use std::ptr;
 use std::time::Duration;
 
@@ -44,12 +42,6 @@ pub fn mount(
 
 pub fn move_mount(src: &str, target: &str) -> Result<(), String> {
     mount(src, target, None, libc::MS_MOVE, None)
-}
-
-pub fn is_block_dev(path: &str) -> bool {
-    fs::metadata(path)
-        .map(|m| m.file_type().is_block_device())
-        .unwrap_or(false)
 }
 
 pub fn sethostname(name: &str) -> Result<(), String> {

--- a/boot/kernel/sandbox-arm64.config
+++ b/boot/kernel/sandbox-arm64.config
@@ -1,11 +1,6 @@
-# arm64 overlay applied after sandbox.config (whose x86-only symbols — PVH,
-# KVM_GUEST, 8250 tuning — drop out on this arch). Base is `defconfig`; the
-# shipped artifact is the flat arch/arm64/boot/Image, which CH and FC both
-# direct-boot on aarch64.
-
-## Console: CH and FC expose a PL011 UART (ttyAMA0) on aarch64.
-CONFIG_SERIAL_AMBA_PL011=y
-CONFIG_SERIAL_AMBA_PL011_CONSOLE=y
+# arm64 overlay applied after sandbox.config. Base is `defconfig`; the shipped
+# artifact is the flat arch/arm64/boot/Image.
+# CONFIG_SERIAL_AMBA_PL011 is not set
 
 ## Wall time: no kvmclock on arm64 — the PL031 RTC supplies it.
 CONFIG_RTC_CLASS=y

--- a/boot/kernel/sandbox.config
+++ b/boot/kernel/sandbox.config
@@ -10,19 +10,17 @@
 ## and forced =y otherwise).
 CONFIG_EXPERT=y
 
-## Boot entry: PVH ELF note lets CH boot the uncompressed vmlinux directly
-## (FC uses the plain ELF loader) — no in-guest decompress stage.
+## Boot entry: PVH lets Cloud Hypervisor boot vmlinux without decompression.
 CONFIG_PVH=y
 CONFIG_PARAVIRT=y
 CONFIG_KVM_GUEST=y
 CONFIG_PRINTK_TIME=y
 
-## Virtio transport + devices. CH = PCI; FC = MMIO with cmdline devices.
+## Virtio PCI transport and devices.
 CONFIG_PCI=y
 CONFIG_PCI_MSI=y
 CONFIG_VIRTIO_PCI=y
-CONFIG_VIRTIO_MMIO=y
-CONFIG_VIRTIO_MMIO_CMDLINE_DEVICES=y
+# CONFIG_VIRTIO_MMIO is not set
 CONFIG_VIRTIO_BLK=y
 CONFIG_VIRTIO_NET=y
 CONFIG_VIRTIO_CONSOLE=y
@@ -55,11 +53,10 @@ CONFIG_BLK_DEV_INITRD=y
 # Entropy: since 6.2 the kernel trusts CPU/bootloader seeds by default
 # (random.trust_cpu removed as a Kconfig) — no boot-time entropy stall.
 
-## Console: 8250 serial (FC ttyS0) + virtio-console hvc0 (CH).
+## Console: virtio-console hvc0.
 ## No VT/VGA, no PS/2 — kills the i8042 probe the old cmdline worked around.
 ## INPUT_KEYBOARD must go too: KEYBOARD_ATKBD (default y) selects SERIO_I8042.
-CONFIG_SERIAL_8250=y
-CONFIG_SERIAL_8250_CONSOLE=y
+# CONFIG_SERIAL_8250 is not set
 CONFIG_UNIX98_PTYS=y
 # CONFIG_VT is not set
 # CONFIG_LEGACY_PTYS is not set
@@ -152,8 +149,7 @@ CONFIG_TRANSPARENT_HUGEPAGE_MADVISE=y
 
 ## Measured cuts (initcall_debug on a real boot, 2026-07-03): NFS+SUNRPC,
 ## guest-pointless IOMMU drivers, jitterentropy self-init, quota, netlabel,
-## kprobes, RTC (kvmclock supplies wall time via KVM_GUEST), and a 4-UART
-## 8250 scan for a console that only ever has one port.
+## kprobes, and RTC (kvmclock supplies wall time via KVM_GUEST).
 # CONFIG_NFS_FS is not set
 # CONFIG_AMD_IOMMU is not set
 # CONFIG_INTEL_IOMMU is not set
@@ -171,9 +167,6 @@ CONFIG_TRANSPARENT_HUGEPAGE_MADVISE=y
 # CONFIG_NETLABEL is not set
 # CONFIG_KPROBES is not set
 # CONFIG_RTC_CLASS is not set
-CONFIG_SERIAL_8250_NR_UARTS=1
-CONFIG_SERIAL_8250_RUNTIME_UARTS=1
-
 ## Trim: no sound/USB/graphics/vendor hardware, no debug info, no ftrace.
 ## Guest disks are virtio-blk only; guest NICs are virtio-net only.
 # CONFIG_SOUND is not set

--- a/docs/android.md
+++ b/docs/android.md
@@ -7,7 +7,7 @@ adb and any adb-based tooling (scrcpy, Appium, uiautomator2).
 
 ```go
 sb, err := client.New(ctx, "ghcr.io/cocoonstack/sandbox/android:15",
-    sandbox.WithNetwork(sandbox.NetEgress), sandbox.WithSize(sandbox.XLarge))
+    sandbox.WithNetwork(sandbox.NetNone), sandbox.WithSize(sandbox.XLarge))
 ```
 
 The claim returns when silkd answers (seconds); the Android framework
@@ -20,9 +20,9 @@ out, err := sb.Exec(ctx, "/system/bin/sh", "-c", "getprop sys.boot_completed")
 
 ## Claim shape
 
-- **Lane**: `net=egress` only. The image boots its own embedded kernel
-  (with the binder module) on Cloud Hypervisor with a tap NIC; the
-  Firecracker no-network lane does not support this shape.
+- **Lane**: `net=none`. The image boots its own embedded kernel (with the
+  binder module) on Cloud Hypervisor without a NIC, keeping checkpoint and
+  branch available.
 - **Size**: `xlarge` (4 CPU / 8G) is the intended tier.
 - **Template**: `ghcr.io/cocoonstack/sandbox/android:15` — the official
   `ghcr.io/cocoonstack/cocoon/android:15.0` base plus silkd started from an
@@ -30,17 +30,13 @@ out, err := sb.Exec(ctx, "/system/bin/sh", "-c", "getprop sys.boot_completed")
 
 ## adb access
 
-adbd listens on `[::]:5555` (all interfaces) inside the guest. Two paths:
+adbd listens on `[::]:5555` inside the guest. Reach it through the relay from
+anywhere the SDK reaches sandboxd:
 
-- **Through the relay** (works from anywhere the SDK reaches sandboxd):
-
-  ```go
-  ln, err := sb.ProxyPort(ctx, "127.0.0.1:6555", 5555)
-  // adb connect 127.0.0.1:6555
-  ```
-
-- **Direct** (when the egress lane hands the VM a routable address):
-  `adb connect <vm-ip>:5555`.
+```go
+ln, err := sb.ProxyPort(ctx, "127.0.0.1:6555", 5555)
+// adb connect 127.0.0.1:6555
+```
 
 ## What works, what differs
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -89,6 +89,52 @@ labeled and must only be compared against other nested runs.
 
 <!-- paste `make bench` output below -->
 
+### 2026-07-22 — bare metal (3e54866, CH-only round: both lanes on Cloud Hypervisor)
+
+| environment | |
+|---|---|
+| host | bare metal, AMD Ryzen 7 9700X 8-Core Processor, 16 cores, 60 GiB |
+| kernel | 7.0.0-28-generic |
+| cpufreq | powersave/balance_performance |
+| cocoon | master-e9502f6 |
+| cloud-hypervisor | dev d77dcf12 (cocoonstack fork) |
+| template | ghcr.io/cocoonstack/sandbox/rt:24.04 @ sha256:804a596ee808 |
+
+| claim tier | p50 | p90 | max | n |
+|---|---|---|---|---|
+| warm pool hit | 0.3 ms | 0.3 ms | 0.6 ms | 6 |
+| clone from golden | 0.3 ms | 0.3 ms | 0.5 ms | 10 |
+| cold boot (unpooled ghcr.io/cocoonstack/sandbox/python:3.12) | 215.4 ms | 215.4 ms | 221.5 ms | 3 |
+| burst: 16 concurrent clones | 102.1 ms | 179.3 ms | 234.5 ms | 16 |
+
+The clone-tier row measured warm hits this round: the pipelined refill
+(clone and probe gated separately) refills between back-to-back claims, so
+the adaptive watermark wins the race the harness assumes it loses. The
+burst row is the real clone-path number.
+
+| data plane | measured |
+|---|---|
+| exec RTT (dial per RPC) | n=200 p50=0.19ms p90=0.25ms p99=0.40ms |
+| fs_pull throughput (128 MiB) | 925.0 MiB/s best of 3 |
+| burst wall (16 concurrent clones) | 295 ms |
+| warm refill recovery (0 → 6) | 207 ms |
+
+| hibernate / wake (cocoon tooling, `small` 512 M, N=5) | measured |
+|---|---|
+| `vm hibernate` | 168–272 ms |
+| `vm restore` eager | 53–188 ms, median ~65 |
+| `vm restore --restore-mode mmap` | 40–67 ms, median ~55; snapshot deleted right after each restore, 5 consecutive cycles healthy |
+
+| boot chain (boot-bench.sh, RUNS=5, hvc0 console) | published kernel | this branch's kernel (no 8250/MMIO) |
+|---|---|---|
+| kernel→sandbox-init | 40–50 ms | 40–50 ms |
+| init→handoff | 0 ms | 0 ms |
+| spawn→silkd answering | 137–184 ms (median ~157) | 136–208 ms (median ~151) |
+
+Warm fill (sandboxd, `warm=16`, `refill_concurrency=8`, `restore_mode:
+mmap`, `no_direct_io: true`): golden build 0.8 s, then 16 warm in 1.9 s
+(8.3/s). Full e2e (`sandboxd-e2e.sh`, both lanes via `sbxbr0`): PASS.
+
 ### 2026-07-14 — bare metal (205d3f3, first round on the rust-review silkd)
 
 | environment | |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -4,7 +4,7 @@ Every number this project publishes is reproducible with one command on
 your own hardware. This page defines exactly what each number measures —
 because in this market most published "cold start" figures do not measure
 a cold start — and hosts the dated results log. The analysis behind the
-numbers (backend asymmetry, boot anatomy, hibernate costs) lives in
+numbers (Cloud Hypervisor lifecycle, boot anatomy, hibernate costs) lives in
 [Performance](performance.md).
 
 ## The three claim tiers
@@ -27,6 +27,10 @@ The harness also reports **warm refill recovery**: after fully draining the
 warm pool it times the refill loop rebuilding to target — the number bounded
 by refill admission (`refill_concurrency`, see
 [Deployment](deploy.md)) rather than by a single restore.
+
+Cloud Hypervisor serves both lanes. Use `net=none` for no-NIC measurements,
+and record `no_direct_io` with results because it changes disk and fill
+behavior.
 
 When comparing against other systems, match tiers — not headlines:
 
@@ -235,4 +239,3 @@ answers long before a console login prompt would appear.
 |---|---|
 | exec RTT (dial per RPC) | n=200 p50=1.43ms p90=5.49ms p99=8.27ms |
 | fs_pull throughput (128 MiB) | 95.7 MiB/s best of 3 |
-

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -7,10 +7,8 @@ the cocoon CLI and needs a template image with silkd baked in.
 
 - Linux with KVM (`/dev/kvm`)
 - [cocoon](https://github.com/cocoonstack/cocoon) **v0.5.2 or newer** installed
-  and working (`cocoon vm run` boots a VM), with Cloud Hypervisor and/or
-  Firecracker. Older cocoon fails or degrades — **v0.5.0 silently breaks the
-  Firecracker clone-from-snapshot path** (warm-pool refill and fork), fixed in
-  v0.5.1, and v0.5.2 adds the parallel-clone and snapshot/store perf work the
+  and working (`cocoon vm run` boots a Cloud Hypervisor VM). v0.5.2 adds the
+  parallel-clone and snapshot/store performance work the
   [performance](performance.md) numbers assume. sandboxd logs a warning at
   startup when the detected cocoon is below v0.5.2 (a dev/`master-<sha>` build
   is assumed current)
@@ -28,6 +26,12 @@ artifact and the `base`/`rt`/`python` images are multi-arch manifests
 `make sandboxd` (produces `dist/sandboxd`); either way `sandboxd -version`
 reports what you are running.
 
+## Upgrading
+
+This CH-only release does not convert existing VM or snapshot state. Drain old
+claims and use fresh `data_dir` and `checkpoint_dir` locations when upgrading;
+older checkpoints and promoted templates must not be reused.
+
 ## Configuration
 
 sandboxd reads one JSON file (`-config`, default
@@ -38,6 +42,8 @@ sandboxd reads one JSON file (`-config`, default
   "listen": ":7777",
   "data_dir": "/var/lib/sandboxd",
   "cocoon_bin": "cocoon",
+  "restore_mode": "mmap",
+  "no_direct_io": true,
   "advertise_addr": "10.0.0.5:7777",
   "bridge": "br0",
   "api_token": "…",
@@ -59,6 +65,8 @@ sandboxd reads one JSON file (`-config`, default
 | `listen` | `:7777` | control- and data-plane HTTP listener |
 | `data_dir` | `/var/lib/sandboxd` | golden snapshot exports, the claims journal, the usage/audit journals (`usage.jsonl`, `audit.jsonl` + `.1` backups), and `checkpoints/` by default |
 | `cocoon_bin` | `cocoon` | cocoon CLI binary |
+| `restore_mode` | unset | clone memory restore mode: `copy`, `ondemand`, or `mmap`; use `mmap` for dense pools |
+| `no_direct_io` | false | use buffered writable disks for Cloud Hypervisor cold boots and clones; recommended for dense ephemeral pools to avoid direct-I/O CoW journal contention |
 | `advertise_addr` | = `listen` | the host:port clients reach this node at; returned as a claim's owner address and gossiped to peers. Must be routable when `listen` is a wildcard |
 | `bridge` / `network` | unset | egress-lane attachment: a host bridge device, or a CNI conflist name. Mutually exclusive; with neither set the node serves only the no-network lane. [Guarded egress](egress.md) needs the bridge form and rejects a CNI network at load |
 | `egress_ca` | unset | [HTTPS-interception](egress.md#https-interception) PKI: `root_cert` (the cluster root baked into intercepted guests; may bundle old+new roots during rotation) plus this node's `intermediate_cert`/`intermediate_key` from `sandboxd ca issue-intermediate`. Required when any pool rule sets `intercept` |
@@ -104,6 +112,8 @@ here validates on load:
   "data_dir": "/var/lib/sandboxd",
   "advertise_addr": "10.0.0.5:7777",
   "bridge": "br0",
+  "restore_mode": "mmap",
+  "no_direct_io": true,
 
   "api_token": "op-root-token",
   "tenants": [
@@ -159,6 +169,17 @@ Secret values come from the environment named by `value_env` (here
 `sandboxd ca` — see [Guarded egress](egress.md#https-interception). On a
 cluster, `api_token`, `tenants`, `preview_secret`, and `cluster_key` must
 match on every node.
+
+### High-density no-network pools
+
+Both lanes use Cloud Hypervisor; `net: "none"` launches it with no NIC. For
+dense ephemeral pools, set `restore_mode` to `mmap`, enable `no_direct_io`,
+place Cocoon's `run_dir` on a capacity-sized tmpfs, and set Cocoon's
+`cni_conf_dir` empty on none-only nodes to avoid per-VM network namespaces.
+The last setting also removes the VMM's network-namespace quarantine. On a
+384-core host, start with `refill_concurrency: 64`; higher values need
+measurement. Pause `cocoon daemon` or lengthen its reconcile interval during a
+mass fill.
 
 ### Auth model
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -65,7 +65,7 @@ sandboxd reads one JSON file (`-config`, default
 | `listen` | `:7777` | control- and data-plane HTTP listener |
 | `data_dir` | `/var/lib/sandboxd` | golden snapshot exports, the claims journal, the usage/audit journals (`usage.jsonl`, `audit.jsonl` + `.1` backups), and `checkpoints/` by default |
 | `cocoon_bin` | `cocoon` | cocoon CLI binary |
-| `restore_mode` | unset | clone memory restore mode: `copy`, `ondemand`, or `mmap`; use `mmap` for dense pools |
+| `restore_mode` | unset | clone and wake-restore memory mode: `copy`, `ondemand`, or `mmap`; use `mmap` for dense pools |
 | `no_direct_io` | false | use buffered writable disks for Cloud Hypervisor cold boots and clones; recommended for dense ephemeral pools to avoid direct-I/O CoW journal contention |
 | `advertise_addr` | = `listen` | the host:port clients reach this node at; returned as a claim's owner address and gossiped to peers. Must be routable when `listen` is a wildcard |
 | `bridge` / `network` | unset | egress-lane attachment: a host bridge device, or a CNI conflist name. Mutually exclusive; with neither set the node serves only the no-network lane. [Guarded egress](egress.md) needs the bridge form and rejects a CNI network at load |

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -6,7 +6,7 @@ lives host-side and enters no guest memory, so prompt injection can exfiltrate
 at most the proxy's answers, and every credentialed call lands in the audit and
 usage journals keyed by sandbox and tenant. Default-deny.
 
-The same host proxy also serves the **none lane** (a NIC-less Firecracker
+The same host proxy also serves the **none lane** (a NIC-less Cloud Hypervisor
 guest) over vsock, so a network-less sandbox can call approved APIs with
 injected credentials — no NIC required in the guest.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,15 +7,14 @@ milliseconds; cold boot is ~200ms on bare metal.
 
 ```
 SDK (Go)                sandboxd (per node)              guest microVM
-sandbox.New() ── HTTP ─► claim: warm pool / golden clone  CH (egress) | FC (none)
+sandbox.New() ── HTTP ─► claim: warm pool / golden clone  Cloud Hypervisor
 sb.Exec/Files/… ─ HTTP upgrade ─► byte relay ── vsock ──► silkd :2048
                         memberlist mesh: warm-count gossip,
                         MOVED-style redirect to the owning node
 ```
 
-Two network lanes, derived from the claim: `net=none` → Firecracker, no NIC,
-vsock-only (hardened default); `net=egress` → Cloud Hypervisor with a
-bridge/CNI NIC. Backends are never user-selected.
+Cloud Hypervisor serves both network lanes. `net=none` has no NIC and uses
+vsock-only I/O (hardened default); `net=egress` attaches a bridge/CNI NIC.
 
 ## Guides
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -82,12 +82,14 @@ nothing lost. Direct capture
 ([cocoonstack/cocoon#109](https://github.com/cocoonstack/cocoon/pull/109))
 fsyncs and renames the snapshot into the store instead of streaming it
 through a tar pass, cutting the CH pause window ~1.5×. Measured bare
-metal, `small` 1 G, cocoon `32bcbc6`, N=5:
+metal (16c/60G), `small` 512 M, cocoon `master-e9502f6`, CH dev `d77dcf12`,
+N=5:
 
 | op | latency | notes |
 |---|---|---|
-| `vm hibernate` | ~345–365 ms | pause → snapshot → fsync + rename into the store → VMM killed; memory freed, snapshot point and stop coincide |
-| `vm restore` (stopped VM) | ~97–103 ms | machine identity preserved, tmpfs contents intact, in-guest daemons resume |
+| `vm hibernate` | ~170–270 ms | pause → snapshot → persist into the store → VMM killed; memory freed, snapshot point and stop coincide |
+| `vm restore` (stopped VM, eager) | ~55–190 ms (median ~65) | machine identity preserved, tmpfs contents intact, in-guest daemons resume |
+| `vm restore` (stopped VM, `restore_mode: mmap`) | ~40–67 ms (median ~55) | the node's `restore_mode` rides sandboxd wakes too; the wake drops its snapshot right after — safe, restore stages a private copy |
 
 ## Method notes
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -23,17 +23,17 @@ bare metal, `small` tier:
 | pool miss, golden exists | **~45–75 ms** | clone from the golden snapshot + entropy/machine-id reseed + readiness probe |
 | cold boot (no golden yet) | **~200–350 ms** | full boot from the template image to silkd answering |
 
-Backend cold-boot vs restore asymmetry (bare metal, vsock agent-ready):
+Cloud Hypervisor lifecycle latency (bare metal, vsock agent-ready):
 
-| path | Cloud Hypervisor | Firecracker |
-|---|---|---|
-| cold boot | ~230 ms | ~330 ms |
-| clone from golden (eager) | ~44 ms | ~28 ms |
+| path | latency |
+|---|---|
+| cold boot | ~230 ms |
+| clone from golden (eager) | ~44 ms |
 
-CH wins cold (block I/O), FC wins restore — which is why the no-network
-lane (FC) is also the fastest-restore lane. Eager memory restore beats
-UFFD on-demand for sandbox-sized VMs in every configuration measured
-(the working set is small and mostly touched during readiness).
+Both network lanes use Cloud Hypervisor; `net=none` only removes the NIC.
+Eager memory restore beats UFFD on-demand for sandbox-sized VMs in every
+configuration measured (the working set is small and mostly touched during
+readiness).
 
 Burst degradation under concurrent restores is real, and warm pools exist
 to absorb it — they move provisioning off the request path entirely.
@@ -71,7 +71,7 @@ parallel at sysinit and adds ~1–10 ms cold / ~3–12 ms on restore paths.
 
 > The `vm hibernate` / `vm restore` rows below were measured with cocoon's
 > own tooling on the same hardware; they are not reproducible from this
-> repository alone. The SDK row is smoke-measured in-repo.
+> repository alone.
 
 cocoon's atomic hibernate
 ([cocoonstack/cocoon#87](https://github.com/cocoonstack/cocoon/pull/87))
@@ -86,9 +86,8 @@ metal, `small` 1 G, cocoon `32bcbc6`, N=5:
 
 | op | latency | notes |
 |---|---|---|
-| `vm hibernate` | ~345–365 ms CH / ~475–505 ms FC | pause → snapshot → fsync + rename into the store → VMM killed; memory freed, snapshot point and stop coincide |
-| `vm restore` (stopped VM) | ~97–103 ms CH / ~18–20 ms FC | machine identity preserved, tmpfs contents intact, in-guest daemons resume; FC wins restore, consistent with the clone asymmetry |
-| SDK hibernate → wake loop | ~315 ms | `sb.Hibernate()` + transparent wake on the next exec, through the relay (FC none lane); a live shell session survives with its state intact (smoke-measured) |
+| `vm hibernate` | ~345–365 ms | pause → snapshot → fsync + rename into the store → VMM killed; memory freed, snapshot point and stop coincide |
+| `vm restore` (stopped VM) | ~97–103 ms | machine identity preserved, tmpfs contents intact, in-guest daemons resume |
 
 ## Method notes
 

--- a/docs/sdk-python.md
+++ b/docs/sdk-python.md
@@ -91,7 +91,7 @@ sb = client.new("ghcr.io/cocoonstack/sandbox/rt:24.04",
 
 | parameter | values | default | meaning |
 |---|---|---|---|
-| `net` | `"none"`, `"egress"` | `"none"` | `none`: no NIC at all, vsock-only I/O (hardened lane, Firecracker). `egress`: bridge/CNI NIC (Cloud Hypervisor) |
+| `net` | `"none"`, `"egress"` | `"none"` | Cloud Hypervisor network shape: `none` disables the NIC and uses vsock-only I/O; `egress` attaches a bridge/CNI NIC |
 | `size` | `"small"`, `"medium"`, `"large"`, `"xlarge"` | `"small"` | resource tier: 1cpu/512M, 2cpu/1G, 4cpu/4G, 4cpu/8G |
 | `ttl_seconds` | int | server default 5m | sandbox TTL, server-capped at 24h. The node reaps the sandbox after the TTL even if the client vanishes |
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -137,7 +137,7 @@ defer sb.Close()
 
 | option | values | default | meaning |
 |---|---|---|---|
-| `WithNetwork(n)` | `NetNone`, `NetEgress` | `NetNone` | `NetNone`: no NIC at all, vsock-only I/O (hardened lane, Firecracker). `NetEgress`: bridge/CNI NIC (Cloud Hypervisor) |
+| `WithNetwork(n)` | `NetNone`, `NetEgress` | `NetNone` | Cloud Hypervisor network shape: `NetNone` disables the NIC and uses vsock-only I/O; `NetEgress` attaches a bridge/CNI NIC |
 | `WithSize(s)` | `Small`, `Medium`, `Large`, `XLarge` | `Small` | resource tier: 1cpu/512M, 2cpu/1G, 4cpu/4G, 4cpu/8G |
 | `WithTimeout(d)` | duration | server default 5m | sandbox TTL, rounded up to seconds, server-capped at 24h. The node reaps the sandbox after the TTL even if the client vanishes |
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -86,7 +86,7 @@ surfaces answer tenants 403.
 Facts to plan around, stated so the boundary is honest:
 
 - **The VMM processes are not additionally sandboxed.** cloud-hypervisor
-  and firecracker run as ordinary host processes under cocoon; a VMM
+  runs as an ordinary host process under cocoon; a VMM
   escape lands on the host with the VMM's privileges (upstream:
   cocoonstack/cocoon#83). Compensate with dedicated sandbox nodes and a
   minimal host.

--- a/e2e/cmd/androidsmoke/main.go
+++ b/e2e/cmd/androidsmoke/main.go
@@ -1,4 +1,4 @@
-// androidsmoke is the android-flavor acceptance: claim (egress/xlarge) → Android
+// androidsmoke is the android-flavor acceptance: claim (none/xlarge) → Android
 // init tree over the relay → adb CNXN handshake on the adb port →
 // checkpoint/branch of the booted guest. No session step: the guest
 // ships no bash.
@@ -51,7 +51,7 @@ func run(addr, token, template string) error {
 
 	start := time.Now()
 	sb, err := client.New(ctx, template,
-		sandbox.WithNetwork(sandbox.NetEgress), sandbox.WithSize(sandbox.XLarge),
+		sandbox.WithNetwork(sandbox.NetNone), sandbox.WithSize(sandbox.XLarge),
 		sandbox.WithTimeout(30*time.Minute))
 	if err != nil {
 		return fmt.Errorf("claim: %w", err)

--- a/e2e/fakeengine_test.go
+++ b/e2e/fakeengine_test.go
@@ -31,7 +31,7 @@ type fakeEngine struct {
 
 func newFakeEngine(dir string) *fakeEngine {
 	return &fakeEngine{
-		real:      engine.New("cocoon", "", "", ""),
+		real:      engine.New("cocoon", "", "", false, ""),
 		dir:       dir,
 		listeners: map[string]io.Closer{},
 		socks:     map[string]string{},

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -103,11 +104,7 @@ func toolCreateSandbox(ctx context.Context, s *server, raw json.RawMessage) (str
 	if args.TTLSeconds > 0 {
 		opts = append(opts, sandbox.WithTimeout(time.Duration(args.TTLSeconds)*time.Second))
 	}
-	template := args.Template
-	if template == "" {
-		template = s.template
-	}
-	sb, err := s.client.New(ctx, template, opts...)
+	sb, err := s.client.New(ctx, cmp.Or(args.Template, s.template), opts...)
 	if err != nil {
 		return "", err
 	}

--- a/os-image/android/README.md
+++ b/os-image/android/README.md
@@ -5,7 +5,7 @@ redroid image (`ghcr.io/cocoonstack/cocoon/android:15.0`, upstream
 redroid 15 rootfs + cocoon boot chain, built from `cocoon/os-image/android/`)
 plus silkd, claimable like any other template. Remote access is adb on
 port 5555 — no VNC in this lineage. The intended pool shape is
-`size: xlarge` (4 CPU / 8G).
+`net: none`, `size: xlarge` (4 CPU / 8G).
 
 ## Build
 
@@ -24,8 +24,8 @@ The base image (15.0) pulls anonymously from ghcr at docker and
 (`/boot/vmlinuz-6.8.*-generic` + initrd, `binder_linux.ko`) booted via
 `/sbin/init` busybox wrapper → Android `/init`; runs `cocoon-agent` from
 `/system/etc/init/cocoon-agent.rc`; boots the full framework to
-`sys.boot_completed=1` with zygote64 + system_server alive (CH egress
-lane, 4 CPU / 8G).
+`sys.boot_completed=1` with zygote64 + system_server alive (Cloud Hypervisor,
+no NIC, 4 CPU / 8G).
 
 Do not revert to the previous `ghcr.io/jiaqing-simular/cocoon-android-vnc`
 pin: that build ships a broken dexpreopt boot-image chain that
@@ -35,9 +35,8 @@ crash-loops zygote before the framework ever completes.
 
 - **Boot chain**: the image boots its embedded 6.8 kernel via Android
   `/init`, not the sandbox boot chain (PVH kernel + overlay-root init).
-  The claim lane must be CH/egress — the FC no-network lane fails the
-  readiness probe. Snapshot/restore of a booted Android is covered by the
-  `androidsmoke` acceptance round.
+  Use Cloud Hypervisor with `net: none`; snapshot/restore of a booted Android
+  is covered by the `androidsmoke` acceptance round.
 - **silkd on Android**: the musl-static binary runs against an Android
   userspace (`/system/bin/sh`, no `/bin/sh`); exec/session behavior is
   covered by the `androidsmoke` acceptance round.

--- a/sandboxd/config/config.go
+++ b/sandboxd/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"cmp"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -298,31 +299,19 @@ func (c *Config) guardsEgressLane() bool {
 }
 
 func (c *Config) applyDefaults() {
-	if c.Listen == "" {
-		c.Listen = defaultListen
-	}
-	if c.DataDir == "" {
-		c.DataDir = defaultDataDir
-	}
-	if c.CocoonBin == "" {
-		c.CocoonBin = defaultCocoonBin
-	}
-	if c.AdvertiseAddr == "" {
-		c.AdvertiseAddr = c.Listen
-	}
+	c.Listen = cmp.Or(c.Listen, defaultListen)
+	c.DataDir = cmp.Or(c.DataDir, defaultDataDir)
+	c.CocoonBin = cmp.Or(c.CocoonBin, defaultCocoonBin)
+	c.AdvertiseAddr = cmp.Or(c.AdvertiseAddr, c.Listen)
 	if c.PreviewListen != "" && c.PreviewAdvertise == "" {
 		c.PreviewAdvertise = c.PreviewListen
 	}
-	if c.MaxForkCount == 0 {
-		c.MaxForkCount = defaultMaxForkCount
-	}
+	c.MaxForkCount = cmp.Or(c.MaxForkCount, defaultMaxForkCount)
 	if c.RefillConcurrency == 0 {
 		c.RefillConcurrency = min(max(refillFloor, runtime.NumCPU()/16), refillCeiling)
 	}
 	for i := range c.Pools {
-		if c.Pools[i].Warm == 0 {
-			c.Pools[i].Warm = defaultWarm
-		}
+		c.Pools[i].Warm = cmp.Or(c.Pools[i].Warm, defaultWarm)
 	}
 }
 

--- a/sandboxd/config/config.go
+++ b/sandboxd/config/config.go
@@ -174,7 +174,7 @@ type Config struct {
 	Bridge  string `json:"bridge,omitempty"`
 	Network string `json:"network,omitempty"`
 
-	// RestoreMode rides clones as cocoon's --restore-mode. Opt-in: mmap
+	// RestoreMode rides clones and wake restores as cocoon's --restore-mode. Opt-in: mmap
 	// needs every node's cloud-hypervisor to carry CoW restore — an older CH
 	// silently eager-copies while reporting success.
 	RestoreMode types.RestoreMode `json:"restore_mode,omitempty"`

--- a/sandboxd/config/config.go
+++ b/sandboxd/config/config.go
@@ -174,10 +174,13 @@ type Config struct {
 	Bridge  string `json:"bridge,omitempty"`
 	Network string `json:"network,omitempty"`
 
-	// RestoreMode rides CH-lane clones as cocoon's --restore-mode. Opt-in: mmap
+	// RestoreMode rides clones as cocoon's --restore-mode. Opt-in: mmap
 	// needs every node's cloud-hypervisor to carry CoW restore — an older CH
 	// silently eager-copies while reporting success.
 	RestoreMode types.RestoreMode `json:"restore_mode,omitempty"`
+
+	// NoDirectIO enables buffered writable disks for cold boots and clones.
+	NoDirectIO bool `json:"no_direct_io,omitempty"`
 
 	// APIToken, when set, guards claim and info; per-sandbox tokens guard
 	// sandbox-scoped calls regardless.

--- a/sandboxd/config/config_test.go
+++ b/sandboxd/config/config_test.go
@@ -52,6 +52,9 @@ func TestLoadAppliesDefaults(t *testing.T) {
 	if cfg.RefillConcurrency < 1 {
 		t.Errorf("refill_concurrency default missing: %d", cfg.RefillConcurrency)
 	}
+	if cfg.NoDirectIO {
+		t.Error("no_direct_io defaulted on; want existing direct-I/O behavior")
+	}
 	if cfg.Pools[0].Warm < 1 {
 		t.Errorf("pool warm default missing: %d", cfg.Pools[0].Warm)
 	}
@@ -198,12 +201,12 @@ func TestHasEgress(t *testing.T) {
 
 func TestLoadKeepsExplicitValues(t *testing.T) {
 	path := writeConfig(t, `{"listen":"0.0.0.0:9999","advertise_addr":"10.0.0.5:9999","max_fork_count":4,
-		"refill_concurrency":8,"bridge":"br0","pools":[{"template":"rt:24.04","net":"egress","size":"small","warm":3}]}`)
+		"refill_concurrency":8,"no_direct_io":true,"bridge":"br0","pools":[{"template":"rt:24.04","net":"egress","size":"small","warm":3}]}`)
 	cfg, err := Load(path)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if cfg.AdvertiseAddr != "10.0.0.5:9999" || cfg.MaxForkCount != 4 || cfg.RefillConcurrency != 8 || cfg.Pools[0].Warm != 3 {
+	if cfg.AdvertiseAddr != "10.0.0.5:9999" || cfg.MaxForkCount != 4 || cfg.RefillConcurrency != 8 || !cfg.NoDirectIO || cfg.Pools[0].Warm != 3 {
 		t.Errorf("explicit values overridden: %+v", cfg)
 	}
 	if cfg.Pools[0].Net != types.NetEgress {

--- a/sandboxd/egress/ca.go
+++ b/sandboxd/egress/ca.go
@@ -1,6 +1,7 @@
 package egress
 
 import (
+	"cmp"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -162,9 +163,7 @@ func parseRootBundle(pemBytes []byte) (*x509.Certificate, error) {
 		if !cert.IsCA {
 			return nil, fmt.Errorf("root bundle: %q is not a certificate authority", cert.Subject.CommonName)
 		}
-		if anchor == nil {
-			anchor = cert
-		}
+		anchor = cmp.Or(anchor, cert)
 	}
 	if anchor == nil {
 		return nil, fmt.Errorf("root cert: no pem block")

--- a/sandboxd/engine/cloneargs_test.go
+++ b/sandboxd/engine/cloneargs_test.go
@@ -47,10 +47,7 @@ func TestLifecycleArgsApplyDirectIOPolicy(t *testing.T) {
 		t.Run(strconv.FormatBool(noDirectIO), func(t *testing.T) {
 			e := New("cocoon", "", "", noDirectIO, "")
 			want := "--no-direct-io=" + strconv.FormatBool(noDirectIO)
-			cold, err := e.runColdArgs("sbx-1", key)
-			if err != nil {
-				t.Fatalf("runColdArgs: %v", err)
-			}
+			cold := e.runColdArgs("sbx-1", key)
 			for _, args := range [][]string{
 				cold,
 				e.cloneArgs("/goldens/g1", "sbx-1", key),

--- a/sandboxd/engine/cloneargs_test.go
+++ b/sandboxd/engine/cloneargs_test.go
@@ -2,27 +2,28 @@ package engine
 
 import (
 	"slices"
+	"strconv"
 	"testing"
 
 	"github.com/cocoonstack/sandbox/sandboxd/types"
 )
 
 func TestCloneArgsRestoreMode(t *testing.T) {
-	chKey := types.PoolKey{Template: "rt:24.04", Net: types.NetEgress, Size: types.SizeMedium}
-	fcKey := types.PoolKey{Template: "rt:24.04", Net: types.NetNone, Size: types.SizeMedium}
+	noneKey := types.PoolKey{Template: "rt:24.04", Net: types.NetNone, Size: types.SizeMedium}
+	egressKey := types.PoolKey{Template: "rt:24.04", Net: types.NetEgress, Size: types.SizeMedium}
 	cases := []struct {
 		name string
 		mode types.RestoreMode
 		key  types.PoolKey
 		want bool
 	}{
-		{"ch lane carries the flag", types.RestoreMmap, chKey, true},
-		{"fc lane never carries it", types.RestoreMmap, fcKey, false},
-		{"unset mode adds nothing", "", chKey, false},
+		{"none lane carries the flag", types.RestoreMmap, noneKey, true},
+		{"egress lane carries the flag", types.RestoreMmap, egressKey, true},
+		{"unset mode adds nothing", "", noneKey, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			e := New("cocoon", "br0", "", tc.mode)
+			e := New("cocoon", "br0", "", false, tc.mode)
 			for _, args := range [][]string{
 				e.cloneArgs("/goldens/g1", "sbx-1", tc.key),
 				e.cloneSnapArgs("ck_1", "sbx-1", tc.key),
@@ -34,6 +35,32 @@ func TestCloneArgsRestoreMode(t *testing.T) {
 				if tc.want && args[i+1] != string(tc.mode) {
 					t.Fatalf("args %v: mode %q, want %q", args, args[i+1], tc.mode)
 				}
+			}
+		})
+	}
+}
+
+func TestLifecycleArgsApplyDirectIOPolicy(t *testing.T) {
+	key := types.PoolKey{Template: "rt:24.04", Net: types.NetNone, Size: types.SizeMedium}
+	for _, noDirectIO := range []bool{false, true} {
+		t.Run(strconv.FormatBool(noDirectIO), func(t *testing.T) {
+			e := New("cocoon", "", "", noDirectIO, "")
+			want := "--no-direct-io=" + strconv.FormatBool(noDirectIO)
+			cold, err := e.runColdArgs("sbx-1", key)
+			if err != nil {
+				t.Fatalf("runColdArgs: %v", err)
+			}
+			for _, args := range [][]string{
+				cold,
+				e.cloneArgs("/goldens/g1", "sbx-1", key),
+				e.cloneSnapArgs("ck_1", "sbx-1", key),
+			} {
+				if !slices.Contains(args, want) {
+					t.Errorf("args %v missing %q", args, want)
+				}
+			}
+			if !slices.Contains(cold, "--nics") || !slices.Contains(cold, "0") {
+				t.Errorf("none-lane cold args %v missing --nics 0", cold)
 			}
 		})
 	}

--- a/sandboxd/engine/cloneargs_test.go
+++ b/sandboxd/engine/cloneargs_test.go
@@ -27,6 +27,7 @@ func TestCloneArgsRestoreMode(t *testing.T) {
 			for _, args := range [][]string{
 				e.cloneArgs("/goldens/g1", "sbx-1", tc.key),
 				e.cloneSnapArgs("ck_1", "sbx-1", tc.key),
+				e.restoreCmdArgs("sbx-1", "sbx-hib-1"),
 			} {
 				i := slices.Index(args, "--restore-mode")
 				if got := i >= 0; got != tc.want {

--- a/sandboxd/engine/engine.go
+++ b/sandboxd/engine/engine.go
@@ -147,7 +147,7 @@ func (e *Engine) Hibernate(ctx context.Context, vmName, snapName string) error {
 // Restore resumes a VM from a snapshot with its memory state and identity
 // intact (cocoon reseeds entropy only on restore), returning its vsock UDS.
 func (e *Engine) Restore(ctx context.Context, vmName, snapRef string) (string, error) {
-	out, err := e.run(ctx, "vm", "restore", argOutput, formatJSON, vmName, snapRef)
+	out, err := e.run(ctx, e.restoreCmdArgs(vmName, snapRef)...)
 	if err != nil {
 		return "", err
 	}
@@ -306,6 +306,11 @@ func (e *Engine) cloneSnapArgs(snap, name string, key types.PoolKey) []string {
 	args := []string{"vm", "clone", snap, argName, name, "--pull", argOutput, formatJSON, e.directIOArg()}
 	args = append(args, e.restoreArgs()...)
 	return append(args, e.netArgs(key, false)...)
+}
+
+func (e *Engine) restoreCmdArgs(vmName, snapRef string) []string {
+	args := append([]string{"vm", "restore", argOutput, formatJSON}, e.restoreArgs()...)
+	return append(args, vmName, snapRef)
 }
 
 func (e *Engine) directIOArg() string {

--- a/sandboxd/engine/engine.go
+++ b/sandboxd/engine/engine.go
@@ -28,10 +28,12 @@ import (
 )
 
 const (
-	// RequiredCocoon is the minimum supported cocoon release: v0.5.0 breaks FC
-	// clone-from-snapshot; v0.5.2 carries the perf work the latency numbers assume.
+	// RequiredCocoon carries the snapshot/store performance baseline.
 	RequiredCocoon = "v0.5.2"
 
+	argName       = "--name"
+	argOutput     = "--output"
+	formatJSON    = "json"
 	silkdPort     = 2048 // silkd's fixed guest vsock port, the claim-ready anchor
 	egressPort    = 2049 // guest→host egress port; VMM maps it to <vsock_socket>_2049
 	cmdTimeout    = 2 * time.Minute
@@ -50,13 +52,13 @@ type Engine struct {
 	bin         string
 	bridge      string
 	network     string
+	noDirectIO  bool
 	restoreMode types.RestoreMode
 }
 
-// New returns an Engine invoking bin; bridge or network picks the
-// egress-lane attachment, restoreMode the CH clone memory-restore mode.
-func New(bin, bridge, network string, restoreMode types.RestoreMode) *Engine {
-	return &Engine{bin: bin, bridge: bridge, network: network, restoreMode: restoreMode}
+// New returns a cocoon engine with node-wide network and disk policy.
+func New(bin, bridge, network string, noDirectIO bool, restoreMode types.RestoreMode) *Engine {
+	return &Engine{bin: bin, bridge: bridge, network: network, noDirectIO: noDirectIO, restoreMode: restoreMode}
 }
 
 // Version reports cocoon's version string — a "vX.Y.Z" release or a
@@ -85,16 +87,12 @@ func (e *Engine) VersionWarning(ctx context.Context) (version, warning string) {
 		return "", fmt.Sprintf("cannot determine cocoon version (need >= %s): %v", RequiredCocoon, err)
 	}
 	if below, comparable := belowFloor(v); comparable && below {
-		return v, fmt.Sprintf("cocoon %s is below the required %s: v0.5.0 breaks FC clone/fork — upgrade cocoon", v, RequiredCocoon)
+		return v, fmt.Sprintf("cocoon %s is below the required %s — upgrade cocoon", v, RequiredCocoon)
 	}
 	return v, ""
 }
 
-// Clone restores a VM from an exported golden directory, returning its
-// lifecycle record (vsock UDS, NIC tap). The no-network lane passes no net
-// flags at all — the golden has no NIC to retarget, the only clone shape FC
-// supports; the egress lane re-attaches to the node's bridge or CNI network.
-// cocoon signals the in-guest reseed itself after resume.
+// Clone restores a VM from an exported golden directory.
 func (e *Engine) Clone(ctx context.Context, fromDir, name string, key types.PoolKey) (types.VMRecord, error) {
 	out, err := e.run(ctx, e.cloneArgs(fromDir, name, key)...)
 	if err != nil {
@@ -127,8 +125,7 @@ func (e *Engine) RunCold(ctx context.Context, name string, key types.PoolKey) (t
 	return parseRecord(ctx, out), nil
 }
 
-// Remove force-deletes a VM; `rm --force` skips the graceful stop window
-// (FC guests without i8042 never answer it), so one call is authoritative.
+// Remove force-deletes a VM.
 func (e *Engine) Remove(ctx context.Context, name string) error {
 	_, err := e.run(ctx, "vm", "rm", "--force", name)
 	return err
@@ -136,21 +133,21 @@ func (e *Engine) Remove(ctx context.Context, name string) error {
 
 // SnapshotSave snapshots a running VM under snapName.
 func (e *Engine) SnapshotSave(ctx context.Context, vmName, snapName string) error {
-	_, err := e.run(ctx, "snapshot", "save", "--name", snapName, vmName)
+	_, err := e.run(ctx, "snapshot", "save", argName, snapName, vmName)
 	return err
 }
 
 // Hibernate atomically snapshots a running VM under snapName and stops it,
 // freeing its memory; Restore with the snapshot resumes it.
 func (e *Engine) Hibernate(ctx context.Context, vmName, snapName string) error {
-	_, err := e.run(ctx, "vm", "hibernate", "--name", snapName, vmName)
+	_, err := e.run(ctx, "vm", "hibernate", argName, snapName, vmName)
 	return err
 }
 
 // Restore resumes a VM from a snapshot with its memory state and identity
 // intact (cocoon reseeds entropy only on restore), returning its vsock UDS.
 func (e *Engine) Restore(ctx context.Context, vmName, snapRef string) (string, error) {
-	out, err := e.run(ctx, "vm", "restore", "--output", "json", vmName, snapRef)
+	out, err := e.run(ctx, "vm", "restore", argOutput, formatJSON, vmName, snapRef)
 	if err != nil {
 		return "", err
 	}
@@ -172,7 +169,7 @@ func (e *Engine) SnapshotRemove(ctx context.Context, snapName string) error {
 
 // SnapshotList returns the names of all snapshots in cocoon's local DB.
 func (e *Engine) SnapshotList(ctx context.Context) ([]string, error) {
-	out, err := e.run(ctx, "snapshot", "list", "--format", "json")
+	out, err := e.run(ctx, "snapshot", "list", "--format", formatJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +195,7 @@ func (e *Engine) SnapshotList(ctx context.Context) ([]string, error) {
 
 // List returns cocoon's view of local VMs, optionally filtered by name.
 func (e *Engine) List(ctx context.Context, filters ...string) ([]types.VMRecord, error) {
-	args := append([]string{"vm", "list", "--format", "json"}, filters...)
+	args := append([]string{"vm", "list", "--format", formatJSON}, filters...)
 	out, err := e.run(ctx, args...)
 	if err != nil {
 		return nil, err
@@ -300,20 +297,23 @@ func (e *Engine) cloneArgs(fromDir, name string, key types.PoolKey) []string {
 	// --pull: a checkpoint/template export carries only COW + memory; on a
 	// cross-node claim the base image blobs resolve locally or are pulled
 	// by digest.
-	args := []string{"vm", "clone", "--from-dir", fromDir, "--name", name, "--pull", "--output", "json"}
-	args = append(args, e.restoreArgs(key)...)
+	args := []string{"vm", "clone", "--from-dir", fromDir, argName, name, "--pull", argOutput, formatJSON, e.directIOArg()}
+	args = append(args, e.restoreArgs()...)
 	return append(args, e.netArgs(key, false)...)
 }
 
 func (e *Engine) cloneSnapArgs(snap, name string, key types.PoolKey) []string {
-	args := []string{"vm", "clone", snap, "--name", name, "--pull", "--output", "json"}
-	args = append(args, e.restoreArgs(key)...)
+	args := []string{"vm", "clone", snap, argName, name, "--pull", argOutput, formatJSON, e.directIOArg()}
+	args = append(args, e.restoreArgs()...)
 	return append(args, e.netArgs(key, false)...)
 }
 
-func (e *Engine) restoreArgs(key types.PoolKey) []string {
-	// cocoon's --restore-mode is CH-only; the FC File backend already maps lazily.
-	if e.restoreMode == "" || key.Backend() == types.BackendFC {
+func (e *Engine) directIOArg() string {
+	return "--no-direct-io=" + strconv.FormatBool(e.noDirectIO)
+}
+
+func (e *Engine) restoreArgs() []string {
+	if e.restoreMode == "" {
 		return nil
 	}
 	return []string{"--restore-mode", string(e.restoreMode)}
@@ -324,10 +324,7 @@ func (e *Engine) runColdArgs(name string, key types.PoolKey) ([]string, error) {
 	if !ok {
 		return nil, fmt.Errorf("unknown size %q", key.Size)
 	}
-	args := []string{"vm", "run", "--name", name, "--output", "json", "--cpu", strconv.Itoa(spec.CPU), "--memory", spec.Memory}
-	if key.Backend() == types.BackendFC {
-		args = append(args, "--fc")
-	}
+	args := []string{"vm", "run", argName, name, argOutput, formatJSON, "--cpu", strconv.Itoa(spec.CPU), "--memory", spec.Memory, e.directIOArg()}
 	args = append(args, e.netArgs(key, true)...)
 	return append(args, key.Template), nil
 }

--- a/sandboxd/engine/engine.go
+++ b/sandboxd/engine/engine.go
@@ -114,11 +114,7 @@ func (e *Engine) CloneSnap(ctx context.Context, snap, name string, key types.Poo
 // RunCold boots a VM from the template image (golden builds and cache-miss
 // claims), returning its lifecycle record.
 func (e *Engine) RunCold(ctx context.Context, name string, key types.PoolKey) (types.VMRecord, error) {
-	args, err := e.runColdArgs(name, key)
-	if err != nil {
-		return types.VMRecord{}, err
-	}
-	out, err := e.run(ctx, args...)
+	out, err := e.run(ctx, e.runColdArgs(name, key)...)
 	if err != nil {
 		return types.VMRecord{}, err
 	}
@@ -324,14 +320,11 @@ func (e *Engine) restoreArgs() []string {
 	return []string{"--restore-mode", string(e.restoreMode)}
 }
 
-func (e *Engine) runColdArgs(name string, key types.PoolKey) ([]string, error) {
-	spec, ok := key.Size.Spec()
-	if !ok {
-		return nil, fmt.Errorf("unknown size %q", key.Size)
-	}
+func (e *Engine) runColdArgs(name string, key types.PoolKey) []string {
+	spec, _ := key.Size.Spec()
 	args := []string{"vm", "run", argName, name, argOutput, formatJSON, "--cpu", strconv.Itoa(spec.CPU), "--memory", spec.Memory, e.directIOArg()}
 	args = append(args, e.netArgs(key, true)...)
-	return append(args, key.Template), nil
+	return append(args, key.Template)
 }
 
 func (e *Engine) netArgs(key types.PoolKey, cold bool) []string {

--- a/sandboxd/engine/engine_test.go
+++ b/sandboxd/engine/engine_test.go
@@ -24,7 +24,7 @@ func TestDialSilkdConsumesOnlyHandshake(t *testing.T) {
 	// over-reads past the newline, the first Read below loses it.
 	listenMuxer(t, path, "OK 2048\nX")
 
-	conn, err := New("cocoon", "", "", "").DialSilkd(t.Context(), path)
+	conn, err := New("cocoon", "", "", false, "").DialSilkd(t.Context(), path)
 	if err != nil {
 		t.Fatalf("DialSilkd: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestDialSilkdRejectedHandshake(t *testing.T) {
 	path := sockPath(t)
 	listenMuxer(t, path, "ERR no guest listener\n")
 
-	_, err := New("cocoon", "", "", "").DialSilkd(t.Context(), path)
+	_, err := New("cocoon", "", "", false, "").DialSilkd(t.Context(), path)
 	if err == nil || !strings.Contains(err.Error(), "no guest listener") {
 		t.Errorf("got %v, want handshake rejection", err)
 	}
@@ -52,7 +52,7 @@ func TestProbeSucceeds(t *testing.T) {
 	path := sockPath(t)
 	listenMuxer(t, path, "OK 2048\n", infoFrame)
 
-	if err := New("cocoon", "", "", "").Probe(t.Context(), path, 2*time.Second); err != nil {
+	if err := New("cocoon", "", "", false, "").Probe(t.Context(), path, 2*time.Second); err != nil {
 		t.Errorf("Probe: %v", err)
 	}
 }
@@ -61,7 +61,7 @@ func TestInfoRoundTripRejectsErrorFrame(t *testing.T) {
 	path := sockPath(t)
 	listenMuxer(t, path, "OK 2048\n", errFrame)
 
-	err := New("cocoon", "", "", "").infoRoundTrip(t.Context(), path)
+	err := New("cocoon", "", "", false, "").infoRoundTrip(t.Context(), path)
 	if err == nil || !strings.Contains(err.Error(), `info reply type "error"`) {
 		t.Errorf("got %v, want error-frame rejection", err)
 	}
@@ -71,7 +71,7 @@ func TestProbeRetriesPastFailures(t *testing.T) {
 	path := sockPath(t)
 	listenMuxer(t, path, "OK 2048\n", errFrame, errFrame, infoFrame)
 
-	if err := New("cocoon", "", "", "").Probe(t.Context(), path, 2*time.Second); err != nil {
+	if err := New("cocoon", "", "", false, "").Probe(t.Context(), path, 2*time.Second); err != nil {
 		t.Errorf("Probe: %v", err)
 	}
 }
@@ -80,7 +80,7 @@ func TestProbeRetriesUntilListenerAppears(t *testing.T) {
 	path := sockPath(t)
 	done := make(chan error, 1)
 	go func() {
-		done <- New("cocoon", "", "", "").Probe(t.Context(), path, 2*time.Second)
+		done <- New("cocoon", "", "", false, "").Probe(t.Context(), path, 2*time.Second)
 	}()
 
 	time.Sleep(60 * time.Millisecond)
@@ -118,7 +118,7 @@ func TestDialGuestPortCtxCancel(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
 	defer cancel()
-	if _, err := New("cocoon", "", "", "").DialGuestPort(ctx, path, 8080); !errors.Is(err, context.DeadlineExceeded) {
+	if _, err := New("cocoon", "", "", false, "").DialGuestPort(ctx, path, 8080); !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("got %v, want context.DeadlineExceeded", err)
 	}
 }
@@ -126,13 +126,13 @@ func TestDialGuestPortCtxCancel(t *testing.T) {
 func TestProbeTimeout(t *testing.T) {
 	path := sockPath(t)
 
-	err := New("cocoon", "", "", "").Probe(t.Context(), path, 150*time.Millisecond)
+	err := New("cocoon", "", "", false, "").Probe(t.Context(), path, 150*time.Millisecond)
 	if err == nil || !strings.Contains(err.Error(), "silkd probe") {
 		t.Errorf("got %v, want probe timeout", err)
 	}
 }
 
-// listenMuxer fakes the CH/FC hybrid-vsock muxer on a UDS: per connection it
+// listenMuxer fakes the hybrid-vsock muxer on a UDS: per connection it
 // consumes the CONNECT line, replies with handshake, then answers the first
 // frame line of connection i with frames[i] (last frame repeats; no frames
 // means handshake only).

--- a/sandboxd/engine/installca_test.go
+++ b/sandboxd/engine/installca_test.go
@@ -121,7 +121,7 @@ func (f *fakeSilkd) handleExec(conn net.Conn, argv []string, env map[string]stri
 func TestInstallCACertWritesCertAndUpdates(t *testing.T) {
 	path := sockPath(t)
 	fake := serveFakeSilkd(t, path)
-	if err := New("cocoon", "", "", "").InstallCACert(t.Context(), path, []byte("CERT-PEM")); err != nil {
+	if err := New("cocoon", "", "", false, "").InstallCACert(t.Context(), path, []byte("CERT-PEM")); err != nil {
 		t.Fatalf("InstallCACert: %v", err)
 	}
 	fake.mu.Lock()
@@ -151,7 +151,7 @@ func TestInstallCACertNonzeroExitFails(t *testing.T) {
 	path := sockPath(t)
 	fake := serveFakeSilkd(t, path)
 	fake.execCode = 3
-	err := New("cocoon", "", "", "").InstallCACert(t.Context(), path, []byte("x"))
+	err := New("cocoon", "", "", false, "").InstallCACert(t.Context(), path, []byte("x"))
 	if err == nil || !strings.Contains(err.Error(), "exit code 3") {
 		t.Errorf("got %v, want exit code 3 failure", err)
 	}
@@ -161,7 +161,7 @@ func TestInstallCACertWriteErrorFrameFails(t *testing.T) {
 	path := sockPath(t)
 	fake := serveFakeSilkd(t, path)
 	fake.writeErr = "disk full"
-	err := New("cocoon", "", "", "").InstallCACert(t.Context(), path, []byte("x"))
+	err := New("cocoon", "", "", false, "").InstallCACert(t.Context(), path, []byte("x"))
 	if err == nil || !strings.Contains(err.Error(), "disk full") {
 		t.Errorf("got %v, want fs_write error-frame failure", err)
 	}

--- a/sandboxd/main.go
+++ b/sandboxd/main.go
@@ -69,7 +69,7 @@ func main() {
 	if err != nil {
 		logger.Fatalf(ctx, err, "load config")
 	}
-	eng := engine.New(cfg.CocoonBin, cfg.Bridge, cfg.Network, cfg.RestoreMode)
+	eng := engine.New(cfg.CocoonBin, cfg.Bridge, cfg.Network, cfg.NoDirectIO, cfg.RestoreMode)
 	if v, warn := eng.VersionWarning(ctx); warn != "" {
 		logger.Warn(ctx, warn)
 	} else {

--- a/sandboxd/pool/drain_test.go
+++ b/sandboxd/pool/drain_test.go
@@ -16,7 +16,6 @@ func TestDrainRefusesClaimsTrimsWarmAndUncordonRefills(t *testing.T) {
 	if err := os.MkdirAll(goldenDir, 0o750); err != nil {
 		t.Fatalf("setup golden: %v", err)
 	}
-	markGoldenRuntime(t, goldenDir)
 	if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: testKey, Warm: 2}}); err != nil {
 		t.Fatalf("SetPools: %v", err)
 	}

--- a/sandboxd/pool/drain_test.go
+++ b/sandboxd/pool/drain_test.go
@@ -16,6 +16,7 @@ func TestDrainRefusesClaimsTrimsWarmAndUncordonRefills(t *testing.T) {
 	if err := os.MkdirAll(goldenDir, 0o750); err != nil {
 		t.Fatalf("setup golden: %v", err)
 	}
+	markGoldenRuntime(t, goldenDir)
 	if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: testKey, Warm: 2}}); err != nil {
 		t.Fatalf("SetPools: %v", err)
 	}

--- a/sandboxd/pool/egress_test.go
+++ b/sandboxd/pool/egress_test.go
@@ -390,7 +390,6 @@ func TestSetPoolsPreservesEgressPolicy(t *testing.T) {
 	if err := os.MkdirAll(gd, 0o750); err != nil { // on disk so re-add adopts it, sparing an async build
 		t.Fatalf("golden dir: %v", err)
 	}
-	markGoldenRuntime(t, gd)
 	m.mu.Lock()
 	m.pools[egKey].goldenDir = gd
 	m.mu.Unlock()

--- a/sandboxd/pool/egress_test.go
+++ b/sandboxd/pool/egress_test.go
@@ -95,7 +95,7 @@ func TestArmEgressFailsClosedWhenNICUnlockable(t *testing.T) {
 	m := egressManager(t, newFakeEngine(), config.PoolSpec{PoolKey: egKey, Egress: egPolicy})
 	// The engine reports no NIC tap, so the nft lock cannot apply; arming must
 	// fail rather than hand out an egress-lane NIC that bypasses the proxy.
-	sb := &types.Sandbox{ID: "sb_eg_fc", Key: egKey, VMName: "sbx-fc-1"}
+	sb := &types.Sandbox{ID: "sb_eg_no_tap", Key: egKey, VMName: "sbx-no-tap-1"}
 	if armErr := m.armEgress(t.Context(), sb); armErr == nil {
 		t.Fatal("armEgress must fail closed when the egress-lane NIC cannot be locked")
 	}
@@ -390,6 +390,7 @@ func TestSetPoolsPreservesEgressPolicy(t *testing.T) {
 	if err := os.MkdirAll(gd, 0o750); err != nil { // on disk so re-add adopts it, sparing an async build
 		t.Fatalf("golden dir: %v", err)
 	}
+	markGoldenRuntime(t, gd)
 	m.mu.Lock()
 	m.pools[egKey].goldenDir = gd
 	m.mu.Unlock()

--- a/sandboxd/pool/fork.go
+++ b/sandboxd/pool/fork.go
@@ -77,7 +77,11 @@ func (m *Manager) forkSource(ctx context.Context, sb *types.Sandbox) (func() (*t
 		if err := m.eng.SnapshotSave(ctx, sb.VMName, snap); err != nil {
 			return nil, nil, err
 		}
-		return func() (*types.Sandbox, error) { return m.provisionSnap(ctx, sb.Key, snap) },
+		return func() (*types.Sandbox, error) {
+				return m.startVM(ctx, sb.Key, func(name string) (types.VMRecord, error) {
+					return m.eng.CloneSnap(ctx, snap, name, sb.Key)
+				})
+			},
 			func() { m.dropSnap(ctx, snap) }, nil
 	}
 	dir, err := os.MkdirTemp(m.dataDir, "fork-")
@@ -89,6 +93,10 @@ func (m *Manager) forkSource(ctx context.Context, sb *types.Sandbox) (func() (*t
 		_ = os.RemoveAll(dir)
 		return nil, nil, err
 	}
-	return func() (*types.Sandbox, error) { return m.provision(ctx, sb.Key, exportDir) },
+	return func() (*types.Sandbox, error) {
+			return m.startVM(ctx, sb.Key, func(name string) (types.VMRecord, error) {
+				return m.eng.Clone(ctx, exportDir, name, sb.Key)
+			})
+		},
 		func() { _ = os.RemoveAll(dir) }, nil
 }

--- a/sandboxd/pool/fork.go
+++ b/sandboxd/pool/fork.go
@@ -58,18 +58,18 @@ func (m *Manager) Fork(ctx context.Context, id, token string, count int, ttl tim
 // cloned straight from a fresh store snapshot (no export copy); a hibernated
 // source stays on the export path (its shared wake image needs a private copy).
 func (m *Manager) forkClones(ctx context.Context, sb *types.Sandbox, count int) ([]*types.Sandbox, error) {
-	provision, cleanup, err := m.forkSource(ctx, sb)
+	create, cleanup, err := m.forkSource(ctx, sb)
 	if err != nil {
 		return nil, err
 	}
 	defer cleanup()
-	return m.cloneBatch(ctx, count, provision)
+	return m.cloneBatch(ctx, count, sb.Key, create)
 }
 
 // forkSource decides and captures the fork source under the transition lock
 // (a racing hibernate cannot swap the snapshot out from under the fan-out),
 // returning the per-child provisioner and its cleanup.
-func (m *Manager) forkSource(ctx context.Context, sb *types.Sandbox) (func() (*types.Sandbox, error), func(), error) {
+func (m *Manager) forkSource(ctx context.Context, sb *types.Sandbox) (func(string) (types.VMRecord, error), func(), error) {
 	sb.Transition.Lock()
 	defer sb.Transition.Unlock()
 	if sb.HibernateSnap == "" {
@@ -77,11 +77,7 @@ func (m *Manager) forkSource(ctx context.Context, sb *types.Sandbox) (func() (*t
 		if err := m.eng.SnapshotSave(ctx, sb.VMName, snap); err != nil {
 			return nil, nil, err
 		}
-		return func() (*types.Sandbox, error) {
-				return m.startVM(ctx, sb.Key, func(name string) (types.VMRecord, error) {
-					return m.eng.CloneSnap(ctx, snap, name, sb.Key)
-				})
-			},
+		return func(name string) (types.VMRecord, error) { return m.eng.CloneSnap(ctx, snap, name, sb.Key) },
 			func() { m.dropSnap(ctx, snap) }, nil
 	}
 	dir, err := os.MkdirTemp(m.dataDir, "fork-")
@@ -93,10 +89,6 @@ func (m *Manager) forkSource(ctx context.Context, sb *types.Sandbox) (func() (*t
 		_ = os.RemoveAll(dir)
 		return nil, nil, err
 	}
-	return func() (*types.Sandbox, error) {
-			return m.startVM(ctx, sb.Key, func(name string) (types.VMRecord, error) {
-				return m.eng.Clone(ctx, exportDir, name, sb.Key)
-			})
-		},
+	return func(name string) (types.VMRecord, error) { return m.eng.Clone(ctx, exportDir, name, sb.Key) },
 		func() { _ = os.RemoveAll(dir) }, nil
 }

--- a/sandboxd/pool/intercept_test.go
+++ b/sandboxd/pool/intercept_test.go
@@ -84,6 +84,21 @@ func TestGoldenCAMatchRebuildsOnMismatch(t *testing.T) {
 	}
 }
 
+func TestGoldenRuntimeMarkerRejectsLegacyExport(t *testing.T) {
+	m := newTestManager(t, newFakeEngine())
+	final := filepath.Join(m.goldensDir(), testKey.Hash())
+	if err := os.MkdirAll(final, 0o750); err != nil {
+		t.Fatalf("stage golden: %v", err)
+	}
+	if m.goldenRuntimeMatches(final) {
+		t.Error("adopted an unmarked pre-CH-only golden; want rebuild")
+	}
+	markGoldenRuntime(t, final)
+	if !m.goldenRuntimeMatches(final) {
+		t.Error("rejected a golden marked for Cloud Hypervisor")
+	}
+}
+
 func TestColdProvisionInstallsCAForInterceptPool(t *testing.T) {
 	eng := newFakeEngine()
 	m := egressManager(t, eng, config.PoolSpec{PoolKey: interceptKey, Warm: 1, Egress: interceptPolicy()})

--- a/sandboxd/pool/intercept_test.go
+++ b/sandboxd/pool/intercept_test.go
@@ -84,21 +84,6 @@ func TestGoldenCAMatchRebuildsOnMismatch(t *testing.T) {
 	}
 }
 
-func TestGoldenRuntimeMarkerRejectsLegacyExport(t *testing.T) {
-	m := newTestManager(t, newFakeEngine())
-	final := filepath.Join(m.goldensDir(), testKey.Hash())
-	if err := os.MkdirAll(final, 0o750); err != nil {
-		t.Fatalf("stage golden: %v", err)
-	}
-	if m.goldenRuntimeMatches(final) {
-		t.Error("adopted an unmarked pre-CH-only golden; want rebuild")
-	}
-	markGoldenRuntime(t, final)
-	if !m.goldenRuntimeMatches(final) {
-		t.Error("rejected a golden marked for Cloud Hypervisor")
-	}
-}
-
 func TestColdProvisionInstallsCAForInterceptPool(t *testing.T) {
 	eng := newFakeEngine()
 	m := egressManager(t, eng, config.PoolSpec{PoolKey: interceptKey, Warm: 1, Egress: interceptPolicy()})

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -54,7 +54,9 @@ const (
 	forkPrefix      = "sbx-fork-"
 	vmStateRunning  = "running"
 
-	caSidecarSuffix = ".cafp"
+	caSidecarSuffix      = ".cafp"
+	runtimeSidecarSuffix = ".runtime"
+	runtimeMarker        = "cloud-hypervisor\n"
 )
 
 var (
@@ -253,6 +255,7 @@ type Manager struct {
 	claimed map[string]*types.Sandbox
 
 	refillSem  chan struct{}
+	probeSem   chan struct{}
 	refillKick chan struct{}
 }
 
@@ -287,6 +290,7 @@ func NewManager(ctx context.Context, cfg *config.Config, eng Engine, secrets *eg
 		dial:            egressDialer.DialContext,
 		sweep:           netfilter.SweepExcept,
 		refillSem:       make(chan struct{}, refill),
+		probeSem:        make(chan struct{}, refill),
 		refillKick:      make(chan struct{}, 1),
 	}
 	if err := os.MkdirAll(m.goldensDir(), 0o750); err != nil {
@@ -568,7 +572,7 @@ func benignSweepErr(err error) bool {
 }
 
 func vmName(key types.PoolKey) string {
-	return vmPrefix + key.Hash() + "-" + randHex(3)
+	return vmPrefix + key.Hash() + "-" + randHex(6)
 }
 
 func randHex(n int) string {

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -4,6 +4,7 @@
 package pool
 
 import (
+	"cmp"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -543,11 +544,7 @@ func newStoreView(ctx context.Context, cfg *config.Config, staging string, idRe 
 	if cs := cfg.CheckpointStore; cs != nil && cs.Kind == "s3" {
 		return s3.New(ctx, *cs.S3, filepath.Join(cfg.DataDir, staging), idRe)
 	}
-	ckptDir := cfg.CheckpointDir
-	if ckptDir == "" {
-		ckptDir = filepath.Join(cfg.DataDir, "checkpoints")
-	}
-	return dir.New(ckptDir, idRe)
+	return dir.New(cmp.Or(cfg.CheckpointDir, filepath.Join(cfg.DataDir, "checkpoints")), idRe)
 }
 
 func dirExists(path string) bool {

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -54,9 +54,7 @@ const (
 	forkPrefix      = "sbx-fork-"
 	vmStateRunning  = "running"
 
-	caSidecarSuffix      = ".cafp"
-	runtimeSidecarSuffix = ".runtime"
-	runtimeMarker        = "cloud-hypervisor\n"
+	caSidecarSuffix = ".cafp"
 )
 
 var (

--- a/sandboxd/pool/pool_test.go
+++ b/sandboxd/pool/pool_test.go
@@ -239,7 +239,6 @@ func TestReconcile(t *testing.T) {
 	if err := os.MkdirAll(goldenDir, 0o750); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
-	markGoldenRuntime(t, goldenDir)
 
 	if err := m.Reconcile(t.Context()); err != nil {
 		t.Fatalf("Reconcile: %v", err)
@@ -287,7 +286,6 @@ func TestSetPoolsGrowShrinkAndDrain(t *testing.T) {
 	if err := os.MkdirAll(goldenDir, 0o750); err != nil {
 		t.Fatalf("setup golden: %v", err)
 	}
-	markGoldenRuntime(t, goldenDir)
 
 	if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: testKey, Warm: 2}}); err != nil {
 		t.Fatalf("SetPools grow: %v", err)
@@ -554,9 +552,6 @@ func TestGoldenBuildPipeline(t *testing.T) {
 	if fi, err := os.Stat(golden); err != nil || !fi.IsDir() {
 		t.Errorf("golden dir not exported: %v", err)
 	}
-	if !m.goldenRuntimeMatches(golden) {
-		t.Error("golden runtime marker missing after build")
-	}
 	builder := vmPrefix + "gb-" + testKey.Hash()
 	if removed := eng.removedNames(); !slices.Contains(removed, builder) {
 		t.Errorf("removes=%v, want builder VM %s destroyed", removed, builder)
@@ -639,13 +634,6 @@ func TestProbeReadyWaitsForVsock(t *testing.T) {
 func newTestManager(t *testing.T, eng *fakeEngine, pools ...config.PoolSpec) *Manager {
 	t.Helper()
 	return newTestManagerAt(t, eng, t.TempDir(), pools...)
-}
-
-func markGoldenRuntime(t *testing.T, golden string) {
-	t.Helper()
-	if err := os.WriteFile(golden+runtimeSidecarSuffix, []byte(runtimeMarker), 0o644); err != nil {
-		t.Fatalf("write golden runtime marker: %v", err)
-	}
 }
 
 // claimAny composes warm-then-provision the way the server does around the

--- a/sandboxd/pool/pool_test.go
+++ b/sandboxd/pool/pool_test.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -67,8 +68,16 @@ func TestClaimMissClonesFromGolden(t *testing.T) {
 	if len(eng.clones) != 1 || len(eng.colds) != 0 {
 		t.Fatalf("got clones=%v colds=%v, want one clone", eng.clones, eng.colds)
 	}
-	if !strings.HasPrefix(sb.VMName, vmPrefix+testKey.Hash()) {
-		t.Errorf("vm name %q missing pool prefix", sb.VMName)
+	prefix := vmPrefix + testKey.Hash() + "-"
+	if !strings.HasPrefix(sb.VMName, prefix) {
+		t.Fatalf("vm name %q missing pool prefix", sb.VMName)
+	}
+	suffix := strings.TrimPrefix(sb.VMName, prefix)
+	if len(suffix) != 12 {
+		t.Errorf("vm name suffix %q has %d chars, want 12", suffix, len(suffix))
+	}
+	if _, err := hex.DecodeString(suffix); err != nil {
+		t.Errorf("vm name suffix %q is not hex: %v", suffix, err)
 	}
 	if want := "/vsock/" + sb.VMName; sb.VsockSocket != want {
 		t.Errorf("vsock %q, want %q", sb.VsockSocket, want)
@@ -230,6 +239,7 @@ func TestReconcile(t *testing.T) {
 	if err := os.MkdirAll(goldenDir, 0o750); err != nil {
 		t.Fatalf("setup: %v", err)
 	}
+	markGoldenRuntime(t, goldenDir)
 
 	if err := m.Reconcile(t.Context()); err != nil {
 		t.Fatalf("Reconcile: %v", err)
@@ -277,6 +287,7 @@ func TestSetPoolsGrowShrinkAndDrain(t *testing.T) {
 	if err := os.MkdirAll(goldenDir, 0o750); err != nil {
 		t.Fatalf("setup golden: %v", err)
 	}
+	markGoldenRuntime(t, goldenDir)
 
 	if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: testKey, Warm: 2}}); err != nil {
 		t.Fatalf("SetPools grow: %v", err)
@@ -318,6 +329,7 @@ func TestRefillServicesEveryPoolUnderTightBudget(t *testing.T) {
 		config.PoolSpec{PoolKey: testKey, Warm: 3},
 		config.PoolSpec{PoolKey: key2, Warm: 3})
 	m.refillSem = make(chan struct{}, 1)
+	m.probeSem = make(chan struct{}, 1)
 	m.mu.Lock()
 	m.pools[testKey].goldenDir = "/goldens/a"
 	m.pools[key2].goldenDir = "/goldens/b"
@@ -398,26 +410,103 @@ func TestSetPoolsRejectsEgress(t *testing.T) {
 func TestRefillRespectsSemaphore(t *testing.T) {
 	eng := newFakeEngine()
 	eng.probeStall = make(chan struct{})
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 6})
+	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 7})
+	m.refillSem = make(chan struct{}, 2)
+	m.probeSem = make(chan struct{}, 2)
 	m.pools[testKey].goldenDir = "/goldens/x"
 
 	m.refillOnce(t.Context())
-	waitFor(t, func() bool { return eng.cloneCount() == defaultRefill })
+	waitFor(t, func() bool { return eng.cloneCount() == 4 && eng.probeCount() == 2 })
 	time.Sleep(50 * time.Millisecond)
-	if n := eng.cloneCount(); n != defaultRefill {
-		t.Errorf("clones=%d while stalled, want %d", n, defaultRefill)
+	if clones, probes := eng.cloneCount(), eng.probeCount(); clones != 4 || probes != 2 {
+		t.Errorf("stalled pipeline clones=%d probes=%d, want 4/2", clones, probes)
+	}
+	infos, _ := m.Info()
+	if infos[0].Warm != 0 || infos[0].Refilling != 4 {
+		t.Errorf("stalled pipeline info=%+v, want warm=0 refilling=4", infos[0])
 	}
 
 	close(eng.probeStall)
 	waitFor(t, func() bool {
 		infos, _ := m.Info()
-		return infos[0].Warm+infos[0].Refilling >= defaultRefill && infos[0].Refilling == 0
+		return infos[0].Warm == 7 && infos[0].Refilling == 0
 	})
+}
+
+func TestRefillCloneStageIsBounded(t *testing.T) {
+	eng := newFakeEngine()
+	eng.cloneStall = make(chan struct{})
+	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 5})
+	m.refillSem = make(chan struct{}, 2)
+	m.probeSem = make(chan struct{}, 2)
+	m.pools[testKey].goldenDir = "/goldens/x"
+
+	m.refillOnce(t.Context())
+	waitFor(t, func() bool { return eng.cloneCount() == 2 })
+	time.Sleep(50 * time.Millisecond)
+	if got := eng.cloneCount(); got != 2 {
+		t.Errorf("clones=%d while clone stage stalled, want 2", got)
+	}
+	close(eng.cloneStall)
+	waitFor(t, func() bool {
+		infos, _ := m.Info()
+		return infos[0].Warm == 5 && infos[0].Refilling == 0
+	})
+}
+
+func TestRefillProbeFailureCleansUp(t *testing.T) {
+	eng := newFakeEngine()
+	eng.probeErr = errors.New("never ready")
+	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1})
+	m.pools[testKey].goldenDir = "/goldens/x"
+
 	m.refillOnce(t.Context())
 	waitFor(t, func() bool {
 		infos, _ := m.Info()
-		return infos[0].Warm == 6
+		return infos[0].Warm == 0 && infos[0].Refilling == 0 && len(eng.removedNames()) == 1
 	})
+	eng.mu.Lock()
+	eng.probeErr = nil
+	eng.mu.Unlock()
+	m.refillOnce(t.Context())
+	waitFor(t, func() bool {
+		infos, _ := m.Info()
+		return infos[0].Warm == 1 && infos[0].Refilling == 0
+	})
+}
+
+func TestRefillCanceledWhileWaitingForProbeCleansUp(t *testing.T) {
+	eng := newFakeEngine()
+	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1})
+	m.refillSem = make(chan struct{}, 1)
+	m.probeSem = make(chan struct{}, 1)
+	m.probeSem <- struct{}{}
+	m.pools[testKey].goldenDir = "/goldens/x"
+	ctx, cancel := context.WithCancel(t.Context())
+
+	m.refillOnce(ctx)
+	waitFor(t, func() bool { return eng.cloneCount() == 1 && len(m.refillSem) == 0 })
+	cancel()
+	waitFor(t, func() bool {
+		infos, _ := m.Info()
+		return infos[0].Refilling == 0 && len(eng.removedNames()) == 1
+	})
+	<-m.probeSem
+}
+
+func TestDirectClaimSkipsProbeGate(t *testing.T) {
+	m := newTestManager(t, newFakeEngine())
+	for range cap(m.probeSem) {
+		m.probeSem <- struct{}{}
+	}
+	defer func() {
+		for range cap(m.probeSem) {
+			<-m.probeSem
+		}
+	}()
+	if _, err := claimAny(t.Context(), m, testKey, 0); err != nil {
+		t.Fatalf("direct claim waited on probe gate: %v", err)
+	}
 }
 
 func TestRefillBudgetFollowsConfig(t *testing.T) {
@@ -427,6 +516,9 @@ func TestRefillBudgetFollowsConfig(t *testing.T) {
 	}
 	if got := cap(m.refillSem); got != 2 {
 		t.Errorf("budget %d, want the configured 2", got)
+	}
+	if got := cap(m.probeSem); got != 2 {
+		t.Errorf("probe budget %d, want the configured 2", got)
 	}
 }
 
@@ -461,6 +553,9 @@ func TestGoldenBuildPipeline(t *testing.T) {
 	m.mu.Unlock()
 	if fi, err := os.Stat(golden); err != nil || !fi.IsDir() {
 		t.Errorf("golden dir not exported: %v", err)
+	}
+	if !m.goldenRuntimeMatches(golden) {
+		t.Error("golden runtime marker missing after build")
 	}
 	builder := vmPrefix + "gb-" + testKey.Hash()
 	if removed := eng.removedNames(); !slices.Contains(removed, builder) {
@@ -546,6 +641,13 @@ func newTestManager(t *testing.T, eng *fakeEngine, pools ...config.PoolSpec) *Ma
 	return newTestManagerAt(t, eng, t.TempDir(), pools...)
 }
 
+func markGoldenRuntime(t *testing.T, golden string) {
+	t.Helper()
+	if err := os.WriteFile(golden+runtimeSidecarSuffix, []byte(runtimeMarker), 0o644); err != nil {
+		t.Fatalf("write golden runtime marker: %v", err)
+	}
+}
+
 // claimAny composes warm-then-provision the way the server does around the
 // redirect decision; production has no single-call form.
 func claimAny(ctx context.Context, m *Manager, key types.PoolKey, ttl time.Duration) (*types.Sandbox, error) {
@@ -621,6 +723,7 @@ type fakeEngine struct {
 	tap                                                                                string // non-empty: lifecycle records carry this NIC tap
 	listCount                                                                          int
 
+	cloneStall      chan struct{} // non-nil: Clone blocks until closed
 	probeStall      chan struct{} // non-nil: Probe blocks until closed
 	hibernateStall  chan struct{} // non-nil: Hibernate blocks until closed
 	removeStall     chan struct{} // non-nil: Remove blocks until closed
@@ -634,31 +737,31 @@ func newFakeEngine() *fakeEngine {
 }
 
 func (f *fakeEngine) Clone(_ context.Context, fromDir, name string, _ types.PoolKey) (types.VMRecord, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.clones = append(f.clones, name)
-	f.cloneFroms = append(f.cloneFroms, fromDir)
-	if f.cloneErr != nil {
-		return types.VMRecord{}, f.cloneErr
-	}
-	if f.cloneFailNth > 0 && len(f.clones) == f.cloneFailNth {
-		return types.VMRecord{}, errors.New("clone failed")
-	}
-	f.vms[name] = "/vsock/" + name
-	return f.record(name), nil
+	return f.clone(fromDir, name)
 }
 
 func (f *fakeEngine) CloneSnap(_ context.Context, snap, name string, _ types.PoolKey) (types.VMRecord, error) {
+	return f.clone(snap, name)
+}
+
+func (f *fakeEngine) clone(from, name string) (types.VMRecord, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.clones = append(f.clones, name)
-	f.cloneFroms = append(f.cloneFroms, snap)
-	if f.cloneErr != nil {
-		return types.VMRecord{}, f.cloneErr
+	f.cloneFroms = append(f.cloneFroms, from)
+	call := len(f.clones)
+	stall, err, failNth := f.cloneStall, f.cloneErr, f.cloneFailNth
+	f.mu.Unlock()
+	if stall != nil {
+		<-stall
 	}
-	if f.cloneFailNth > 0 && len(f.clones) == f.cloneFailNth {
+	if err != nil {
+		return types.VMRecord{}, err
+	}
+	if failNth > 0 && call == failNth {
 		return types.VMRecord{}, errors.New("clone failed")
 	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.vms[name] = "/vsock/" + name
 	return f.record(name), nil
 }
@@ -861,6 +964,12 @@ func (f *fakeEngine) cloneCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return len(f.clones)
+}
+
+func (f *fakeEngine) probeCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.probeTimeouts)
 }
 
 func (f *fakeEngine) hibernateCount() int {

--- a/sandboxd/pool/promote_test.go
+++ b/sandboxd/pool/promote_test.go
@@ -1,7 +1,6 @@
 package pool
 
 import (
-	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -161,41 +160,6 @@ func TestResolveGoldenSkipsPromotedEgressTemplate(t *testing.T) {
 	}
 }
 
-func TestReconcileMigratesLegacyTemplates(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng)
-	key := types.PoolKey{Template: "tpl:legacy", Net: testKey.Net, Size: testKey.Size}
-	legacy := filepath.Join(m.goldensDir(), key.Hash())
-	if err := os.MkdirAll(legacy, 0o750); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(legacy, "disk.img"), []byte("golden-bytes"), 0o600); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	if err := m.Reconcile(t.Context()); err != nil {
-		t.Fatalf("Reconcile: %v", err)
-	}
-
-	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
-		t.Errorf("legacy golden dir survived migration: %v", err)
-	}
-	if !m.HasGolden(t.Context(), key) {
-		t.Fatal("migrated template not resolvable")
-	}
-	dir, release, err := m.resolveGolden(t.Context(), key)
-	if err != nil || dir == "" {
-		t.Fatalf("resolveGolden: %q, %v", dir, err)
-	}
-	defer release()
-	if got, err := os.ReadFile(filepath.Join(dir, "disk.img")); err != nil || string(got) != "golden-bytes" {
-		t.Errorf("migrated export: %q, %v", got, err)
-	}
-	if hashes := m.TemplateHashes(); !slices.Contains(hashes, key.Hash()) {
-		t.Errorf("TemplateHashes %v missing migrated %s", hashes, key.Hash())
-	}
-}
-
 func TestTemplateTenantScopedDelete(t *testing.T) {
 	eng := newFakeEngine()
 	m := newTestManager(t, eng)
@@ -244,34 +208,6 @@ func TestCommitTemplateRechecksOwnerUnderLock(t *testing.T) {
 	}
 	if err := m.commitTemplate(t.Context(), stage(), id, "beta"); !errors.Is(err, ErrTemplateOwned) {
 		t.Errorf("beta publish over acme: %v, want ErrTemplateOwned", err)
-	}
-}
-
-type failPublishStore struct{ store.Store }
-
-func (failPublishStore) Publish(context.Context, string, string) error {
-	return errors.New("publish boom")
-}
-
-// TestMigrateRollsBackOnPublishFailure: the staged legacy export is the only
-// copy; a failed publish must move it back or the next staging sweep deletes
-// the template outright.
-func TestMigrateRollsBackOnPublishFailure(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng)
-	legacy := filepath.Join(m.goldensDir(), testKey.Hash())
-	if err := os.MkdirAll(legacy, 0o750); err != nil {
-		t.Fatalf("mkdir legacy: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(legacy, "disk.img"), []byte("golden"), 0o600); err != nil {
-		t.Fatalf("write marker: %v", err)
-	}
-	m.tpls = failPublishStore{Store: m.tpls}
-
-	m.migrateLegacyTemplates(t.Context())
-	got, err := os.ReadFile(filepath.Join(legacy, "disk.img"))
-	if err != nil || string(got) != "golden" {
-		t.Fatalf("legacy template lost after failed publish: %q, %v", got, err)
 	}
 }
 

--- a/sandboxd/pool/reconcile.go
+++ b/sandboxd/pool/reconcile.go
@@ -88,7 +88,6 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 	if err := m.tpls.SweepStaging(); err != nil {
 		log.WithFunc("pool.Reconcile").Error(ctx, err, "sweep template staging")
 	}
-	m.migrateLegacyTemplates(ctx)
 	for _, tmp := range tmps {
 		_ = os.RemoveAll(tmp)
 	}

--- a/sandboxd/pool/refill.go
+++ b/sandboxd/pool/refill.go
@@ -32,7 +32,9 @@ func (m *Manager) refillOnce(ctx context.Context) {
 		return
 	}
 	now := time.Now()
+	inFlight := 0
 	for key, p := range m.pools {
+		inFlight += p.refilling
 		// SetPools leaves a removed pool in place while a build/refill is in
 		// flight; sweep it once quiescent.
 		if p.removed {
@@ -46,11 +48,7 @@ func (m *Manager) refillOnce(ctx context.Context) {
 			go m.buildGolden(ctx, p)
 		}
 	}
-	inFlight := 0
-	for _, p := range m.pools {
-		inFlight += p.refilling
-	}
-	limit := 2 * cap(m.refillSem)
+	limit := cap(m.refillSem) + cap(m.probeSem)
 	for spawned := true; spawned && inFlight < limit; {
 		spawned = false
 		for _, p := range m.pools {
@@ -157,10 +155,7 @@ func (m *Manager) buildGoldenSteps(ctx context.Context, key types.PoolKey, name,
 	if err := m.exportGolden(ctx, snap, final); err != nil {
 		return err
 	}
-	if err := m.writeGoldenCASidecar(final, caBaked); err != nil {
-		return err
-	}
-	return os.WriteFile(final+runtimeSidecarSuffix, []byte(runtimeMarker), 0o644) //nolint:gosec // public runtime marker
+	return m.writeGoldenCASidecar(final, caBaked)
 }
 
 // writeGoldenCASidecar records (or clears) the baked-CA fingerprint, so a
@@ -182,14 +177,9 @@ func (m *Manager) writeGoldenCASidecar(final string, caBaked bool) error {
 // adoptGolden points p at a golden already on disk from the pool's earlier
 // life, when its baked-CA state still fits; buildGolden covers the rest.
 func (m *Manager) adoptGolden(p *pool) {
-	if g := filepath.Join(m.goldensDir(), p.key.Hash()); dirExists(g) && m.goldenRuntimeMatches(g) && m.goldenCAMatches(g, m.poolEgress[p.key].Intercepts()) {
+	if g := filepath.Join(m.goldensDir(), p.key.Hash()); dirExists(g) && m.goldenCAMatches(g, m.poolEgress[p.key].Intercepts()) {
 		p.goldenDir = g
 	}
-}
-
-func (m *Manager) goldenRuntimeMatches(final string) bool {
-	runtime, err := os.ReadFile(final + runtimeSidecarSuffix) //nolint:gosec // node-local golden marker
-	return err == nil && string(runtime) == runtimeMarker
 }
 
 // goldenCAMatches reports whether a golden's baked-CA state fits the pool: a
@@ -279,7 +269,6 @@ func (m *Manager) provision(ctx context.Context, key types.PoolKey, golden strin
 	})
 }
 
-// provisionVM creates and probes one VM, cleaning up any failure.
 func (m *Manager) provisionVM(ctx context.Context, key types.PoolKey, probeTimeout time.Duration, create func(name string) (types.VMRecord, error)) (*types.Sandbox, error) {
 	sb, err := m.startVM(ctx, key, create)
 	if err != nil {
@@ -321,15 +310,14 @@ func (m *Manager) readyBounded(ctx context.Context, sb *types.Sandbox, deadline 
 	return m.readyVM(probeCtx, sb, deadline)
 }
 
-// cloneBatch creates and probes a fork batch through separate gates.
-func (m *Manager) cloneBatch(ctx context.Context, count int, startOne func() (*types.Sandbox, error)) ([]*types.Sandbox, error) {
+func (m *Manager) cloneBatch(ctx context.Context, count int, key types.PoolKey, create func(string) (types.VMRecord, error)) ([]*types.Sandbox, error) {
 	children := make([]*types.Sandbox, count)
 	errs := make([]error, count)
 	var wg sync.WaitGroup
 	for i := range count {
 		m.refillSem <- struct{}{}
 		wg.Go(func() {
-			child, err := startOne()
+			child, err := m.startVM(ctx, key, create)
 			<-m.refillSem
 			if err == nil {
 				child, err = m.readyBounded(ctx, child, time.Now().Add(claimProbeTimeout))

--- a/sandboxd/pool/refill.go
+++ b/sandboxd/pool/refill.go
@@ -46,15 +46,24 @@ func (m *Manager) refillOnce(ctx context.Context) {
 			go m.buildGolden(ctx, p)
 		}
 	}
-	for spawned := true; spawned; {
+	inFlight := 0
+	for _, p := range m.pools {
+		inFlight += p.refilling
+	}
+	limit := 2 * cap(m.refillSem)
+	for spawned := true; spawned && inFlight < limit; {
 		spawned = false
 		for _, p := range m.pools {
+			if inFlight >= limit {
+				return
+			}
 			if p.removed || p.goldenDir == "" || len(p.warm)+p.refilling >= p.effectiveTarget(now) {
 				continue
 			}
 			select {
 			case m.refillSem <- struct{}{}:
 				p.refilling++
+				inFlight++
 				go m.refillOne(ctx, p, p.goldenDir)
 				spawned = true
 			default:
@@ -66,7 +75,16 @@ func (m *Manager) refillOnce(ctx context.Context) {
 
 func (m *Manager) refillOne(ctx context.Context, p *pool, golden string) {
 	start := time.Now()
-	sb, err := m.provision(ctx, p.key, golden)
+	sb, err := m.startVM(ctx, p.key, func(name string) (types.VMRecord, error) {
+		return m.eng.Clone(ctx, golden, name, p.key)
+	})
+	<-m.refillSem
+	if err == nil {
+		if ctx.Err() == nil {
+			m.refillOnce(ctx)
+		}
+		sb, err = m.readyBounded(ctx, sb, time.Now().Add(claimProbeTimeout))
+	}
 	keep := false
 	m.mu.Lock()
 	p.refilling--
@@ -76,12 +94,15 @@ func (m *Manager) refillOne(ctx context.Context, p *pool, golden string) {
 		keep = true
 	}
 	m.mu.Unlock()
-	<-m.refillSem
 	if err != nil {
-		log.WithFunc("pool.refillOne").Errorf(ctx, err, "refill %s", p.key.Hash())
+		if ctx.Err() == nil {
+			log.WithFunc("pool.refillOne").Errorf(ctx, err, "refill %s", p.key.Hash())
+		}
 		return
 	}
-	m.refillOnce(ctx)
+	if ctx.Err() == nil {
+		m.refillOnce(ctx)
+	}
 	if !keep {
 		m.destroy(ctx, sb.VMName)
 	}
@@ -136,7 +157,10 @@ func (m *Manager) buildGoldenSteps(ctx context.Context, key types.PoolKey, name,
 	if err := m.exportGolden(ctx, snap, final); err != nil {
 		return err
 	}
-	return m.writeGoldenCASidecar(final, caBaked)
+	if err := m.writeGoldenCASidecar(final, caBaked); err != nil {
+		return err
+	}
+	return os.WriteFile(final+runtimeSidecarSuffix, []byte(runtimeMarker), 0o644) //nolint:gosec // public runtime marker
 }
 
 // writeGoldenCASidecar records (or clears) the baked-CA fingerprint, so a
@@ -158,9 +182,14 @@ func (m *Manager) writeGoldenCASidecar(final string, caBaked bool) error {
 // adoptGolden points p at a golden already on disk from the pool's earlier
 // life, when its baked-CA state still fits; buildGolden covers the rest.
 func (m *Manager) adoptGolden(p *pool) {
-	if g := filepath.Join(m.goldensDir(), p.key.Hash()); dirExists(g) && m.goldenCAMatches(g, m.poolEgress[p.key].Intercepts()) {
+	if g := filepath.Join(m.goldensDir(), p.key.Hash()); dirExists(g) && m.goldenRuntimeMatches(g) && m.goldenCAMatches(g, m.poolEgress[p.key].Intercepts()) {
 		p.goldenDir = g
 	}
+}
+
+func (m *Manager) goldenRuntimeMatches(final string) bool {
+	runtime, err := os.ReadFile(final + runtimeSidecarSuffix) //nolint:gosec // node-local golden marker
+	return err == nil && string(runtime) == runtimeMarker
 }
 
 // goldenCAMatches reports whether a golden's baked-CA state fits the pool: a
@@ -250,43 +279,62 @@ func (m *Manager) provision(ctx context.Context, key types.PoolKey, golden strin
 	})
 }
 
-// provisionSnap creates one claim-ready clone from a local-store snapshot —
-// fork's fast path, which skips the export-to-dir copy.
-func (m *Manager) provisionSnap(ctx context.Context, key types.PoolKey, snap string) (*types.Sandbox, error) {
-	return m.provisionVM(ctx, key, claimProbeTimeout, func(name string) (types.VMRecord, error) {
-		return m.eng.CloneSnap(ctx, snap, name, key)
-	})
+// provisionVM creates and probes one VM, cleaning up any failure.
+func (m *Manager) provisionVM(ctx context.Context, key types.PoolKey, probeTimeout time.Duration, create func(name string) (types.VMRecord, error)) (*types.Sandbox, error) {
+	sb, err := m.startVM(ctx, key, create)
+	if err != nil {
+		return nil, err
+	}
+	return m.readyVM(ctx, sb, time.Now().Add(probeTimeout))
 }
 
-// provisionVM creates one VM via create, probes it ready, and destroys it on
-// any failure — including create-command failures, which can leave a half-
-// created VM behind (e.g. the CLI killed by timeout after the VMM spawned).
-func (m *Manager) provisionVM(ctx context.Context, key types.PoolKey, probeTimeout time.Duration, create func(name string) (types.VMRecord, error)) (*types.Sandbox, error) {
+func (m *Manager) startVM(ctx context.Context, key types.PoolKey, create func(name string) (types.VMRecord, error)) (*types.Sandbox, error) {
 	name := vmName(key)
 	rec, err := create(name)
-	var sock string
-	if err == nil {
-		sock, err = m.probeReady(ctx, name, rec.VsockSocket, probeTimeout)
-	}
 	if err != nil {
 		m.destroy(ctx, name)
 		return nil, err
 	}
-	return &types.Sandbox{VMName: name, Key: key, VsockSocket: sock, TAP: rec.TapDevice()}, nil
+	return &types.Sandbox{VMName: name, Key: key, VsockSocket: rec.VsockSocket, TAP: rec.TapDevice()}, nil
 }
 
-// cloneBatch builds count claim-ready VMs via provisionOne, bounded by the
-// refill semaphore — forks and refills contend for the same node resources,
-// so they share one gate. One failure destroys the batch.
-func (m *Manager) cloneBatch(ctx context.Context, count int, provisionOne func() (*types.Sandbox, error)) ([]*types.Sandbox, error) {
+func (m *Manager) readyVM(ctx context.Context, sb *types.Sandbox, deadline time.Time) (*types.Sandbox, error) {
+	sock, err := m.probeReady(ctx, sb.VMName, sb.VsockSocket, time.Until(deadline))
+	if err != nil {
+		m.destroy(ctx, sb.VMName)
+		return nil, err
+	}
+	sb.VsockSocket = sock
+	return sb, nil
+}
+
+func (m *Manager) readyBounded(ctx context.Context, sb *types.Sandbox, deadline time.Time) (*types.Sandbox, error) {
+	probeCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	select {
+	case m.probeSem <- struct{}{}:
+		defer func() { <-m.probeSem }()
+	case <-probeCtx.Done():
+		m.destroy(ctx, sb.VMName)
+		return nil, probeCtx.Err()
+	}
+	return m.readyVM(probeCtx, sb, deadline)
+}
+
+// cloneBatch creates and probes a fork batch through separate gates.
+func (m *Manager) cloneBatch(ctx context.Context, count int, startOne func() (*types.Sandbox, error)) ([]*types.Sandbox, error) {
 	children := make([]*types.Sandbox, count)
 	errs := make([]error, count)
 	var wg sync.WaitGroup
 	for i := range count {
 		m.refillSem <- struct{}{}
 		wg.Go(func() {
-			defer func() { <-m.refillSem }()
-			children[i], errs[i] = provisionOne()
+			child, err := startOne()
+			<-m.refillSem
+			if err == nil {
+				child, err = m.readyBounded(ctx, child, time.Now().Add(claimProbeTimeout))
+			}
+			children[i], errs[i] = child, err
 		})
 	}
 	wg.Wait()

--- a/sandboxd/pool/template.go
+++ b/sandboxd/pool/template.go
@@ -7,11 +7,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
-
-	"github.com/projecteru2/core/log"
 
 	"github.com/cocoonstack/sandbox/sandboxd/store"
 	"github.com/cocoonstack/sandbox/sandboxd/types"
@@ -283,47 +280,4 @@ func (m *Manager) commitTemplate(ctx context.Context, staging, id, tenant string
 	m.tplSet[id] = struct{}{}
 	m.tplMu.Unlock()
 	return nil
-}
-
-// migrateLegacyTemplates moves pre-store promoted templates
-// (<goldens>/<hash> dirs not backing a pool) into the template store —
-// one-time, at reconcile.
-func (m *Manager) migrateLegacyTemplates(ctx context.Context) {
-	logger := log.WithFunc("pool.migrateLegacyTemplates")
-	entries, err := os.ReadDir(m.goldensDir())
-	if err != nil {
-		return
-	}
-	for _, e := range entries {
-		hash := e.Name()
-		id := store.TemplateID(hash)
-		if !e.IsDir() || m.pooledHash(hash) || !store.TemplateIDRe.MatchString(id) {
-			continue
-		}
-		staging, err := m.tpls.Stage(id)
-		if err != nil {
-			logger.Errorf(ctx, err, "stage %s", id)
-			continue
-		}
-		legacy := filepath.Join(m.goldensDir(), hash)
-		if err := os.Rename(legacy, filepath.Join(staging, store.ExportDir)); err != nil {
-			logger.Errorf(ctx, err, "move %s", legacy)
-			_ = os.RemoveAll(staging)
-			continue
-		}
-		if err := m.commitTemplate(ctx, staging, id, ""); err != nil {
-			// The staged export is the only copy: put it back, or quarantine
-			// the staging dir out of the sweep's .tmp suffix when even that
-			// rename fails.
-			if rbErr := os.Rename(filepath.Join(staging, store.ExportDir), legacy); rbErr != nil {
-				_ = os.Rename(staging, strings.TrimSuffix(staging, ".tmp")+".stuck")
-				logger.Errorf(ctx, rbErr, "restore %s", legacy)
-			} else {
-				_ = os.RemoveAll(staging)
-			}
-			logger.Errorf(ctx, err, "publish %s", id)
-			continue
-		}
-		logger.Infof(ctx, "migrated legacy template %s", id)
-	}
 }

--- a/sandboxd/server/server.go
+++ b/sandboxd/server/server.go
@@ -206,14 +206,9 @@ func (s *Server) handleClaim(w http.ResponseWriter, r *http.Request) {
 		writeRedirect(w, s.placer.Candidates(hash)) {
 		return
 	}
-	switch {
-	case writePoolErr(w, err):
-	case err != nil:
-		log.WithFunc("server.handleClaim").Errorf(r.Context(), err, "claim %s", hash)
-		writeErr(w, http.StatusInternalServerError, "provisioning failed")
-	default:
+	writeResult(w, r, "claim", hash, "provisioning failed", err, func() {
 		writeJSON(w, http.StatusOK, s.claimResponse(sb))
-	}
+	})
 }
 
 // redirectClaim redirects a warm-miss to a better peer — a warm holder, or the
@@ -243,14 +238,9 @@ func (s *Server) handleSandboxVerb(verb string, do func(ctx context.Context, id,
 		}
 		id := r.PathValue("id")
 		err := do(r.Context(), id, token)
-		switch {
-		case writePoolErr(w, err):
-		case err != nil:
-			log.WithFunc("server.handleSandboxVerb").Errorf(r.Context(), err, "%s %s", verb, id)
-			writeErr(w, http.StatusInternalServerError, verb+" failed")
-		default:
+		writeResult(w, r, verb, id, verb+" failed", err, func() {
 			w.WriteHeader(http.StatusNoContent)
-		}
+		})
 	}
 }
 
@@ -263,18 +253,13 @@ func (s *Server) handleFork(w http.ResponseWriter, r *http.Request) {
 	}
 	id := r.PathValue("id")
 	children, err := s.mgr.Fork(r.Context(), id, req.Token, req.Count, req.TTL())
-	switch {
-	case writePoolErr(w, err):
-	case err != nil:
-		log.WithFunc("server.handleFork").Errorf(r.Context(), err, "fork %s", id)
-		writeErr(w, http.StatusInternalServerError, "fork failed")
-	default:
+	writeResult(w, r, "fork", id, "fork failed", err, func() {
 		resp := types.ForkResponse{Children: make([]types.ClaimResponse, len(children))}
 		for i, c := range children {
 			resp.Children[i] = s.claimResponse(c)
 		}
 		writeJSON(w, http.StatusOK, resp)
-	}
+	})
 }
 
 // handlePromote publishes a claimed sandbox as a node-local template.
@@ -285,14 +270,9 @@ func (s *Server) handlePromote(w http.ResponseWriter, r *http.Request) {
 	}
 	id := r.PathValue("id")
 	key, err := s.mgr.Promote(r.Context(), id, req.Token, req.Template, tenantFrom(r.Context()))
-	switch {
-	case writePoolErr(w, err):
-	case err != nil:
-		log.WithFunc("server.handlePromote").Errorf(r.Context(), err, "promote %s", id)
-		writeErr(w, http.StatusInternalServerError, "promote failed")
-	default:
+	writeResult(w, r, "promote", id, "promote failed", err, func() {
 		writeJSON(w, http.StatusOK, types.PromoteResponse{Key: key})
-	}
+	})
 }
 
 // handleCheckpoint captures a claimed sandbox's state as a new checkpoint.
@@ -303,14 +283,9 @@ func (s *Server) handleCheckpoint(w http.ResponseWriter, r *http.Request) {
 	}
 	id := r.PathValue("id")
 	ckpt, err := s.mgr.Checkpoint(r.Context(), id, req.Token, req.Name, tenantFrom(r.Context()))
-	switch {
-	case writePoolErr(w, err):
-	case err != nil:
-		log.WithFunc("server.handleCheckpoint").Errorf(r.Context(), err, "checkpoint %s", id)
-		writeErr(w, http.StatusInternalServerError, "checkpoint failed")
-	default:
+	writeResult(w, r, "checkpoint", id, "checkpoint failed", err, func() {
 		writeJSON(w, http.StatusOK, types.CheckpointResponse{Checkpoint: ckpt})
-	}
+	})
 }
 
 // handleClaimCheckpoint claims a fresh sandbox branched from a checkpoint.
@@ -321,14 +296,9 @@ func (s *Server) handleClaimCheckpoint(w http.ResponseWriter, r *http.Request) {
 	}
 	ckptID := r.PathValue("id")
 	sb, err := s.mgr.ClaimCheckpoint(r.Context(), ckptID, req.TTL(), tenantFrom(r.Context()))
-	switch {
-	case writePoolErr(w, err):
-	case err != nil:
-		log.WithFunc("server.handleClaimCheckpoint").Errorf(r.Context(), err, "claim checkpoint %s", ckptID)
-		writeErr(w, http.StatusInternalServerError, "provisioning failed")
-	default:
+	writeResult(w, r, "claim checkpoint", ckptID, "provisioning failed", err, func() {
 		writeJSON(w, http.StatusOK, s.claimResponse(sb))
-	}
+	})
 }
 
 // handleListCheckpoints lists this node's checkpoints, newest first — a
@@ -347,14 +317,9 @@ func (s *Server) handleListCheckpoints(w http.ResponseWriter, r *http.Request) {
 // only its own records (anything else is 404).
 func (s *Server) handleDeleteCheckpoint(w http.ResponseWriter, r *http.Request) {
 	err := s.mgr.DeleteCheckpoint(r.Context(), r.PathValue("id"), tenantFrom(r.Context()))
-	switch {
-	case writePoolErr(w, err):
-	case err != nil:
-		log.WithFunc("server.handleDeleteCheckpoint").Errorf(r.Context(), err, "delete checkpoint %s", r.PathValue("id"))
-		writeErr(w, http.StatusInternalServerError, "delete checkpoint failed")
-	default:
+	writeResult(w, r, "delete checkpoint", r.PathValue("id"), "delete checkpoint failed", err, func() {
 		w.WriteHeader(http.StatusNoContent)
-	}
+	})
 }
 
 // handleDeleteTemplate removes a promoted template; the key axes ride as
@@ -375,14 +340,9 @@ func (s *Server) handleDeleteTemplate(w http.ResponseWriter, r *http.Request) {
 		writeRedirect(w, s.placer.TemplateOwners(key.Hash())) {
 		return
 	}
-	switch {
-	case writePoolErr(w, err):
-	case err != nil:
-		log.WithFunc("server.handleDeleteTemplate").Errorf(r.Context(), err, "delete template %s", req.Template)
-		writeErr(w, http.StatusInternalServerError, "delete template failed")
-	default:
+	writeResult(w, r, "delete template", req.Template, "delete template failed", err, func() {
 		w.WriteHeader(http.StatusNoContent)
-	}
+	})
 }
 
 // handleOwner answers whether this node owns the sandbox (used by the SDK's

--- a/sandboxd/server/server_http.go
+++ b/sandboxd/server/server_http.go
@@ -1,12 +1,15 @@
 package server
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/projecteru2/core/log"
 
 	"github.com/cocoonstack/sandbox/sandboxd/types"
 	"github.com/cocoonstack/sandbox/sandboxd/utils"
@@ -71,15 +74,22 @@ func decodeBodyStrict[T any](w http.ResponseWriter, r *http.Request) (T, bool) {
 func writePoolErr(w http.ResponseWriter, err error) bool {
 	for _, m := range poolErrHTTP {
 		if errors.Is(err, m.err) {
-			msg := m.msg
-			if msg == "" {
-				msg = err.Error()
-			}
-			writeErr(w, m.code, msg)
+			writeErr(w, m.code, cmp.Or(m.msg, err.Error()))
 			return true
 		}
 	}
 	return false
+}
+
+func writeResult(w http.ResponseWriter, r *http.Request, op, id, failMsg string, err error, ok func()) {
+	switch {
+	case writePoolErr(w, err):
+	case err != nil:
+		log.WithFunc("server.writeResult").Errorf(r.Context(), err, "%s %s", op, id)
+		writeErr(w, http.StatusInternalServerError, failMsg)
+	default:
+		ok()
+	}
 }
 
 // writeRedirect answers with the redirect shape of the claim protocol when

--- a/sandboxd/types/types.go
+++ b/sandboxd/types/types.go
@@ -1,6 +1,4 @@
-// Package types defines the shared vocabulary of the sandbox control plane:
-// pool keys with their derived backend lane, size tiers, and the sandbox
-// record tracked by a node.
+// Package types defines the shared vocabulary of the sandbox control plane.
 package types
 
 import (
@@ -23,9 +21,6 @@ const (
 	SizeLarge  Size = "large"
 	SizeXLarge Size = "xlarge"
 
-	BackendCH Backend = "ch"
-	BackendFC Backend = "fc"
-
 	RestoreCopy     RestoreMode = "copy"
 	RestoreOnDemand RestoreMode = "ondemand"
 	RestoreMmap     RestoreMode = "mmap"
@@ -45,17 +40,14 @@ var (
 	}
 )
 
-// NetShape selects the sandbox network lane and derives the backend.
+// NetShape selects whether the Cloud Hypervisor guest has a NIC.
 type NetShape string
 
-// Backend names the hypervisor serving a lane.
-type Backend string
-
-// RestoreMode selects cocoon's CH clone memory-restore strategy; empty leaves
+// RestoreMode selects cocoon's clone memory-restore strategy; empty leaves
 // cocoon's eager-copy default.
 type RestoreMode string
 
-// Validate accepts the empty default plus cocoon's known CH restore modes.
+// Validate accepts the empty default plus cocoon's known restore modes.
 func (m RestoreMode) Validate() error {
 	switch m {
 	case "", RestoreCopy, RestoreOnDemand, RestoreMmap:
@@ -89,16 +81,6 @@ type PoolKey struct {
 	Size     Size     `json:"size"`
 }
 
-// Backend derives the hypervisor lane: FC serves the no-network lane (faster
-// restore, minimal device model, and none of FC's clone restrictions apply
-// without a NIC); CH serves the full-featured egress lane.
-func (k PoolKey) Backend() Backend {
-	if k.Net == NetNone {
-		return BackendFC
-	}
-	return BackendCH
-}
-
 // Capturable reports whether state capture (fork, checkpoint, promote) is
 // allowed: the egress lane refuses it — a resumed capture opens an
 // unlocked-NIC window before the tap lock can reapply.
@@ -106,8 +88,8 @@ func (k PoolKey) Capturable() bool {
 	return k.Net != NetEgress
 }
 
-// Defaulted fills the wire defaults: the hardened lane (net none → FC) and
-// the smallest tier — the one home for both the claim and pool-spec paths.
+// Defaulted fills the wire defaults: the hardened no-NIC lane and the smallest
+// tier — the one home for both the claim and pool-spec paths.
 func (k PoolKey) Defaulted() PoolKey {
 	k.Net = cmp.Or(k.Net, NetNone)
 	k.Size = cmp.Or(k.Size, SizeSmall)

--- a/scripts/boot-bench.sh
+++ b/scripts/boot-bench.sh
@@ -103,7 +103,7 @@ run_once() {
   done
   local layers_csv
   layers_csv=$(IFS=,; echo "${ids[*]}")
-  local cmdline="console=ttyS0 loglevel=3 reboot=k clocksource=kvm-clock rw cocoon.layers=$layers_csv cocoon.cow=cow $EXTRA_CMDLINE"
+  local cmdline="console=hvc0 loglevel=3 clocksource=kvm-clock rw cocoon.layers=$layers_csv cocoon.cow=cow $EXTRA_CMDLINE"
 
   local vsock_args=()
   [ -n "$AGENT_PORT" ] && vsock_args=(--vsock "cid=$VSOCK_CID,socket=$vsock")
@@ -113,13 +113,13 @@ run_once() {
   "$CH_BIN" --cpus "boot=$CPUS" --memory "size=$MEM" \
     --kernel "$KERNEL" --initramfs "$INITRD" --cmdline "$cmdline" \
     "${disk_args[@]}" --disk "path=$cow,image_type=raw,serial=cow" \
-    --serial "file=$log" --console off "${vsock_args[@]}" >"$work/ch.log" 2>&1 &
+    --serial off --console "file=$log" "${vsock_args[@]}" >"$work/ch.log" 2>&1 &
   ch=$!
 
   local deadline line k_init k_handoff
   deadline=$(($(date +%s) + 30))
   # Patterns include the terminated uptime number: CH writes the emulated
-  # UART byte-wise, so a bare-prefix match could grab a half-flushed line.
+  # console byte-wise, so a bare-prefix match could grab a half-flushed line.
   line=$(wait_line "$log" 'sandbox-init: start at [0-9.]+s' "$deadline") \
     || { keep=1; echo "run $n: sandbox-init start marker never appeared (logs kept in $work)"; return 1; }
   k_init=$(echo "$line" | grep -oE 'at [0-9.]+s' | grep -oE '[0-9.]+')

--- a/sdk/go/proc.go
+++ b/sdk/go/proc.go
@@ -1,6 +1,7 @@
 package sandbox
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"io"
@@ -66,12 +67,8 @@ func (s *Sandbox) drainProc(ctx context.Context, req wire.Request, stdout, stder
 		return 0, false, err
 	}
 	defer done()
-	if stdout == nil {
-		stdout = io.Discard
-	}
-	if stderr == nil {
-		stderr = io.Discard
-	}
+	stdout = cmp.Or(stdout, io.Writer(io.Discard))
+	stderr = cmp.Or(stderr, io.Writer(io.Discard))
 	for {
 		resp, err := recv(ctx, conn)
 		if err != nil {

--- a/sdk/go/proc.go
+++ b/sdk/go/proc.go
@@ -67,8 +67,8 @@ func (s *Sandbox) drainProc(ctx context.Context, req wire.Request, stdout, stder
 		return 0, false, err
 	}
 	defer done()
-	stdout = cmp.Or(stdout, io.Writer(io.Discard))
-	stderr = cmp.Or(stderr, io.Writer(io.Discard))
+	stdout = cmp.Or(stdout, io.Discard)
+	stderr = cmp.Or(stderr, io.Discard)
 	for {
 		resp, err := recv(ctx, conn)
 		if err != nil {

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -111,8 +111,8 @@ func (s *Sandbox) Run(ctx context.Context, cmd Cmd) (int, error) {
 		go pumpStdin(conn, cmd.Stdin)
 	}
 
-	stdout := cmp.Or(cmd.Stdout, io.Writer(io.Discard))
-	stderr := cmp.Or(cmd.Stderr, io.Writer(io.Discard))
+	stdout := cmp.Or(cmd.Stdout, io.Discard)
+	stderr := cmp.Or(cmd.Stderr, io.Discard)
 	for {
 		resp, err := recv(ctx, conn)
 		if err != nil {

--- a/sdk/go/sandbox.go
+++ b/sdk/go/sandbox.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"io"
@@ -110,13 +111,8 @@ func (s *Sandbox) Run(ctx context.Context, cmd Cmd) (int, error) {
 		go pumpStdin(conn, cmd.Stdin)
 	}
 
-	stdout, stderr := cmd.Stdout, cmd.Stderr
-	if stdout == nil {
-		stdout = io.Discard
-	}
-	if stderr == nil {
-		stderr = io.Discard
-	}
+	stdout := cmp.Or(cmd.Stdout, io.Writer(io.Discard))
+	stderr := cmp.Or(cmd.Stderr, io.Writer(io.Discard))
 	for {
 		resp, err := recv(ctx, conn)
 		if err != nil {

--- a/sdk/go/silkd/silkdtest/fake.go
+++ b/sdk/go/silkd/silkdtest/fake.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"io"
 	"io/fs"
+	"maps"
 	"net"
 	"os"
 	"path/filepath"
@@ -257,10 +258,7 @@ func (f *Fake) sessionCreate(conn net.Conn, req *wire.SessionCreate) {
 
 func (f *Fake) sessionList(conn net.Conn) {
 	f.mu.Lock()
-	ids := make([]string, 0, len(f.sessions))
-	for id := range f.sessions {
-		ids = append(ids, id)
-	}
+	ids := slices.Collect(maps.Keys(f.sessions))
 	f.mu.Unlock()
 	send(conn, &wire.Sessions{Sessions: ids})
 }

--- a/sdk/go/silkd/silkdtest/silkdtest.go
+++ b/sdk/go/silkd/silkdtest/silkdtest.go
@@ -1,5 +1,5 @@
 // Package silkdtest fakes a silkd daemon for host-side tests: deterministic
-// frame semantics over any listener, plus the CH/FC hybrid-vsock muxer
+// frame semantics over any listener, plus the hybrid-vsock muxer
 // handshake for tests that dial a UDS the way sandboxd does.
 package silkdtest
 

--- a/silkd/src/vsock.rs
+++ b/silkd/src/vsock.rs
@@ -1,5 +1,5 @@
 //! vsock listener. On Linux silkd binds the guest's hybrid-vsock port and
-//! serves each connection; the host (sandboxd) reaches it through the CH/FC
+//! serves each connection; the host (sandboxd) reaches it through the VMM
 //! muxer's `CONNECT <port>` handshake, which the VMM answers — silkd sees a
 //! plain byte stream. Off Linux the crate still builds (host tooling, tests)
 //! with a stub so `cargo test` runs everywhere.


### PR DESCRIPTION
Closes #47

## Summary

- run both `none` and `egress` lanes on Cloud Hypervisor, removing the alternate backend and its boot, runtime, configuration, and documentation paths
- add node-level `no_direct_io`; pass an explicit value to cold boots and both clone forms, and apply restore mode to both lanes
- pipeline refill clone and readiness work through separate R-sized gates with 2R total in flight, and widen VM suffixes to 48 bits
- mark Cloud Hypervisor goldens, update Android none-lane coverage, and document the C1M deployment and upgrade recipe

## Compatibility

This is a breaking Cloud Hypervisor-only migration. Drain old claims and use fresh `data_dir` and `checkpoint_dir`; old checkpoints and promoted templates are not converted.

## Validation

- `go test -race ./...` in all five Go modules
- `golangci-lint run --new-from-rev=origin/main ./...` on sandboxd and e2e for Linux and Darwin
- Rust fmt, tests, and clippy for boot/init and silkd
- `bash -n scripts/boot-bench.sh`
- `docker build --check --platform linux/amd64 -f boot/Dockerfile boot`
- tracked source and documentation keyword scan: zero old-backend references

## Follow-up rounds on this branch

- wake restores now carry the node `restore_mode` (restore stages a private run-dir copy, so dropping the snapshot right after the wake is safe in every mode)
- golden `.runtime` marker removed — no pre-CH goldens exist under the fresh-`data_dir` upgrade contract, so the guard was unreachable
- review cut round: legacy-template migration dropped (same unreachable-under-contract argument), HTTP handler result tails deduped, `cmp.Or` defaults, redundant size guard removed (−178 lines net)

## Hardware validation (bare metal, 16c/60G, cocoon master-e9502f6, CH fork dev d77dcf12)

- `sandboxd-e2e.sh` full regression, both lanes: **PASS** (warm claim 0.2–0.6 ms, exec RTT 1.7–3.7 ms)
- boot-bench on a kernel built from this branch's config (no 8250/MMIO, hvc0 console): boots clean, kernel→init 40–50 ms, spawn→silkd median ~151 ms — no latency delta vs the published kernel
- hibernate/wake N=5: hibernate 168–272 ms; restore eager median ~65 ms, `mmap` median ~55 ms with the snapshot deleted immediately after each restore, 5 consecutive cycles healthy
- warm fill: golden build 0.8 s, 16 warm in 1.9 s at `refill_concurrency: 8` with `restore_mode: mmap` + `no_direct_io`
- full tier/data-plane tables appended to `docs/benchmarks.md` (2026-07-22 entry)
