### PR TITLE
ci: bump pinned actions to current majors

### DIFF
--- a/.github/workflows/build-boot.yml
+++ b/.github/workflows/build-boot.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: sandbox-init tests
         working-directory: boot/init
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Read kernel version
         id: ver
@@ -89,7 +89,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: boot-digests-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -103,7 +103,7 @@ jobs:
       image: ${{ steps.ref.outputs.image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Read kernel version
         id: ver
@@ -116,7 +116,7 @@ jobs:
         run: echo "image=ghcr.io/${{ github.repository }}/boot:$(cat boot/kernel/VERSION)-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: boot-digests-*
           path: /tmp/digests

--- a/.github/workflows/build-os-images.yml
+++ b/.github/workflows/build-os-images.yml
@@ -53,7 +53,7 @@ jobs:
       flavor_matrix: ${{ steps.set-matrix.outputs.flavor_matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -162,7 +162,7 @@ jobs:
       matrix: ${{ fromJson(needs.detect.outputs.base_matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Read versions
         id: ver
@@ -255,7 +255,7 @@ jobs:
       matrix: ${{ fromJson(needs.detect.outputs.flavor_matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/build-silkd.yml
+++ b/.github/workflows/build-silkd.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: fmt + clippy + test
         working-directory: silkd
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -83,7 +83,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: silkd-digests-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -97,7 +97,7 @@ jobs:
       image: ${{ steps.ref.outputs.image }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Read silkd version
         id: ver
@@ -109,7 +109,7 @@ jobs:
         run: echo "image=ghcr.io/${{ github.repository }}/silkd:${{ steps.ver.outputs.version }}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: silkd-digests-*
           path: /tmp/digests

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -39,7 +39,7 @@ jobs:
       osimage: ${{ steps.diff.outputs.osimage }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -27,7 +27,7 @@ jobs:
       id-token: write # OIDC for PyPI Trusted Publishing
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Resolve package dir from the tag
         id: pkg
@@ -44,7 +44,7 @@ jobs:
           echo "version=$ver" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,8 +19,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install tooling

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: sandboxd/go.mod
       - name: Build silkd (musl static)
@@ -47,7 +47,7 @@ jobs:
           tar -C /tmp/silkd-dist -czf "dist-extra/silkd_${GITHUB_REF_NAME#v}_Linux_arm64.tar.gz" silkd
           tar -C /tmp/silkd-dist -czf "dist-extra/silkd_Linux_arm64.tar.gz" silkd
       - name: goreleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           args: release --clean
         env:

--- a/.github/workflows/sandboxd.yml
+++ b/.github/workflows/sandboxd.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: sandboxd/go.mod
 

--- a/.github/workflows/silkd.yml
+++ b/.github/workflows/silkd.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: fmt + clippy + test
         working-directory: silkd


### PR DESCRIPTION
Part of an org-wide CI/CD refresh: pinned action versions had drifted apart across repos. Each target is the current `latest` release major, read from `gh api repos/<action>/releases/latest` rather than assumed.

Note `actions/download-artifact` goes to v8 alongside `upload-artifact` v7 — the two have to move together or the download side cannot read the uploaded artifact.

## Gates

CI is the gate here: this repo has no Go module / no cargo toolchain on the authoring machine, so the workflows themselves are what proves the bump. Merging on green.