### PR TITLE
ci: pin the rust toolchain for silkd and boot/init

### DIFF
--- a/.github/workflows/build-boot.yml
+++ b/.github/workflows/build-boot.yml
@@ -33,7 +33,6 @@ jobs:
       - name: sandbox-init tests
         working-directory: boot/init
         run: |
-          rustup component add rustfmt clippy
           cargo fmt --check
           cargo clippy --all-targets -- -D warnings
           cargo test

--- a/.github/workflows/build-silkd.yml
+++ b/.github/workflows/build-silkd.yml
@@ -33,7 +33,6 @@ jobs:
       - name: fmt + clippy + test
         working-directory: silkd
         run: |
-          rustup component add rustfmt clippy
           cargo fmt --check
           cargo clippy --all-targets -- -D warnings
           cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
           go-version-file: sandboxd/go.mod
       - name: Build silkd (musl static)
         run: |
-          rustup target add x86_64-unknown-linux-musl
           sudo apt-get update && sudo apt-get install -y --no-install-recommends musl-tools
           (cd silkd && cargo build --release --target x86_64-unknown-linux-musl)
           strip silkd/target/x86_64-unknown-linux-musl/release/silkd

--- a/.github/workflows/silkd.yml
+++ b/.github/workflows/silkd.yml
@@ -28,7 +28,6 @@ jobs:
       - name: fmt + clippy + test
         working-directory: silkd
         run: |
-          rustup component add rustfmt clippy
           cargo fmt --check
           cargo clippy --all-targets -- -D warnings
           cargo test

--- a/boot/init/rust-toolchain.toml
+++ b/boot/init/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/silkd/rust-toolchain.toml
+++ b/silkd/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]
+targets = ["x86_64-unknown-linux-musl"]
+profile = "minimal"


### PR DESCRIPTION
`silkd` and `boot/init` had no toolchain declaration anywhere: the workflows call `cargo` directly and take whatever Rust the GitHub runner image ships. That version moves whenever GitHub refreshes the image, nothing records which one built a given release, and a local `make test` can silently use a different compiler than CI.

Both crates are `edition = "2024"` with `rust-version = "1.85"` — a floor, not a build version.

## Change

A `rust-toolchain.toml` per crate (they are independent crates, not a workspace), tracking `stable`:

- `silkd/` — adds `rustfmt`, `clippy`, and the `x86_64-unknown-linux-musl` target
- `boot/init/` — adds `rustfmt`, `clippy`

`cargo` reads these automatically, so CI and local builds resolve the same toolchain with no workflow plumbing.

The `rustup component add` / `rustup target add` lines the workflows ran by hand are now redundant and removed. `musl-tools` stays: that is the C toolchain for the musl link, which rustup does not provide.

## Why `stable` rather than a fixed version

Matches `gateway`, the other Rust repo in the org. Pinning an exact version would be more reproducible but needs a human to move it; if you'd rather have that, the channel is a one-line change.

## Gates

CI is the gate — no cargo on the authoring machine. The clippy/fmt/test jobs in `build-silkd`, `build-boot` and `silkd` exercise the new resolution path, and `release.yml`'s musl build exercises the target declaration.