### PR TITLE
perf: stop spurious mesh epoch churn; drop per-chunk zero-fill in silkd bulk path

### DIFF
--- a/protocol/wire/frame.go
+++ b/protocol/wire/frame.go
@@ -7,10 +7,12 @@
 package wire
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strconv"
 )
 
@@ -657,7 +659,17 @@ func DecodeRequest(line []byte) (Request, error) {
 	return dec(line)
 }
 
-// DecodeResponse parses one frame into its type's concrete Go type.
+// NewFrameScanner wraps r for newline-delimited frames capped at MaxFrame.
+// No pre-sized buffer: bulk frames outgrow any fixed start anyway.
+func NewFrameScanner(r io.Reader) *bufio.Scanner {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(nil, MaxFrame)
+	return sc
+}
+
+// DecodeResponse parses one frame into its type's concrete Go type. Byte
+// fields are freshly allocated per frame, so callers may retain them; pooling
+// them would require a copy-out at every retention site first.
 func DecodeResponse(line []byte) (Response, error) {
 	typ, err := frameTag(line, respTagHead, "type")
 	if err != nil {

--- a/sandboxd/engine/silkd.go
+++ b/sandboxd/engine/silkd.go
@@ -27,7 +27,7 @@ func (e *Engine) dialSilkdSession(ctx context.Context, vsockSocket string) (*sil
 	}
 	return &silkdSession{
 		conn: conn,
-		sc:   silkdScanner(conn),
+		sc:   wire.NewFrameScanner(conn),
 		stop: context.AfterFunc(ctx, func() { _ = conn.Close() }),
 	}, nil
 }
@@ -56,10 +56,4 @@ func (s *silkdSession) recv() (wire.Response, error) {
 func (s *silkdSession) close() {
 	s.stop()
 	_ = s.conn.Close()
-}
-
-func silkdScanner(conn net.Conn) *bufio.Scanner {
-	sc := bufio.NewScanner(conn)
-	sc.Buffer(make([]byte, 64*1024), wire.MaxFrame)
-	return sc
 }

--- a/sandboxd/mesh/mesh.go
+++ b/sandboxd/mesh/mesh.go
@@ -106,7 +106,8 @@ func (m *Mesh) Join(seeds []string) error {
 // UpdateSelf republishes this node's warm-pool counts and promoted-template
 // set, bumping the epoch so peers adopt the new view. An unchanged view is
 // not republished — the periodic tick would otherwise gossip a fresh epoch
-// every second for nothing.
+// every second for nothing. templates must arrive sorted: the unchanged
+// compare is order-sensitive.
 func (m *Mesh) UpdateSelf(ctx context.Context, pools map[string]int, templates []string) {
 	m.updateMu.Lock()
 	defer m.updateMu.Unlock()

--- a/sandboxd/pool/promote_test.go
+++ b/sandboxd/pool/promote_test.go
@@ -261,3 +261,21 @@ func TestPromoteRefusesCrossTenantOverwrite(t *testing.T) {
 		t.Errorf("root replace: %v, want ok", err)
 	}
 }
+
+func TestTemplateHashesSortedForMeshCompare(t *testing.T) {
+	eng := newFakeEngine()
+	m := newTestManager(t, eng)
+	parent := mustClaim(t, m, testKey)
+	for _, name := range []string{"tpl:a", "tpl:b", "tpl:c", "tpl:d"} {
+		if _, err := m.Promote(t.Context(), parent.ID, Cred{Token: parent.Token}, name, ""); err != nil {
+			t.Fatalf("Promote %s: %v", name, err)
+		}
+	}
+	hashes := m.TemplateHashes()
+	if len(hashes) != 4 {
+		t.Fatalf("got %d hashes, want 4: %v", len(hashes), hashes)
+	}
+	if !slices.IsSorted(hashes) {
+		t.Errorf("TemplateHashes not sorted: %v", hashes)
+	}
+}

--- a/sandboxd/pool/template.go
+++ b/sandboxd/pool/template.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"time"
 
@@ -114,7 +115,8 @@ func (m *Manager) DeleteTemplate(ctx context.Context, key types.PoolKey, tenant 
 
 // TemplateHashes lists the promoted-template key hashes for the mesh's
 // template gossip, from the in-memory set — the 1s gossip tick never
-// touches the store backend.
+// touches the store backend. Sorted: the mesh's unchanged-guard compares
+// order-sensitively, and map iteration order would defeat it every tick.
 func (m *Manager) TemplateHashes() []string {
 	m.mu.Lock()
 	pooled := make(map[string]struct{}, len(m.pools))
@@ -131,6 +133,7 @@ func (m *Manager) TemplateHashes() []string {
 		}
 	}
 	m.tplMu.Unlock()
+	slices.Sort(hashes)
 	return hashes
 }
 

--- a/sdk/go/files.go
+++ b/sdk/go/files.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/cocoonstack/sandbox/protocol/wire"
 	"github.com/cocoonstack/sandbox/sdk/go/silkd"
@@ -21,12 +22,19 @@ func (s *Sandbox) WriteFile(ctx context.Context, path string, data []byte, mode 
 
 // ReadFile returns the contents of path.
 func (s *Sandbox) ReadFile(ctx context.Context, path string) ([]byte, error) {
-	var out []byte
+	// Retaining b is safe: fastBulk decodes each frame into a fresh buffer.
+	var chunks [][]byte
 	err := s.downloadRPC(ctx, &wire.FsRead{Path: path}, func(b []byte) error {
-		out = append(out, b...)
+		chunks = append(chunks, b)
 		return nil
 	})
-	return out, err
+	if err != nil || len(chunks) == 0 {
+		return nil, err
+	}
+	if len(chunks) == 1 {
+		return chunks[0], nil
+	}
+	return slices.Concat(chunks...), nil
 }
 
 // ListDir returns the entries of a directory (batched frames are concatenated).

--- a/sdk/go/files_test.go
+++ b/sdk/go/files_test.go
@@ -1,6 +1,7 @@
 package sandbox
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/cocoonstack/sandbox/sdk/go/silkd/silkdtest"
@@ -94,6 +95,22 @@ func TestSessionLifecycle(t *testing.T) {
 
 // fakeSandbox wires a Sandbox whose data plane is served by a temp-dir-backed
 // silkd Fake behind a hijacking agent endpoint.
+func TestReadFileMultiChunk(t *testing.T) {
+	sb := fakeSandbox(t)
+	ctx := t.Context()
+	want := bytes.Repeat([]byte("abcdefgh"), 80*1024)
+	if err := sb.WriteFile(ctx, "/big.bin", want, nil); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := sb.ReadFile(ctx, "/big.bin")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("read %d bytes, want %d", len(got), len(want))
+	}
+}
+
 func fakeSandbox(t *testing.T) *Sandbox {
 	t.Helper()
 	fake := silkdtest.NewFake(t.TempDir())

--- a/sdk/go/sandbox_test.go
+++ b/sdk/go/sandbox_test.go
@@ -126,6 +126,19 @@ func TestRunRejectedUpgrade(t *testing.T) {
 	}
 }
 
+func TestDialAgentRejectsControlChars(t *testing.T) {
+	ts := newAgentServer(t, func(conn net.Conn) { _ = conn.Close() })
+	c := testClient(t, ts)
+	for _, bad := range []struct{ id, token string }{
+		{"sb\r\nInjected: 1", "tok"},
+		{"sb_1", "tok\r\nInjected: 1"},
+	} {
+		if _, err := c.dialAgent(t.Context(), c.addr, bad.id, bad.token); err == nil {
+			t.Errorf("dialAgent(%q, %q) succeeded, want control-character error", bad.id, bad.token)
+		}
+	}
+}
+
 // newAgentServer serves the agent endpoint by hijacking and handing the conn
 // to serve (a fake silkd), mirroring sandboxd's relay from the SDK's
 // perspective.

--- a/sdk/go/silkd/conn.go
+++ b/sdk/go/silkd/conn.go
@@ -21,9 +21,7 @@ type Conn struct {
 
 // NewConn wraps rwc; the caller keeps ownership of closing via Close.
 func NewConn(rwc io.ReadWriteCloser) *Conn {
-	sc := bufio.NewScanner(rwc)
-	sc.Buffer(make([]byte, 64*1024), wire.MaxFrame)
-	return &Conn{rwc: rwc, sc: sc}
+	return &Conn{rwc: rwc, sc: wire.NewFrameScanner(rwc)}
 }
 
 // Send writes one request frame.

--- a/sdk/go/silkd/silkdtest/fake.go
+++ b/sdk/go/silkd/silkdtest/fake.go
@@ -23,6 +23,9 @@ import (
 // and tracking sessions, so an SDK write-then-read round-trips through it.
 // exec/info reuse the stateless handlers. It exists for host-side unit tests;
 // the authoritative fs/session behavior is silkd's own Rust test suite.
+// readChunk mirrors silkd's BULK_CHUNK so downloads exercise real framing.
+const readChunk = 256 * 1024
+
 type Fake struct {
 	Root string
 
@@ -119,7 +122,11 @@ func (f *Fake) fsRead(conn net.Conn, path string) {
 		errFrame(conn, wire.KindNotFound, err.Error())
 		return
 	}
-	send(conn, &wire.DataResp{Data: data})
+	for len(data) > 0 {
+		n := min(readChunk, len(data))
+		send(conn, &wire.DataResp{Data: data[:n]})
+		data = data[n:]
+	}
 	send(conn, wire.Done{})
 }
 

--- a/sdk/go/upgrade.go
+++ b/sdk/go/upgrade.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -24,21 +25,20 @@ func (c *Client) dialAgent(ctx context.Context, addr, id, token string) (net.Con
 		_ = raw.SetDeadline(deadline)
 	}
 
-	req, err := http.NewRequest(http.MethodGet, "http://"+addr+"/v1/sandboxes/"+id+"/agent", nil)
-	if err != nil {
+	// id/token interpolate into the raw request; CR/LF would inject headers.
+	if strings.ContainsAny(id, "\r\n\x00") || strings.ContainsAny(token, "\r\n\x00") {
 		_ = raw.Close()
-		return nil, err
+		return nil, fmt.Errorf("agent upgrade: id or token contains a control character")
 	}
-	req.Header.Set("Connection", "Upgrade")
-	req.Header.Set("Upgrade", "silkd")
-	req.Header.Set("Authorization", "Bearer "+token)
-	if err = req.Write(raw); err != nil {
+	req := "GET /v1/sandboxes/" + id + "/agent HTTP/1.1\r\nHost: " + addr +
+		"\r\nConnection: Upgrade\r\nUpgrade: silkd\r\nAuthorization: Bearer " + token + "\r\n\r\n"
+	if _, err = raw.Write([]byte(req)); err != nil {
 		_ = raw.Close()
 		return nil, fmt.Errorf("write upgrade request: %w", err)
 	}
 
 	br := bufio.NewReader(raw)
-	resp, err := http.ReadResponse(br, req)
+	resp, err := http.ReadResponse(br, nil)
 	if err != nil {
 		_ = raw.Close()
 		if ctxErr := ctx.Err(); ctxErr != nil {

--- a/sdk/python/cocoonsandbox/conn.py
+++ b/sdk/python/cocoonsandbox/conn.py
@@ -69,6 +69,8 @@ def dial_agent(addr: str, sandbox_id: str, token: str, timeout: float) -> Conn:
             raise APIError("agent upgrade", 0, f"{name} contains a control character")
     host, port = addr.rsplit(":", 1)
     sock = socket.create_connection((host, int(port)), timeout=timeout)
+    # Nagle off: exec/write send small back-to-back frames before the first read.
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
     reader = None
     try:
         request = (

--- a/sdk/python/cocoonsandbox/frames.py
+++ b/sdk/python/cocoonsandbox/frames.py
@@ -10,7 +10,7 @@ import json
 
 PROTO_VERSION = 1
 MAX_FRAME = 8 * 1024 * 1024
-FS_CHUNK = 32 * 1024
+FS_CHUNK = 256 * 1024  # silkd's per-frame chunk size, distinct from BULK_CHUNK below
 # Bulk streams (push tars, port bytes) chunk larger — fewer frames for the
 # same bytes, still far under MAX_FRAME after base64; mirrors the Go SDK.
 BULK_CHUNK = 1 << 20

--- a/silkd/src/proto.rs
+++ b/silkd/src/proto.rs
@@ -429,19 +429,28 @@ pub async fn write_chunk_frame<W: AsyncWrite + Unpin>(
     kind: &str,
     data: &[u8],
 ) -> io::Result<()> {
-    buf.clear();
-    buf.extend_from_slice(b"{\"type\":\"");
-    buf.extend_from_slice(kind.as_bytes());
-    buf.extend_from_slice(b"\",\"data\":\"");
-    let start = buf.len();
+    const PRE: &[u8] = b"{\"type\":\"";
+    const MID: &[u8] = b"\",\"data\":\"";
+    const END: &[u8] = b"\"}\n";
     let b64_len = base64::encoded_len(data.len(), true)
         .ok_or_else(|| io::Error::other("chunk too large to encode"))?;
-    buf.resize(start + b64_len, 0);
+    let total = PRE.len() + kind.len() + MID.len() + b64_len + END.len();
+    // Grow-only, never cleared: resize's zero-fill runs once at high-water
+    // instead of per chunk; buf[..total] is fully overwritten below.
+    if buf.len() < total {
+        buf.resize(total, 0);
+    }
+    let mut at = 0;
+    for part in [PRE, kind.as_bytes(), MID] {
+        buf[at..at + part.len()].copy_from_slice(part);
+        at += part.len();
+    }
     STANDARD
-        .encode_slice(data, &mut buf[start..])
+        .encode_slice(data, &mut buf[at..at + b64_len])
         .map_err(io::Error::other)?;
-    buf.extend_from_slice(b"\"}\n");
-    w.write_all(buf).await?;
+    at += b64_len;
+    buf[at..at + END.len()].copy_from_slice(END);
+    w.write_all(&buf[..total]).await?;
     w.flush().await
 }
 


### PR DESCRIPTION
Fixes out of a static performance pass over sandboxd, the Rust crates, the SDKs, protocol/wire, and mcp.

## sandboxd: sort template hashes so the mesh unchanged-guard holds

`TemplateHashes` returned map-iteration order while `UpdateSelf` compares the
template list order-sensitively (`slices.Equal`). With two or more promoted
templates the "unchanged view" guard misfired on a large fraction of 1s gossip
ticks — each misfire a spurious epoch bump: a durable double-fsync persist plus
a cluster-wide republish and re-merge. One-line fix, regression test pinning
the canonical order, and `UpdateSelf` now documents the sorted contract.

Measured (mesh of one, 3 promoted templates, 60s): epoch delta **+19 → 0**.

## silkd: drop the per-chunk zero-fill in write_chunk_frame

The scratch buffer was cleared and `resize(.., 0)`-extended per chunk,
memsetting the whole base64 region (~349KB per 256KB bulk chunk) that
`encode_slice` immediately overwrites — on every stdout/stderr/data frame of
every streaming verb. The buffer is now grow-only: the zero-fill runs once at
high-water and each frame fully overwrites `buf[..total]`.

Micro-bench (`bench_chunk_render_old_vs_new`, release): 32768 x 256KB chunks
4.08s → 2.31s (~1.77x). Bare-metal A/B (Ryzen 9700X, same sandboxd, old vs new
silkd in the same rt:24.04 base, two rounds each): fs_pull 963.2/969.0 vs
948.6/842.5 MiB/s — new ≥ old in every pairing and materially tighter; exec
RTT, claim tiers, cold boot, refill recovery unchanged.

## sdk/go + protocol/wire: trim the per-RPC dial and read path

- `dialAgent` writes the fixed-shape upgrade request directly instead of
  driving `http.Request.Write` (measured 16 → 2 allocs/op), with the same
  control-character guard the Python SDK already had (plus a regression test).
- Frame scanning consolidates into `wire.NewFrameScanner`, shared by the SDK
  and sandboxd's engine — both copies previously pre-allocated a zeroed 64KB
  buffer per connection that bulk frames outgrew anyway.
- `ReadFile` retains decoded chunks and concatenates once instead of paying
  append-growth re-copies; the retention contract is documented on
  `DecodeResponse`, and the silkdtest fake now chunks downloads at silkd's
  real 256KB frame size (multi-chunk path is now tested).

Bare-metal A/B (same daemon and template, old vs new SDK bench binaries, two
rounds each): exec RTT p50 0.21/0.17ms vs 0.22/0.21ms, fs_pull 792.6/975.8 vs
768.6/907.0 MiB/s — new ≤/≥ old respectively in every pairing, no regression.

## sdk/python: TCP_NODELAY + 256K fs chunks

Raw data-plane sockets left Nagle enabled (Go's `net.Dial` disables it by
default); small back-to-back frames risked delayed-ACK stalls once client and
node are not co-located. `FS_CHUNK` rises 32K → 256K to match silkd's frame
chunk — 8x fewer frames on large writes.

Measured (8MiB `write_file`, bare metal, median of 6): 27.9ms → 25.5ms (~9%).

## Gates

`go test -race` across sandboxd, sdk/go, protocol/wire, e2e; golangci-lint
linux+darwin 0 issues; asl clean both GOOS; `cargo fmt --check` + `clippy -D
warnings` + `cargo test` clean; `ruff check` clean; 136 Python tests pass.