### PR TITLE
Back a warm pool off after an unbroken run of failed refills

### DIFF
--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -45,18 +45,12 @@ const (
 	maxTTL             = 24 * time.Hour
 	recommitBackoff    = 20 * time.Millisecond
 	recommitMaxBackoff = 5 * time.Second
-	// refillFailStreak is how many refills must fail back-to-back, with no
-	// success between them, before a pool backs off. A single failure is
-	// ordinary — one VM does not boot — and stalling the pool for it would
-	// trade a lost VM for a stalled pool. Only an unbroken streak says the
+	// One failed boot is ordinary; only an unbroken run of failures says the
 	// next attempt will fail too.
 	refillFailStreak = 8
-	// refillBackoffBase/Max bound the wait after that streak, doubling per
-	// further failure. The ceiling matches buildRetryDelay: long enough that
-	// retrying a persistent failure costs nothing, short enough that a node
-	// recovering is picked up promptly.
+	// Doubles per failure past the streak.
 	refillBackoffBase = 250 * time.Millisecond
-	refillBackoffMax  = 30 * time.Second
+	refillBackoffMax  = buildRetryDelay
 	// defaultMaxFork/defaultRefill are the fallbacks when a Manager is built
 	// from a Config that skipped config.Load's defaulting (direct construction
 	// in tests).
@@ -164,20 +158,20 @@ type pool struct {
 	warm      []*types.Sandbox
 	refilling int
 
-	// refillFails counts refills that failed back-to-back and nextRefill is
-	// when the pool may try again. Without them a pool short of target retries
-	// every tick at full concurrency for as long as the cause lasts, which for
-	// anything node-wide — a bridge at its port limit, a full disk — is
-	// indefinite: each attempt still forks the engine and runs the CNI plugins
-	// before failing, so the retries cost more than the work they replace.
+	// An unbroken failure streak and the retry gate it earns; without them a
+	// node-wide dead cause is retried every tick at full concurrency.
 	refillFails int
 	nextRefill  time.Time
 }
 
-// noteRefillResult records one refill outcome and returns whether this call
-// started a backoff, so the caller can log the transition rather than every
-// attempt. A success clears the streak: pools recover without waiting out a
-// backoff earned by a burst that has passed.
+// refillGated reports whether a refill may not spawn: the backoff wait, or —
+// expired — the single probe already in flight (a success resets the streak).
+func (p *pool) refillGated(now time.Time) bool {
+	return now.Before(p.nextRefill) || (p.refillFails >= refillFailStreak && p.refilling > 0)
+}
+
+// noteRefillResult records one refill outcome and reports whether this call
+// started a backoff, so the caller logs the transition, not every attempt.
 func (p *pool) noteRefillResult(now time.Time, failed bool) bool {
 	if !failed {
 		p.refillFails, p.nextRefill = 0, time.Time{}

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -45,6 +45,18 @@ const (
 	maxTTL             = 24 * time.Hour
 	recommitBackoff    = 20 * time.Millisecond
 	recommitMaxBackoff = 5 * time.Second
+	// refillFailStreak is how many refills must fail back-to-back, with no
+	// success between them, before a pool backs off. A single failure is
+	// ordinary — one VM does not boot — and stalling the pool for it would
+	// trade a lost VM for a stalled pool. Only an unbroken streak says the
+	// next attempt will fail too.
+	refillFailStreak = 8
+	// refillBackoffBase/Max bound the wait after that streak, doubling per
+	// further failure. The ceiling matches buildRetryDelay: long enough that
+	// retrying a persistent failure costs nothing, short enough that a node
+	// recovering is picked up promptly.
+	refillBackoffBase = 250 * time.Millisecond
+	refillBackoffMax  = 30 * time.Second
 	// defaultMaxFork/defaultRefill are the fallbacks when a Manager is built
 	// from a Config that skipped config.Load's defaulting (direct construction
 	// in tests).
@@ -151,6 +163,34 @@ type pool struct {
 	removed   bool // dropped from the desired set while building/refilling; swept by refillOnce
 	warm      []*types.Sandbox
 	refilling int
+
+	// refillFails counts refills that failed back-to-back and nextRefill is
+	// when the pool may try again. Without them a pool short of target retries
+	// every tick at full concurrency for as long as the cause lasts, which for
+	// anything node-wide — a bridge at its port limit, a full disk — is
+	// indefinite: each attempt still forks the engine and runs the CNI plugins
+	// before failing, so the retries cost more than the work they replace.
+	refillFails int
+	nextRefill  time.Time
+}
+
+// noteRefillResult records one refill outcome and returns whether this call
+// started a backoff, so the caller can log the transition rather than every
+// attempt. A success clears the streak: pools recover without waiting out a
+// backoff earned by a burst that has passed.
+func (p *pool) noteRefillResult(now time.Time, failed bool) bool {
+	if !failed {
+		p.refillFails, p.nextRefill = 0, time.Time{}
+		return false
+	}
+	p.refillFails++
+	if p.refillFails < refillFailStreak {
+		return false
+	}
+	first := !now.Before(p.nextRefill)
+	backoff := refillBackoffBase << min(p.refillFails-refillFailStreak, 16)
+	p.nextRefill = now.Add(min(backoff, refillBackoffMax))
+	return first
 }
 
 func (p *pool) applySpec(spec config.PoolSpec) {

--- a/sandboxd/pool/refill.go
+++ b/sandboxd/pool/refill.go
@@ -55,7 +55,7 @@ func (m *Manager) refillOnce(ctx context.Context) {
 			if inFlight >= limit {
 				return
 			}
-			if p.removed || p.goldenDir == "" || now.Before(p.nextRefill) ||
+			if p.removed || p.goldenDir == "" || p.refillGated(now) ||
 				len(p.warm)+p.refilling >= p.effectiveTarget(now) {
 				continue
 			}
@@ -85,24 +85,30 @@ func (m *Manager) refillOne(ctx context.Context, p *pool, golden string) {
 		sb, err = m.readyBounded(ctx, sb, time.Now().Add(claimProbeTimeout))
 	}
 	keep := false
+	var fails int
+	var wait time.Duration
 	m.mu.Lock()
+	now := time.Now()
 	p.refilling--
-	if err == nil && !m.draining && len(p.warm) < p.effectiveTarget(time.Now()) {
+	if err == nil && !m.draining && len(p.warm) < p.effectiveTarget(now) {
 		p.warm = append(p.warm, sb)
 		p.noteLead(time.Since(start))
 		keep = true
 	}
 	// A canceled context is the daemon going down, not the pool failing.
-	backedOff := ctx.Err() == nil && p.noteRefillResult(time.Now(), err != nil)
-	wait := time.Until(p.nextRefill)
+	backedOff := ctx.Err() == nil && p.noteRefillResult(now, err != nil)
+	if backedOff {
+		fails, wait = p.refillFails, time.Until(p.nextRefill)
+	}
 	m.mu.Unlock()
 	if err != nil {
 		if ctx.Err() == nil {
-			log.WithFunc("pool.refillOne").Errorf(ctx, err, "refill %s", p.key.Hash())
+			hash := p.key.Hash()
+			log.WithFunc("pool.refillOne").Errorf(ctx, err, "refill %s", hash)
 			if backedOff {
 				log.WithFunc("pool.refillOne").Warnf(ctx,
 					"refill %s failed %d times running; pausing refill for %s",
-					p.key.Hash(), refillFailStreak, wait.Round(time.Millisecond))
+					hash, fails, wait.Round(time.Millisecond))
 			}
 		}
 		return

--- a/sandboxd/pool/refill.go
+++ b/sandboxd/pool/refill.go
@@ -55,7 +55,8 @@ func (m *Manager) refillOnce(ctx context.Context) {
 			if inFlight >= limit {
 				return
 			}
-			if p.removed || p.goldenDir == "" || len(p.warm)+p.refilling >= p.effectiveTarget(now) {
+			if p.removed || p.goldenDir == "" || now.Before(p.nextRefill) ||
+				len(p.warm)+p.refilling >= p.effectiveTarget(now) {
 				continue
 			}
 			select {
@@ -91,10 +92,18 @@ func (m *Manager) refillOne(ctx context.Context, p *pool, golden string) {
 		p.noteLead(time.Since(start))
 		keep = true
 	}
+	// A canceled context is the daemon going down, not the pool failing.
+	backedOff := ctx.Err() == nil && p.noteRefillResult(time.Now(), err != nil)
+	wait := time.Until(p.nextRefill)
 	m.mu.Unlock()
 	if err != nil {
 		if ctx.Err() == nil {
 			log.WithFunc("pool.refillOne").Errorf(ctx, err, "refill %s", p.key.Hash())
+			if backedOff {
+				log.WithFunc("pool.refillOne").Warnf(ctx,
+					"refill %s failed %d times running; pausing refill for %s",
+					p.key.Hash(), refillFailStreak, wait.Round(time.Millisecond))
+			}
 		}
 		return
 	}

--- a/sandboxd/pool/refillbackoff_test.go
+++ b/sandboxd/pool/refillbackoff_test.go
@@ -1,0 +1,120 @@
+package pool
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cocoonstack/sandbox/sandboxd/config"
+)
+
+// TestRefillBacksOffOnlyAfterAnUnbrokenRunOfFailures pins both halves of the
+// discriminator. One VM failing to boot is ordinary and must not stall the
+// pool; everything failing means the next attempt will fail too, and retrying
+// that at ticker rate is what turns a capacity limit into an outage.
+func TestRefillBacksOffOnlyAfterAnUnbrokenRunOfFailures(t *testing.T) {
+	p := &pool{}
+	now := time.Now()
+
+	for i := range refillFailStreak - 1 {
+		if p.noteRefillResult(now, true) {
+			t.Fatalf("backed off after %d failures, before the streak was reached", i+1)
+		}
+		if !p.nextRefill.IsZero() {
+			t.Fatalf("nextRefill set after %d failures", i+1)
+		}
+	}
+	if !p.noteRefillResult(now, true) {
+		t.Fatal("the failure completing the streak did not start a backoff")
+	}
+	if !p.nextRefill.After(now) {
+		t.Fatal("backoff started but nextRefill is not in the future")
+	}
+
+	// A success clears it: a pool must recover without waiting out a backoff
+	// earned by a burst that has already passed.
+	p.noteRefillResult(now, false)
+	if p.refillFails != 0 || !p.nextRefill.IsZero() {
+		t.Fatalf("a success left fails=%d nextRefill=%v", p.refillFails, p.nextRefill)
+	}
+
+	// And one straggler failure after that success starts from scratch.
+	if p.noteRefillResult(now, true) {
+		t.Fatal("a single failure after a success backed the pool off")
+	}
+}
+
+// TestBackoffGrowsAndIsCapped keeps a persistent failure from being retried
+// forever at the same rate, without letting the wait run away.
+func TestBackoffGrowsAndIsCapped(t *testing.T) {
+	p := &pool{}
+	now := time.Now()
+	var prev time.Duration
+	for i := range refillFailStreak + 40 {
+		p.noteRefillResult(now, true)
+		if i < refillFailStreak-1 {
+			continue
+		}
+		got := p.nextRefill.Sub(now)
+		if got < prev {
+			t.Fatalf("backoff shrank: %s then %s", prev, got)
+		}
+		if got > refillBackoffMax {
+			t.Fatalf("backoff %s exceeds the %s cap", got, refillBackoffMax)
+		}
+		prev = got
+	}
+	if prev != refillBackoffMax {
+		t.Errorf("backoff settled at %s, want the %s cap", prev, refillBackoffMax)
+	}
+}
+
+// TestRefillOnceHonorsTheBackoff is the property that actually saves the node:
+// while a pool is backed off, the ticker must spawn nothing. Without it a pool
+// short of target re-attempts every tick at full concurrency, and each attempt
+// forks the engine and runs the CNI plugins before failing.
+func TestRefillOnceHonorsTheBackoff(t *testing.T) {
+	eng := newFakeEngine()
+	eng.cloneErr = errors.New("configure network: failed to connect veth to bridge cni0: exchange full")
+	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 50})
+	m.pools[testKey].goldenDir = "/goldens/x"
+
+	// Concurrency is bounded, so the streak accrues over several ticks — the
+	// same way it does on a node whose refills are all failing.
+	backedOff := false
+	for range 50 {
+		m.refillOnce(t.Context())
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return infos[0].Refilling == 0
+		})
+		m.mu.Lock()
+		backedOff = !m.pools[testKey].nextRefill.IsZero()
+		m.mu.Unlock()
+		if backedOff {
+			break
+		}
+	}
+	attempts := eng.cloneCount()
+	if !backedOff {
+		t.Fatal("a pool whose every refill failed is not backed off")
+	}
+
+	for range 5 {
+		m.refillOnce(t.Context())
+	}
+	if n := eng.cloneCount(); n != attempts {
+		t.Errorf("clones=%d after backing off, want %d: a backed-off pool must not attempt again", n, attempts)
+	}
+
+	// It is a pause, not a latch: once the wait expires a working engine fills.
+	m.mu.Lock()
+	m.pools[testKey].nextRefill = time.Now().Add(-time.Second)
+	m.mu.Unlock()
+	eng.cloneErr = nil
+	m.refillOnce(t.Context())
+	waitFor(t, func() bool {
+		infos, _ := m.Info()
+		return infos[0].Warm == 50
+	})
+}

--- a/sandboxd/pool/refillbackoff_test.go
+++ b/sandboxd/pool/refillbackoff_test.go
@@ -8,10 +8,6 @@ import (
 	"github.com/cocoonstack/sandbox/sandboxd/config"
 )
 
-// TestRefillBacksOffOnlyAfterAnUnbrokenRunOfFailures pins both halves of the
-// discriminator. One VM failing to boot is ordinary and must not stall the
-// pool; everything failing means the next attempt will fail too, and retrying
-// that at ticker rate is what turns a capacity limit into an outage.
 func TestRefillBacksOffOnlyAfterAnUnbrokenRunOfFailures(t *testing.T) {
 	p := &pool{}
 	now := time.Now()
@@ -31,21 +27,16 @@ func TestRefillBacksOffOnlyAfterAnUnbrokenRunOfFailures(t *testing.T) {
 		t.Fatal("backoff started but nextRefill is not in the future")
 	}
 
-	// A success clears it: a pool must recover without waiting out a backoff
-	// earned by a burst that has already passed.
 	p.noteRefillResult(now, false)
 	if p.refillFails != 0 || !p.nextRefill.IsZero() {
 		t.Fatalf("a success left fails=%d nextRefill=%v", p.refillFails, p.nextRefill)
 	}
 
-	// And one straggler failure after that success starts from scratch.
 	if p.noteRefillResult(now, true) {
 		t.Fatal("a single failure after a success backed the pool off")
 	}
 }
 
-// TestBackoffGrowsAndIsCapped keeps a persistent failure from being retried
-// forever at the same rate, without letting the wait run away.
 func TestBackoffGrowsAndIsCapped(t *testing.T) {
 	p := &pool{}
 	now := time.Now()
@@ -69,18 +60,15 @@ func TestBackoffGrowsAndIsCapped(t *testing.T) {
 	}
 }
 
-// TestRefillOnceHonorsTheBackoff is the property that actually saves the node:
-// while a pool is backed off, the ticker must spawn nothing. Without it a pool
-// short of target re-attempts every tick at full concurrency, and each attempt
-// forks the engine and runs the CNI plugins before failing.
+// TestRefillOnceHonorsTheBackoff pins the property that saves the node:
+// while a pool is backed off, the ticker spawns nothing.
 func TestRefillOnceHonorsTheBackoff(t *testing.T) {
 	eng := newFakeEngine()
 	eng.cloneErr = errors.New("configure network: failed to connect veth to bridge cni0: exchange full")
 	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 50})
 	m.pools[testKey].goldenDir = "/goldens/x"
 
-	// Concurrency is bounded, so the streak accrues over several ticks — the
-	// same way it does on a node whose refills are all failing.
+	// Concurrency is bounded, so the streak accrues over several ticks.
 	backedOff := false
 	for range 50 {
 		m.refillOnce(t.Context())
@@ -100,6 +88,11 @@ func TestRefillOnceHonorsTheBackoff(t *testing.T) {
 		t.Fatal("a pool whose every refill failed is not backed off")
 	}
 
+	// Pin the expiry far out so the no-spawn assertions cannot race a short
+	// first backoff on a loaded machine.
+	m.mu.Lock()
+	m.pools[testKey].nextRefill = time.Now().Add(time.Hour)
+	m.mu.Unlock()
 	for range 5 {
 		m.refillOnce(t.Context())
 	}
@@ -107,7 +100,7 @@ func TestRefillOnceHonorsTheBackoff(t *testing.T) {
 		t.Errorf("clones=%d after backing off, want %d: a backed-off pool must not attempt again", n, attempts)
 	}
 
-	// It is a pause, not a latch: once the wait expires a working engine fills.
+	// A pause, not a latch: once the wait expires a working engine fills.
 	m.mu.Lock()
 	m.pools[testKey].nextRefill = time.Now().Add(-time.Second)
 	m.mu.Unlock()


### PR DESCRIPTION
## Problem

`refillOne` logs a failure and returns, so the refill ticker re-attempts every
two seconds at the full refill concurrency for as long as the cause lasts. For a
cause that clears on its own that is right. For one that does not, it is a storm:
each attempt still forks the engine, builds a netns and runs the CNI plugins
before failing, and every one of those takes the global `rtnl` lock on the way
through.

A node reaches such a cause on the way to a large warm target. A Linux bridge
holds at most `BR_MAX_PORTS` ports — 1024, a compile-time kernel constant, no
sysctl — and `br_add_if()` returns `EXFULL` for the next one. A single-bridge
node therefore stops accepting VMs somewhere near a thousand however much CPU and
memory it has, and past that point every clone fails in the bridge plugin.

Measured on a 384-core node that crossed it:

| | |
|---|---|
| refill errors in one hour, one node | **19,858** |
| load average | **> 180** |
| CPU idle | **97%** |

The load was tasks queued on `rtnl`, not work — blocking on a mutex is
`TASK_UNINTERRUPTIBLE`, which counts toward load average. `sshd` starved badly
enough to make the box hard to log into, which is the part that turns a capacity
limit into an outage.

## Change

Count refills that fail back-to-back and pause the pool once they reach a streak,
doubling the wait per further failure up to `buildRetryDelay`. Any success resets
the counter.

That reset is what keeps this away from the normal case: one VM failing to boot
is ordinary, and with refills running concurrently a success lands between
failures unless essentially everything is failing. Only an unbroken run says the
next attempt will fail too.

**No error is inspected.** The streak is the whole signal, so this cannot
misjudge a message it has not seen before — no dependence on kernel or CNI
wording.

The pool still reports its true warm count, so a placer sees a node short of
target and can send work elsewhere.

## Tests

- a single failure, and a failure after a success, do not back the pool off
- the failure completing the streak does, and a success clears it
- the wait grows per further failure and is capped
- `refillOnce` spawns nothing while a pool is backed off, and fills again once
  the wait expires

`go test ./...` green; `golangci-lint` (pinned v2.12.2) clean on `GOOS=linux` and
`GOOS=darwin`.