### PR TITLE
Let a NIC-less sandbox reach out with no configuration

### DIFF
--- a/docs/egress.md
+++ b/docs/egress.md
@@ -19,11 +19,16 @@ bound to that sandbox's identity by the socket path — no in-band token. The
 proxy evaluates the policy, injects the matched rule's secret host-side, dials
 the origin, and relays the response.
 
-A sandbox reaches it as a standard HTTP proxy:
+The base image sets `http_proxy`/`https_proxy`/`no_proxy` on silkd's unit, and
+silkd forwards exactly those variables into every exec — only when the guest
+has no NIC beyond `lo`/`sit0`, so a lane with a working NIC is never steered
+into a relay whose host side is closed. An unconfigured client just works, and
+`-x` still does:
 
 ```sh
-curl -x http://127.0.0.1:3128 https://api.github.com/user   # allowed + credentialed
-curl -x http://127.0.0.1:3128 https://evil.example/         # 403 egress denied: evil.example
+curl https://api.github.com/user                            # allowed + credentialed
+curl https://evil.example/                                  # 403 egress denied: evil.example
+curl -x http://127.0.0.1:3128 https://api.github.com/user   # explicit form, same path
 ```
 
 ## How it works (egress lane)
@@ -53,6 +58,21 @@ reserved, per the registry snapshot in `egress.go`) plus the IPv4-embedding
 IPv6 forms (NAT64, 6to4, Teredo, IPv4-compatible) — so an allow-listed host
 that resolves, or is rebound, to one cannot reach the sandboxd host or a
 sibling VM.
+
+`egress_internal_allow` re-admits named prefixes through that guard for nodes
+whose sandboxes legitimately need internal services:
+
+```jsonc
+{ "egress_internal_allow": ["10.8.0.0/16", "fdc8::/16"] }
+```
+
+It is node-wide (every pool and tenant on the node gets the same re-admission)
+and checked after NAT64 unwrapping, so an embedded IPv4 matches as the IPv4 it
+is. Name service prefixes, never the whole private space: the guest bridges are
+themselves ULA/RFC1918, so a blanket permit would open sandbox-to-sandbox and
+the host's own gateway. `0.0.0.0/0` + `::/0` turns the guard off entirely — for
+fleets with a policy-enforcing proxy in front — and requests still pass the
+domain policy first; the allow-list widens the IP gate only.
 
 ### Deployment constraints
 

--- a/docs/silkd.md
+++ b/docs/silkd.md
@@ -65,6 +65,9 @@ lane. `SILKD_NET=none|egress` overrides the probe for tests and operators.
 On every lane silkd also binds `127.0.0.1:3128` and relays each connection to
 the host's [guarded-egress](egress.md) proxy over vsock (`CID2:2049`); when the
 host wired no policy the per-connection dial is refused, so the port is inert.
+On the no-network lane silkd forwards the image-baked proxy variables
+(`http_proxy` and friends) into every exec, so unconfigured clients use the
+relay without being told; a lane with its own network never gets them.
 
 ## Limits
 

--- a/os-image/android/silkd.rc
+++ b/os-image/android/silkd.rc
@@ -10,8 +10,7 @@ service silkd /system/bin/silkd
     user root
     group root
     setenv SILKD_PORT 2048
-    # Mirrors the base:24.04 unit: silkd forwards these into execs only on the
-    # no-network lane (see docs/egress.md).
+    # Mirrors the base:24.04 unit; forwarded into execs only on the no-NIC lane.
     setenv http_proxy http://127.0.0.1:3128
     setenv https_proxy http://127.0.0.1:3128
     setenv no_proxy localhost,127.0.0.1,::1

--- a/os-image/android/silkd.rc
+++ b/os-image/android/silkd.rc
@@ -10,6 +10,11 @@ service silkd /system/bin/silkd
     user root
     group root
     setenv SILKD_PORT 2048
+    # Mirrors the base:24.04 unit: silkd forwards these into execs only on the
+    # no-network lane (see docs/egress.md).
+    setenv http_proxy http://127.0.0.1:3128
+    setenv https_proxy http://127.0.0.1:3128
+    setenv no_proxy localhost,127.0.0.1,::1
 
 on boot
     start silkd

--- a/os-image/base/24.04/Dockerfile
+++ b/os-image/base/24.04/Dockerfile
@@ -54,6 +54,13 @@ RUN --mount=type=secret,id=sandbox_install_agent \
     # [silkd] product-tier daemon on vsock 2048, started at sysinit alongside
     # the agent — this is the sandbox product's readiness signal. Same
     # measured-fast ordering as the agent unit (no local-fs wait).
+    #
+    # The proxy variables are on silkd's own unit because every exec in the
+    # guest is a child of silkd: that is what makes an unconfigured `curl`
+    # work. 3128 is silkd's loopback relay, which forwards to the host's
+    # egress proxy over vsock — the only way out for a none-lane guest, which
+    # has no NIC at all. On the egress lane the NIC carries traffic directly
+    # and the relay simply goes unused.
     printf '%s\n' \
       '[Unit]' \
       'Description=silkd (sandbox product daemon: exec, files, sessions over vsock)' \
@@ -65,6 +72,9 @@ RUN --mount=type=secret,id=sandbox_install_agent \
       'Type=simple' \
       'ExecStart=/usr/local/bin/silkd' \
       'Environment=SILKD_PORT=2048' \
+      'Environment=http_proxy=http://127.0.0.1:3128' \
+      'Environment=https_proxy=http://127.0.0.1:3128' \
+      'Environment=no_proxy=localhost,127.0.0.1,::1' \
       'Restart=always' \
       'RestartSec=2s' \
       'LimitNOFILE=65536' \

--- a/os-image/base/24.04/Dockerfile
+++ b/os-image/base/24.04/Dockerfile
@@ -55,11 +55,9 @@ RUN --mount=type=secret,id=sandbox_install_agent \
     # the agent — this is the sandbox product's readiness signal. Same
     # measured-fast ordering as the agent unit (no local-fs wait).
     #
-    # The proxy variables ride silkd's unit because every guest exec is a silkd
-    # child — that is what makes an unconfigured curl work. 3128 is silkd's
-    # loopback relay over vsock to the host proxy, the none lane's only way
-    # out; silkd forwards them into execs only when the guest has no NIC, so a
-    # lane with its own NIC is never steered into a closed relay.
+    # 3128 is silkd's loopback relay over vsock to the host proxy, the none
+    # lane's only way out. silkd forwards these into execs only on the
+    # no-network lane, so a lane with its own NIC never dials a closed relay.
     printf '%s\n' \
       '[Unit]' \
       'Description=silkd (sandbox product daemon: exec, files, sessions over vsock)' \

--- a/os-image/base/24.04/Dockerfile
+++ b/os-image/base/24.04/Dockerfile
@@ -55,12 +55,11 @@ RUN --mount=type=secret,id=sandbox_install_agent \
     # the agent — this is the sandbox product's readiness signal. Same
     # measured-fast ordering as the agent unit (no local-fs wait).
     #
-    # The proxy variables are on silkd's own unit because every exec in the
-    # guest is a child of silkd: that is what makes an unconfigured `curl`
-    # work. 3128 is silkd's loopback relay, which forwards to the host's
-    # egress proxy over vsock — the only way out for a none-lane guest, which
-    # has no NIC at all. On the egress lane the NIC carries traffic directly
-    # and the relay simply goes unused.
+    # The proxy variables ride silkd's unit because every guest exec is a silkd
+    # child — that is what makes an unconfigured curl work. 3128 is silkd's
+    # loopback relay over vsock to the host proxy, the none lane's only way
+    # out; silkd forwards them into execs only when the guest has no NIC, so a
+    # lane with its own NIC is never steered into a closed relay.
     printf '%s\n' \
       '[Unit]' \
       'Description=silkd (sandbox product daemon: exec, files, sessions over vsock)' \

--- a/sandboxd/config/config.go
+++ b/sandboxd/config/config.go
@@ -232,11 +232,9 @@ type Config struct {
 	// revocation bound for a replica a delete broadcast missed). Off by default.
 	CheckpointPeerHeal bool `json:"checkpoint_peer_heal,omitempty"`
 
-	// EgressInternalAllow re-admits CIDRs the egress proxy's SSRF guard would
-	// refuse, node-wide: every pool and tenant on the node gets the same
-	// re-admission. Prefixes, not a "permit private" switch: the guest bridges
-	// are themselves ULA/RFC1918, so a blanket permit would open
-	// sandbox-to-sandbox and the host's own gateway.
+	// EgressInternalAllow re-admits CIDRs through the proxy's SSRF guard,
+	// node-wide (every pool and tenant). Prefixes, not a permit-private
+	// switch: the guest bridges are themselves ULA/RFC1918.
 	EgressInternalAllow []string `json:"egress_internal_allow,omitempty"`
 
 	// CheckpointTTLHours ages out checkpoints (0 = keep forever); the

--- a/sandboxd/config/config.go
+++ b/sandboxd/config/config.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"runtime"
 	"slices"
@@ -231,6 +232,14 @@ type Config struct {
 	// revocation bound for a replica a delete broadcast missed). Off by default.
 	CheckpointPeerHeal bool `json:"checkpoint_peer_heal,omitempty"`
 
+	// EgressInternalAllow re-admits CIDRs the egress proxy would otherwise
+	// refuse as internal. The proxy blocks private and special-purpose targets
+	// so a guest cannot turn it into an SSRF; a node that must reach corporate
+	// services names their prefixes here. Prefixes, not a "permit private"
+	// switch: the guest bridges are themselves ULA/RFC1918, so a blanket permit
+	// would open sandbox-to-sandbox and the host's own gateway.
+	EgressInternalAllow []string `json:"egress_internal_allow,omitempty"`
+
 	// CheckpointTTLHours ages out checkpoints (0 = keep forever); the
 	// sweep runs hourly and on startup.
 	CheckpointTTLHours int `json:"checkpoint_ttl_hours,omitempty"`
@@ -379,6 +388,11 @@ func (c *Config) validate() error {
 	}
 	if c.CheckpointPeerHeal && c.APIToken == "" {
 		return fmt.Errorf("checkpoint_peer_heal requires api_token: without it resolveScope leaves the raw checkpoint blob GET reachable with no credential")
+	}
+	for _, cidr := range c.EgressInternalAllow {
+		if _, err := netip.ParsePrefix(cidr); err != nil {
+			return fmt.Errorf("egress_internal_allow %q: %w", cidr, err)
+		}
 	}
 	if err := c.validateTenants(); err != nil {
 		return err

--- a/sandboxd/config/config.go
+++ b/sandboxd/config/config.go
@@ -232,12 +232,11 @@ type Config struct {
 	// revocation bound for a replica a delete broadcast missed). Off by default.
 	CheckpointPeerHeal bool `json:"checkpoint_peer_heal,omitempty"`
 
-	// EgressInternalAllow re-admits CIDRs the egress proxy would otherwise
-	// refuse as internal. The proxy blocks private and special-purpose targets
-	// so a guest cannot turn it into an SSRF; a node that must reach corporate
-	// services names their prefixes here. Prefixes, not a "permit private"
-	// switch: the guest bridges are themselves ULA/RFC1918, so a blanket permit
-	// would open sandbox-to-sandbox and the host's own gateway.
+	// EgressInternalAllow re-admits CIDRs the egress proxy's SSRF guard would
+	// refuse, node-wide: every pool and tenant on the node gets the same
+	// re-admission. Prefixes, not a "permit private" switch: the guest bridges
+	// are themselves ULA/RFC1918, so a blanket permit would open
+	// sandbox-to-sandbox and the host's own gateway.
 	EgressInternalAllow []string `json:"egress_internal_allow,omitempty"`
 
 	// CheckpointTTLHours ages out checkpoints (0 = keep forever); the
@@ -389,10 +388,8 @@ func (c *Config) validate() error {
 	if c.CheckpointPeerHeal && c.APIToken == "" {
 		return fmt.Errorf("checkpoint_peer_heal requires api_token: without it resolveScope leaves the raw checkpoint blob GET reachable with no credential")
 	}
-	for _, cidr := range c.EgressInternalAllow {
-		if _, err := netip.ParsePrefix(cidr); err != nil {
-			return fmt.Errorf("egress_internal_allow %q: %w", cidr, err)
-		}
+	if err := c.validateEgressAllow(); err != nil {
+		return err
 	}
 	if err := c.validateTenants(); err != nil {
 		return err
@@ -460,6 +457,17 @@ func (c *Config) validateSecrets() (map[string]struct{}, error) {
 		names[s.Name] = struct{}{}
 	}
 	return names, nil
+}
+
+// validateEgressAllow rejects a malformed prefix at load: a typo would
+// otherwise surface as a refused dial long after startup.
+func (c *Config) validateEgressAllow() error {
+	for _, cidr := range c.EgressInternalAllow {
+		if _, err := netip.ParsePrefix(cidr); err != nil {
+			return fmt.Errorf("egress_internal_allow %q: %w", cidr, err)
+		}
+	}
+	return nil
 }
 
 func (c *Config) validateTenants() error {

--- a/sandboxd/pool/egress.go
+++ b/sandboxd/pool/egress.go
@@ -46,21 +46,12 @@ var (
 		netip.MustParsePrefix("3fff::/20"),      // documentation
 		netip.MustParsePrefix("5f00::/16"),      // SRv6 SIDs
 	}
-
-	// egressDialer blocks internal-address targets so the proxy cannot be an SSRF.
-	// It is the fallback for a node that allows no internal destination; see
-	// newEgressDialer for the configured form.
-	egressDialer = newEgressDialer(nil)
 )
 
-// newEgressDialer builds the proxy's upstream dialer. It blocks every
-// internal-address target so the proxy cannot be turned into an SSRF, then
-// re-admits exactly the prefixes the node names.
-//
-// The allow-list is prefixes rather than a "permit private" switch because the
-// guest bridges are themselves ULA/RFC1918: a blanket permit would let one
-// sandbox reach another, and the host's own gateway address. Naming the
-// corporate ranges keeps those out while letting internal services in.
+// newEgressDialer builds the proxy's upstream dialer: internal-address targets
+// are blocked (the proxy must not be an SSRF), then exactly the node-named
+// prefixes re-admitted — a "permit private" switch would also re-admit the
+// guest bridges, themselves ULA/RFC1918.
 func newEgressDialer(allow []netip.Prefix) *net.Dialer {
 	return &net.Dialer{Control: func(_, address string, _ syscall.RawConn) error {
 		host, _, err := net.SplitHostPort(address)
@@ -76,9 +67,8 @@ func newEgressDialer(allow []netip.Prefix) *net.Dialer {
 			b := ip.As16()
 			ip = netip.AddrFrom4([4]byte{b[12], b[13], b[14], b[15]})
 		}
-		// Checked before the block so an allowed prefix wins, and after the
-		// NAT64 unwrap so a v4 embedded in a v6 target is matched as the v4 it
-		// really is.
+		// After the NAT64 unwrap (a v4-in-v6 target matches as the v4 it is),
+		// before the block, so a named prefix wins.
 		if slices.ContainsFunc(allow, func(p netip.Prefix) bool { return p.Contains(ip) }) {
 			return nil
 		}
@@ -244,9 +234,8 @@ func (m *Manager) effectivePolicy(sb *types.Sandbox) (egress.Evaluator, bool) {
 	}
 }
 
-// parsePrefixes turns the node's allow-list into prefixes. Config validation
-// already rejected a malformed entry, so a leftover here is dropped rather than
-// failing a claim: the strict form of the check belongs at load, not at dial.
+// parsePrefixes turns the allow-list into prefixes; config validation already
+// rejected malformed entries, so a leftover is dropped rather than failing dials.
 func parsePrefixes(cidrs []string) []netip.Prefix {
 	out := make([]netip.Prefix, 0, len(cidrs))
 	for _, c := range cidrs {

--- a/sandboxd/pool/egress.go
+++ b/sandboxd/pool/egress.go
@@ -48,10 +48,9 @@ var (
 	}
 )
 
-// newEgressDialer builds the proxy's upstream dialer: internal-address targets
-// are blocked (the proxy must not be an SSRF), then exactly the node-named
-// prefixes re-admitted — a "permit private" switch would also re-admit the
-// guest bridges, themselves ULA/RFC1918.
+// newEgressDialer builds the proxy's upstream dialer: internal targets are
+// blocked (the proxy must not be an SSRF), then exactly the node-named
+// prefixes re-admitted.
 func newEgressDialer(allow []netip.Prefix) *net.Dialer {
 	return &net.Dialer{Control: func(_, address string, _ syscall.RawConn) error {
 		host, _, err := net.SplitHostPort(address)

--- a/sandboxd/pool/egress.go
+++ b/sandboxd/pool/egress.go
@@ -48,7 +48,21 @@ var (
 	}
 
 	// egressDialer blocks internal-address targets so the proxy cannot be an SSRF.
-	egressDialer = &net.Dialer{Control: func(_, address string, _ syscall.RawConn) error {
+	// It is the fallback for a node that allows no internal destination; see
+	// newEgressDialer for the configured form.
+	egressDialer = newEgressDialer(nil)
+)
+
+// newEgressDialer builds the proxy's upstream dialer. It blocks every
+// internal-address target so the proxy cannot be turned into an SSRF, then
+// re-admits exactly the prefixes the node names.
+//
+// The allow-list is prefixes rather than a "permit private" switch because the
+// guest bridges are themselves ULA/RFC1918: a blanket permit would let one
+// sandbox reach another, and the host's own gateway address. Naming the
+// corporate ranges keeps those out while letting internal services in.
+func newEgressDialer(allow []netip.Prefix) *net.Dialer {
+	return &net.Dialer{Control: func(_, address string, _ syscall.RawConn) error {
 		host, _, err := net.SplitHostPort(address)
 		if err != nil {
 			return err
@@ -62,13 +76,19 @@ var (
 			b := ip.As16()
 			ip = netip.AddrFrom4([4]byte{b[12], b[13], b[14], b[15]})
 		}
+		// Checked before the block so an allowed prefix wins, and after the
+		// NAT64 unwrap so a v4 embedded in a v6 target is matched as the v4 it
+		// really is.
+		if slices.ContainsFunc(allow, func(p netip.Prefix) bool { return p.Contains(ip) }) {
+			return nil
+		}
 		if !ip.IsGlobalUnicast() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
 			slices.ContainsFunc(internalRanges, func(p netip.Prefix) bool { return p.Contains(ip) }) {
 			return fmt.Errorf("egress: blocked internal address %s", ip)
 		}
 		return nil
 	}}
-)
+}
 
 // egressListener is one sandbox's egress accept point: an http.Server serving
 // egress.Proxy over the per-sandbox UDS the VMM connects when the guest dials
@@ -222,4 +242,17 @@ func (m *Manager) effectivePolicy(sb *types.Sandbox) (egress.Evaluator, bool) {
 	default:
 		return nil, false
 	}
+}
+
+// parsePrefixes turns the node's allow-list into prefixes. Config validation
+// already rejected a malformed entry, so a leftover here is dropped rather than
+// failing a claim: the strict form of the check belongs at load, not at dial.
+func parsePrefixes(cidrs []string) []netip.Prefix {
+	out := make([]netip.Prefix, 0, len(cidrs))
+	for _, c := range cidrs {
+		if p, err := netip.ParsePrefix(c); err == nil {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/sandboxd/pool/egress_test.go
+++ b/sandboxd/pool/egress_test.go
@@ -572,3 +572,24 @@ func TestEgressDialerWithNoAllowListBlocksEverythingInternal(t *testing.T) {
 		t.Errorf("public address blocked: %v", err)
 	}
 }
+
+// TestEgressDialerWildcardAllowsEverything pins the fully-open form. A node
+// that lists the whole address space turns the guard off deliberately —
+// including loopback and cloud metadata, which are the two the guard was most
+// worth keeping. It exists for fleets that put a policy-enforcing forward proxy
+// in front instead; without one, a guest can reach anything the node can.
+func TestEgressDialerWildcardAllowsEverything(t *testing.T) {
+	d := newEgressDialer(parsePrefixes([]string{"0.0.0.0/0", "::/0"}))
+	for _, addr := range []string{
+		"93.184.216.34:443",          // public
+		"[fdbd:dc01:fe:200f::1]:443", // corporate v6
+		"10.8.7.149:443",             // corporate v4
+		"[fd00:c0c0:38::5]:443",      // another sandbox
+		"127.0.0.1:7777",             // the node itself
+		"169.254.169.254:80",         // cloud metadata
+	} {
+		if err := d.Control("tcp", addr, nil); err != nil {
+			t.Errorf("%s blocked under a wildcard allow-list: %v", addr, err)
+		}
+	}
+}

--- a/sandboxd/pool/egress_test.go
+++ b/sandboxd/pool/egress_test.go
@@ -426,13 +426,13 @@ func TestEgressDialerBlocksInternal(t *testing.T) {
 		"[64:ff9b::a00:1]:80",     // NAT64-embedded 10.0.0.1
 	}
 	for _, addr := range blocked {
-		if err := egressDialer.Control("tcp", addr, nil); err == nil {
+		if err := newEgressDialer(nil).Control("tcp", addr, nil); err == nil {
 			t.Errorf("dial to internal %s allowed; SSRF not blocked", addr)
 		}
 	}
 	// public v4 direct, public v6, and a public v4 via the NAT64 well-known prefix
 	for _, addr := range []string{"93.184.216.34:443", "[2606:4700:4700::1111]:443", "[64:ff9b::5db8:d822]:443"} {
-		if err := egressDialer.Control("tcp", addr, nil); err != nil {
+		if err := newEgressDialer(nil).Control("tcp", addr, nil); err != nil {
 			t.Errorf("dial to public %s blocked: %v", addr, err)
 		}
 	}
@@ -452,6 +452,61 @@ func TestEgressLaneCannotForkOrCheckpoint(t *testing.T) {
 	}
 	if _, err := m.Promote(t.Context(), sb.ID, Cred{Token: "tok"}, "tpl", ""); !errors.Is(err, ErrNoEgressFork) {
 		t.Errorf("Promote on egress lane: got %v, want ErrNoEgressFork", err)
+	}
+}
+
+// TestEgressDialerAdmitsOnlyNamedInternalPrefixes pins the SSRF boundary:
+// named prefixes re-admit corporate services without re-admitting the guest
+// bridges, which are themselves ULA/RFC1918.
+func TestEgressDialerAdmitsOnlyNamedInternalPrefixes(t *testing.T) {
+	d := newEgressDialer(parsePrefixes([]string{"fdc8::/16", "10.8.0.0/16"}))
+	check := func(addr string) error {
+		return d.Control("tcp", addr, nil)
+	}
+	for name, tc := range map[string]struct {
+		addr    string
+		allowed bool
+	}{
+		"public v4":    {"93.184.216.34:443", true},
+		"public v6":    {"[2606:2800:220:1:248:1893:25c8:1946]:443", true},
+		"corporate v6": {"[fdc8:17:9:200f::1]:443", true},
+		"corporate v4": {"10.8.7.149:443", true},
+		// Guests and the host gateway share fc00::/7 with the corporate range.
+		"another sandbox on the bridge": {"[fd00:c0c0:38::5]:443", false},
+		"the host's bridge gateway":     {"[fd00:c0c0:38::1]:443", false},
+		"other private v4":              {"192.168.1.1:443", false},
+		"loopback":                      {"127.0.0.1:443", false},
+		"cloud metadata":                {"169.254.169.254:80", false},
+		"CGNAT metadata":                {"100.100.100.200:80", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := check(tc.addr)
+			if tc.allowed && err != nil {
+				t.Errorf("%s was blocked: %v", tc.addr, err)
+			}
+			if !tc.allowed && err == nil {
+				t.Errorf("%s was allowed; it must not be reachable from a guest", tc.addr)
+			}
+		})
+	}
+}
+
+// TestEgressDialerWildcardAllowsEverything pins the fully-open form as a
+// deliberate choice — loopback and cloud metadata included — for fleets with
+// a policy-enforcing forward proxy in front.
+func TestEgressDialerWildcardAllowsEverything(t *testing.T) {
+	d := newEgressDialer(parsePrefixes([]string{"0.0.0.0/0", "::/0"}))
+	for _, addr := range []string{
+		"93.184.216.34:443",       // public
+		"[fdc8:17:9:200f::1]:443", // corporate v6
+		"10.8.7.149:443",          // corporate v4
+		"[fd00:c0c0:38::5]:443",   // another sandbox
+		"127.0.0.1:7777",          // the node itself
+		"169.254.169.254:80",      // cloud metadata
+	} {
+		if err := d.Control("tcp", addr, nil); err != nil {
+			t.Errorf("%s blocked under a wildcard allow-list: %v", addr, err)
+		}
 	}
 }
 
@@ -515,81 +570,4 @@ func mustHostname(t *testing.T, raw string) string {
 		t.Fatalf("parse %q: %v", raw, err)
 	}
 	return u.Hostname()
-}
-
-// TestEgressDialerAdmitsOnlyNamedInternalPrefixes is the security boundary of
-// the none lane's proxy. The guard exists so a guest cannot turn the proxy into
-// an SSRF; the allow-list re-admits corporate services without also re-admitting
-// the guest bridges, which are themselves ULA/RFC1918 — a blanket "permit
-// private" would let one sandbox reach another and the host's own gateway.
-func TestEgressDialerAdmitsOnlyNamedInternalPrefixes(t *testing.T) {
-	// The corporate ranges a node would name; the guest bridge ULA deliberately
-	// is not among them.
-	d := newEgressDialer(parsePrefixes([]string{"fdbd::/16", "10.8.0.0/16"}))
-	check := func(addr string) error {
-		return d.Control("tcp", addr, nil)
-	}
-	for name, tc := range map[string]struct {
-		addr    string
-		allowed bool
-	}{
-		"public v4":                    {"93.184.216.34:443", true},
-		"public v6":                    {"[2606:2800:220:1:248:1893:25c8:1946]:443", true},
-		"corporate v6 (code.byted.org)": {"[fdbd:dc01:fe:200f::1]:443", true},
-		"corporate v4":                 {"10.8.7.149:443", true},
-		// The lane's own guests and the host's gateway share fc00::/7 with the
-		// corporate range; naming prefixes rather than permitting private is
-		// exactly what keeps them out.
-		"another sandbox on the bridge": {"[fd00:c0c0:38::5]:443", false},
-		"the host's bridge gateway":     {"[fd00:c0c0:38::1]:443", false},
-		"other private v4":              {"192.168.1.1:443", false},
-		"loopback":                      {"127.0.0.1:443", false},
-		"cloud metadata":                {"169.254.169.254:80", false},
-		"CGNAT metadata":                {"100.100.100.200:80", false},
-	} {
-		t.Run(name, func(t *testing.T) {
-			err := check(tc.addr)
-			if tc.allowed && err != nil {
-				t.Errorf("%s was blocked: %v", tc.addr, err)
-			}
-			if !tc.allowed && err == nil {
-				t.Errorf("%s was allowed; it must not be reachable from a guest", tc.addr)
-			}
-		})
-	}
-}
-
-// TestEgressDialerWithNoAllowListBlocksEverythingInternal keeps the default
-// safe: a node that names nothing behaves exactly as before this knob existed.
-func TestEgressDialerWithNoAllowListBlocksEverythingInternal(t *testing.T) {
-	d := newEgressDialer(nil)
-	for _, addr := range []string{"10.8.7.149:443", "[fdbd:dc01:fe:200f::1]:443", "192.168.1.1:443"} {
-		if err := d.Control("tcp", addr, nil); err == nil {
-			t.Errorf("%s allowed with an empty allow-list", addr)
-		}
-	}
-	if err := d.Control("tcp", "93.184.216.34:443", nil); err != nil {
-		t.Errorf("public address blocked: %v", err)
-	}
-}
-
-// TestEgressDialerWildcardAllowsEverything pins the fully-open form. A node
-// that lists the whole address space turns the guard off deliberately —
-// including loopback and cloud metadata, which are the two the guard was most
-// worth keeping. It exists for fleets that put a policy-enforcing forward proxy
-// in front instead; without one, a guest can reach anything the node can.
-func TestEgressDialerWildcardAllowsEverything(t *testing.T) {
-	d := newEgressDialer(parsePrefixes([]string{"0.0.0.0/0", "::/0"}))
-	for _, addr := range []string{
-		"93.184.216.34:443",          // public
-		"[fdbd:dc01:fe:200f::1]:443", // corporate v6
-		"10.8.7.149:443",             // corporate v4
-		"[fd00:c0c0:38::5]:443",      // another sandbox
-		"127.0.0.1:7777",             // the node itself
-		"169.254.169.254:80",         // cloud metadata
-	} {
-		if err := d.Control("tcp", addr, nil); err != nil {
-			t.Errorf("%s blocked under a wildcard allow-list: %v", addr, err)
-		}
-	}
 }

--- a/sandboxd/pool/egress_test.go
+++ b/sandboxd/pool/egress_test.go
@@ -516,3 +516,59 @@ func mustHostname(t *testing.T, raw string) string {
 	}
 	return u.Hostname()
 }
+
+// TestEgressDialerAdmitsOnlyNamedInternalPrefixes is the security boundary of
+// the none lane's proxy. The guard exists so a guest cannot turn the proxy into
+// an SSRF; the allow-list re-admits corporate services without also re-admitting
+// the guest bridges, which are themselves ULA/RFC1918 — a blanket "permit
+// private" would let one sandbox reach another and the host's own gateway.
+func TestEgressDialerAdmitsOnlyNamedInternalPrefixes(t *testing.T) {
+	// The corporate ranges a node would name; the guest bridge ULA deliberately
+	// is not among them.
+	d := newEgressDialer(parsePrefixes([]string{"fdbd::/16", "10.8.0.0/16"}))
+	check := func(addr string) error {
+		return d.Control("tcp", addr, nil)
+	}
+	for name, tc := range map[string]struct {
+		addr    string
+		allowed bool
+	}{
+		"public v4":                    {"93.184.216.34:443", true},
+		"public v6":                    {"[2606:2800:220:1:248:1893:25c8:1946]:443", true},
+		"corporate v6 (code.byted.org)": {"[fdbd:dc01:fe:200f::1]:443", true},
+		"corporate v4":                 {"10.8.7.149:443", true},
+		// The lane's own guests and the host's gateway share fc00::/7 with the
+		// corporate range; naming prefixes rather than permitting private is
+		// exactly what keeps them out.
+		"another sandbox on the bridge": {"[fd00:c0c0:38::5]:443", false},
+		"the host's bridge gateway":     {"[fd00:c0c0:38::1]:443", false},
+		"other private v4":              {"192.168.1.1:443", false},
+		"loopback":                      {"127.0.0.1:443", false},
+		"cloud metadata":                {"169.254.169.254:80", false},
+		"CGNAT metadata":                {"100.100.100.200:80", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := check(tc.addr)
+			if tc.allowed && err != nil {
+				t.Errorf("%s was blocked: %v", tc.addr, err)
+			}
+			if !tc.allowed && err == nil {
+				t.Errorf("%s was allowed; it must not be reachable from a guest", tc.addr)
+			}
+		})
+	}
+}
+
+// TestEgressDialerWithNoAllowListBlocksEverythingInternal keeps the default
+// safe: a node that names nothing behaves exactly as before this knob existed.
+func TestEgressDialerWithNoAllowListBlocksEverythingInternal(t *testing.T) {
+	d := newEgressDialer(nil)
+	for _, addr := range []string{"10.8.7.149:443", "[fdbd:dc01:fe:200f::1]:443", "192.168.1.1:443"} {
+		if err := d.Control("tcp", addr, nil); err == nil {
+			t.Errorf("%s allowed with an empty allow-list", addr)
+		}
+	}
+	if err := d.Control("tcp", "93.184.216.34:443", nil); err != nil {
+		t.Errorf("public address blocked: %v", err)
+	}
+}

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -384,7 +384,7 @@ func NewManager(ctx context.Context, cfg *config.Config, eng Engine, secrets *eg
 		healPending:     map[string]struct{}{},
 		healAbort:       map[string]struct{}{},
 		egressSecrets:   secrets,
-		dial:            egressDialer.DialContext,
+		dial:            newEgressDialer(parsePrefixes(cfg.EgressInternalAllow)).DialContext,
 		sweep:           netfilter.SweepExcept,
 		refillSem:       make(chan struct{}, refill),
 		probeSem:        make(chan struct{}, refill),

--- a/silkd/src/git.rs
+++ b/silkd/src/git.rs
@@ -10,6 +10,7 @@ use tokio::io::AsyncWrite;
 use tokio::process::Command;
 
 use crate::proto::{self, ErrorKind, GitBranchOp, GitFileStatus, Response};
+use crate::sysutil;
 
 /// Clones `url` into `path` (optionally a branch, shallow depth), then Done.
 pub async fn clone<W: AsyncWrite + Unpin>(
@@ -169,6 +170,7 @@ async fn net_verb<W: AsyncWrite + Unpin>(
 /// exec could otherwise scrape the token.
 fn git_cmd(dir: &str, auth: Option<&str>) -> Command {
     let mut cmd = Command::new("git");
+    sysutil::align_proxy_env(&mut cmd);
     cmd.arg("-C").arg(dir);
     apply_config(&mut cmd, auth);
     cmd.stdin(Stdio::null())

--- a/silkd/src/lsp.rs
+++ b/silkd/src/lsp.rs
@@ -26,6 +26,7 @@ use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::mpsc;
 
 use crate::proto::{self, ErrorKind, Request, Response};
+use crate::sysutil;
 
 const MANIFEST_DIR: &str = "/etc/silkd/lsp.d";
 
@@ -62,6 +63,7 @@ impl Broker {
             }
         };
         let mut cmd = Command::new(&argv[0]);
+        sysutil::align_proxy_env(&mut cmd);
         cmd.args(&argv[1..])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())

--- a/silkd/src/net.rs
+++ b/silkd/src/net.rs
@@ -1,9 +1,9 @@
 //! Guest network-lane detection. The egress lane has a device-backed NIC;
 //! the none lane carries only virtual interfaces (lo, plus the tunnels an
-//! all-builtin kernel auto-creates). Verbs that need the network (git
-//! clone/push/pull) and the proxy-env forwarding consult this so the none
-//! lane fails fast — or reaches out through the relay — instead of hanging.
+//! all-builtin kernel auto-creates). Network verbs (git clone/push/pull) and
+//! proxy-env forwarding consult this.
 
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicI8, Ordering};
 
 static LANE_OVERRIDE: AtomicI8 = AtomicI8::new(-1);
@@ -22,9 +22,9 @@ pub fn has_egress() -> bool {
         1 => return true,
         _ => {}
     }
-    match std::env::var("SILKD_NET").as_deref() {
-        Ok("none") => return false,
-        Ok("egress") => return true,
+    match silkd_net() {
+        0 => return false,
+        1 => return true,
         _ => {}
     }
     let Ok(entries) = std::fs::read_dir("/sys/class/net") else {
@@ -33,9 +33,17 @@ pub fn has_egress() -> bool {
     entries.flatten().any(|e| e.path().join("device").exists())
 }
 
-/// Overrides the lane for tests, which must not reach for `set_var`: setenv
-/// races every concurrent getenv in the binary, and has_egress now runs on
-/// every spawn.
+/// Lane override for tests: set_var would race every concurrent getenv.
 pub fn override_egress_for_tests(lane: Option<bool>) {
     LANE_OVERRIDE.store(lane.map_or(-1, i8::from), Ordering::Relaxed);
+}
+
+/// SILKD_NET decoded once: operator config, fixed at service start.
+fn silkd_net() -> i8 {
+    static SILKD_NET: OnceLock<i8> = OnceLock::new();
+    *SILKD_NET.get_or_init(|| match std::env::var("SILKD_NET").as_deref() {
+        Ok("none") => 0,
+        Ok("egress") => 1,
+        _ => -1,
+    })
 }

--- a/silkd/src/net.rs
+++ b/silkd/src/net.rs
@@ -1,18 +1,27 @@
 //! Guest network-lane detection. The egress lane has a device-backed NIC;
 //! the none lane carries only virtual interfaces (lo, plus the tunnels an
 //! all-builtin kernel auto-creates). Verbs that need the network (git
-//! clone/push/pull) consult this so the none lane fails fast with a typed
-//! error instead of hanging on an unreachable remote.
+//! clone/push/pull) and the proxy-env forwarding consult this so the none
+//! lane fails fast — or reaches out through the relay — instead of hanging.
+
+use std::sync::atomic::{AtomicI8, Ordering};
+
+static LANE_OVERRIDE: AtomicI8 = AtomicI8::new(-1);
 
 /// Reports whether the guest can reach a network. `SILKD_NET` overrides the
-/// probe (`none` / `egress`) for operators and tests; otherwise an interface
-/// under /sys/class/net backed by a real device (a `device` symlink) counts.
+/// probe (`none` / `egress`) for operators; otherwise an interface under
+/// /sys/class/net backed by a real device (a `device` symlink) counts.
 /// Name filtering is not enough: the all-builtin sandbox kernel auto-creates
 /// virtual tunnels (sit0 and friends) even on the no-NIC lane, and `lo` is
 /// virtual too — only a virtio/physical NIC has a device backing. On
 /// non-Linux dev hosts (no /sys/class/net) it defaults to true so git verbs
 /// are testable.
 pub fn has_egress() -> bool {
+    match LANE_OVERRIDE.load(Ordering::Relaxed) {
+        0 => return false,
+        1 => return true,
+        _ => {}
+    }
     match std::env::var("SILKD_NET").as_deref() {
         Ok("none") => return false,
         Ok("egress") => return true,
@@ -22,4 +31,11 @@ pub fn has_egress() -> bool {
         return true;
     };
     entries.flatten().any(|e| e.path().join("device").exists())
+}
+
+/// Overrides the lane for tests, which must not reach for `set_var`: setenv
+/// races every concurrent getenv in the binary, and has_egress now runs on
+/// every spawn.
+pub fn override_egress_for_tests(lane: Option<bool>) {
+    LANE_OVERRIDE.store(lane.map_or(-1, i8::from), Ordering::Relaxed);
 }

--- a/silkd/src/sysutil.rs
+++ b/silkd/src/sysutil.rs
@@ -95,17 +95,18 @@ fn valid_pid(id: u32) -> bool {
 
 /// The environment every exec starts from before the request's env is layered
 /// on — a sane PATH and TERM, plus the proxy snapshot when the guest has no
-/// NIC: only the none lane needs the relay, and on a lane with a working NIC
-/// the proxy variables would steer clients into a closed one.
+/// network of its own (net::has_egress): only the none lane needs the relay,
+/// and on a lane with a working NIC the variables would steer clients into a
+/// closed one.
 pub fn base_env() -> Vec<(&'static str, &'static str)> {
-    compose_env(has_nic(), proxy_vars())
+    compose_env(crate::net::has_egress(), proxy_vars())
 }
 
 /// Aligns an env-inheriting child (git, language servers) with the lane rule
-/// base_env applies to cleared ones: a guest with its own NIC must not be
+/// base_env applies to cleared ones: a guest with its own network must not be
 /// steered into the loopback relay.
 pub fn align_proxy_env(cmd: &mut Command) {
-    align_proxy_env_for(cmd, has_nic());
+    align_proxy_env_for(cmd, crate::net::has_egress());
 }
 
 fn align_proxy_env_for(cmd: &mut Command, nic: bool) {
@@ -146,18 +147,6 @@ fn snapshot_proxy(get: impl Fn(&str) -> Option<String>) -> Vec<(&'static str, St
             _ => None,
         })
         .collect()
-}
-
-/// Whether the guest has a NIC beyond lo/sit0. Read per call: cheap against a
-/// process spawn, and correct the day a NIC is hotplugged at claim.
-fn has_nic() -> bool {
-    std::fs::read_dir("/sys/class/net")
-        .map(|entries| {
-            entries
-                .filter_map(|e| e.ok())
-                .any(|e| e.file_name() != "lo" && e.file_name() != "sit0")
-        })
-        .unwrap_or(false)
 }
 
 /// Resolves a username to uid/gid via getpwnam and sets them on the command.

--- a/silkd/src/sysutil.rs
+++ b/silkd/src/sysutil.rs
@@ -94,17 +94,14 @@ fn valid_pid(id: u32) -> bool {
 }
 
 /// The environment every exec starts from before the request's env is layered
-/// on — a sane PATH and TERM, plus the proxy snapshot when the guest has no
-/// network of its own (net::has_egress): only the none lane needs the relay,
-/// and on a lane with a working NIC the variables would steer clients into a
-/// closed one.
+/// on — a sane PATH and TERM, plus the proxy snapshot on the no-network lane
+/// (a lane with its own NIC would be steered into a closed relay).
 pub fn base_env() -> Vec<(&'static str, &'static str)> {
     compose_env(crate::net::has_egress(), proxy_vars())
 }
 
-/// Aligns an env-inheriting child (git, language servers) with the lane rule
-/// base_env applies to cleared ones: a guest with its own network must not be
-/// steered into the loopback relay.
+/// Applies base_env's lane rule to an env-inheriting child (git, language
+/// servers): with a network of its own, the proxy variables come off.
 pub fn align_proxy_env(cmd: &mut Command) {
     align_proxy_env_for(cmd, crate::net::has_egress());
 }

--- a/silkd/src/sysutil.rs
+++ b/silkd/src/sysutil.rs
@@ -17,6 +17,17 @@ static NSS_LOCK: Mutex<()> = Mutex::new(());
 
 static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
+/// Forwarded from silkd's own environment into every exec: the loopback proxy
+/// relay is the no-NIC lane's only way out, and nothing else may leak.
+const FORWARDED: [&str; 6] = [
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+];
+
 /// A suffix unique within this process (pid + monotonic counter), enough to
 /// name a temp file a concurrent write in the same directory won't collide
 /// with. Not cryptographic — just unique.
@@ -82,37 +93,45 @@ fn valid_pid(id: u32) -> bool {
     id != 0 && id <= i32::MAX as u32
 }
 
-/// Variables forwarded from silkd's own environment into every exec. They are
-/// the one thing a guest cannot discover for itself: on the no-network lane
-/// there is no NIC, and the only way out is the loopback relay this daemon
-/// runs — an unconfigured client would never think to look for it. Everything
-/// else stays uninherited.
-const FORWARDED: [&str; 6] = [
-    "http_proxy",
-    "https_proxy",
-    "no_proxy",
-    "HTTP_PROXY",
-    "HTTPS_PROXY",
-    "NO_PROXY",
-];
+/// The environment every exec starts from before the request's env is layered
+/// on — a sane PATH and TERM, plus FORWARDED when the image set it and the
+/// guest has no NIC: only the none lane needs the relay, and on a lane with a
+/// working NIC the proxy variables would steer clients into a closed one.
+pub fn base_env() -> Vec<(&'static str, String)> {
+    base_env_from(has_nic(), |key| std::env::var(key).ok())
+}
 
-/// The environment every exec starts from before the request's env is
-/// layered on — a sane PATH and TERM, plus FORWARDED when the image set it.
-pub fn base_env() -> Vec<(String, String)> {
+fn base_env_from(nic: bool, get: impl Fn(&str) -> Option<String>) -> Vec<(&'static str, String)> {
     let mut env = vec![
         (
-            "PATH".to_string(),
+            "PATH",
             "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string(),
         ),
-        ("TERM".to_string(), "xterm-256color".to_string()),
+        ("TERM", "xterm-256color".to_string()),
     ];
+    if nic {
+        return env;
+    }
     for key in FORWARDED {
-        match std::env::var(key) {
-            Ok(v) if !v.is_empty() => env.push((key.to_string(), v)),
-            _ => {}
+        if let Some(v) = get(key)
+            && !v.is_empty()
+        {
+            env.push((key, v));
         }
     }
     env
+}
+
+/// Whether the guest has a NIC beyond lo/sit0. Read per call: cheap against a
+/// process spawn, and correct the day a NIC is hotplugged at claim.
+fn has_nic() -> bool {
+    std::fs::read_dir("/sys/class/net")
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .any(|e| e.file_name() != "lo" && e.file_name() != "sit0")
+        })
+        .unwrap_or(false)
 }
 
 /// Resolves a username to uid/gid via getpwnam and sets them on the command.
@@ -284,38 +303,45 @@ mod tests {
     #[test]
     fn base_env_has_path_and_term() {
         let env = base_env();
-        assert!(env.iter().any(|(k, _)| k == "PATH"));
-        assert!(env.iter().any(|(k, _)| k == "TERM"));
+        assert!(env.iter().any(|(k, _)| *k == "PATH"));
+        assert!(env.iter().any(|(k, _)| *k == "TERM"));
     }
 
-    /// The no-network lane has no NIC, so an unconfigured client only reaches
-    /// the outside if the proxy variables arrive without anyone asking. Nothing
-    /// else may leak: silkd's own environment is not the guest's.
+    /// The no-NIC lane only reaches out if the proxy variables arrive without
+    /// anyone asking; nothing else of silkd's environment is the guest's.
     #[test]
     fn base_env_forwards_only_the_proxy_variables() {
-        // SAFETY: single-threaded test process; set/remove are scoped to it.
-        unsafe {
-            std::env::set_var("http_proxy", "http://127.0.0.1:3128");
-            std::env::set_var("SILKD_PORT", "2048");
-            std::env::remove_var("HTTPS_PROXY");
-        }
-        let env = base_env();
+        let vars = |key: &str| match key {
+            "http_proxy" => Some("http://127.0.0.1:3128".to_string()),
+            "HTTPS_PROXY" => Some(String::new()),
+            _ => Some("2048".to_string()),
+        };
+        let env = base_env_from(false, vars);
         assert_eq!(
             env.iter()
-                .find(|(k, _)| k == "http_proxy")
+                .find(|(k, _)| *k == "http_proxy")
                 .map(|(_, v)| v.as_str()),
             Some("http://127.0.0.1:3128"),
         );
         assert!(
-            !env.iter().any(|(k, _)| k == "SILKD_PORT"),
+            !env.iter().any(|(k, _)| *k == "SILKD_PORT"),
             "silkd's own settings must not reach the guest's commands",
         );
         assert!(
-            !env.iter().any(|(k, _)| k == "HTTPS_PROXY"),
-            "an unset variable must not appear as empty",
+            !env.iter().any(|(k, _)| *k == "HTTPS_PROXY"),
+            "an empty variable must not be forwarded",
         );
-        // SAFETY: as above.
-        unsafe { std::env::remove_var("http_proxy") };
+    }
+
+    /// A guest with a working NIC must not be steered into the loopback relay,
+    /// which is closed unless the host armed a proxy for this sandbox.
+    #[test]
+    fn base_env_forwards_nothing_when_a_nic_is_present() {
+        let env = base_env_from(true, |_| Some("http://127.0.0.1:3128".to_string()));
+        assert!(
+            !env.iter().any(|(k, _)| *k == "http_proxy"),
+            "proxy variables must stay off a lane with its own NIC",
+        );
     }
 
     #[test]

--- a/silkd/src/sysutil.rs
+++ b/silkd/src/sysutil.rs
@@ -82,16 +82,37 @@ fn valid_pid(id: u32) -> bool {
     id != 0 && id <= i32::MAX as u32
 }
 
+/// Variables forwarded from silkd's own environment into every exec. They are
+/// the one thing a guest cannot discover for itself: on the no-network lane
+/// there is no NIC, and the only way out is the loopback relay this daemon
+/// runs — an unconfigured client would never think to look for it. Everything
+/// else stays uninherited.
+const FORWARDED: [&str; 6] = [
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+];
+
 /// The environment every exec starts from before the request's env is
-/// layered on — a sane PATH and TERM, nothing inherited from silkd.
-pub fn base_env() -> [(&'static str, &'static str); 2] {
-    [
+/// layered on — a sane PATH and TERM, plus FORWARDED when the image set it.
+pub fn base_env() -> Vec<(String, String)> {
+    let mut env = vec![
         (
-            "PATH",
-            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "PATH".to_string(),
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string(),
         ),
-        ("TERM", "xterm-256color"),
-    ]
+        ("TERM".to_string(), "xterm-256color".to_string()),
+    ];
+    for key in FORWARDED {
+        match std::env::var(key) {
+            Ok(v) if !v.is_empty() => env.push((key.to_string(), v)),
+            _ => {}
+        }
+    }
+    env
 }
 
 /// Resolves a username to uid/gid via getpwnam and sets them on the command.
@@ -263,8 +284,38 @@ mod tests {
     #[test]
     fn base_env_has_path_and_term() {
         let env = base_env();
-        assert!(env.iter().any(|(k, _)| *k == "PATH"));
-        assert!(env.iter().any(|(k, _)| *k == "TERM"));
+        assert!(env.iter().any(|(k, _)| k == "PATH"));
+        assert!(env.iter().any(|(k, _)| k == "TERM"));
+    }
+
+    /// The no-network lane has no NIC, so an unconfigured client only reaches
+    /// the outside if the proxy variables arrive without anyone asking. Nothing
+    /// else may leak: silkd's own environment is not the guest's.
+    #[test]
+    fn base_env_forwards_only_the_proxy_variables() {
+        // SAFETY: single-threaded test process; set/remove are scoped to it.
+        unsafe {
+            std::env::set_var("http_proxy", "http://127.0.0.1:3128");
+            std::env::set_var("SILKD_PORT", "2048");
+            std::env::remove_var("HTTPS_PROXY");
+        }
+        let env = base_env();
+        assert_eq!(
+            env.iter()
+                .find(|(k, _)| k == "http_proxy")
+                .map(|(_, v)| v.as_str()),
+            Some("http://127.0.0.1:3128"),
+        );
+        assert!(
+            !env.iter().any(|(k, _)| k == "SILKD_PORT"),
+            "silkd's own settings must not reach the guest's commands",
+        );
+        assert!(
+            !env.iter().any(|(k, _)| k == "HTTPS_PROXY"),
+            "an unset variable must not appear as empty",
+        );
+        // SAFETY: as above.
+        unsafe { std::env::remove_var("http_proxy") };
     }
 
     #[test]

--- a/silkd/src/sysutil.rs
+++ b/silkd/src/sysutil.rs
@@ -6,8 +6,8 @@ use std::fmt::Write as _;
 use std::io::Read;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::process::ExitStatus;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 use tokio::process::Command;
 
@@ -94,32 +94,58 @@ fn valid_pid(id: u32) -> bool {
 }
 
 /// The environment every exec starts from before the request's env is layered
-/// on — a sane PATH and TERM, plus FORWARDED when the image set it and the
-/// guest has no NIC: only the none lane needs the relay, and on a lane with a
-/// working NIC the proxy variables would steer clients into a closed one.
-pub fn base_env() -> Vec<(&'static str, String)> {
-    base_env_from(has_nic(), |key| std::env::var(key).ok())
+/// on — a sane PATH and TERM, plus the proxy snapshot when the guest has no
+/// NIC: only the none lane needs the relay, and on a lane with a working NIC
+/// the proxy variables would steer clients into a closed one.
+pub fn base_env() -> Vec<(&'static str, &'static str)> {
+    compose_env(has_nic(), proxy_vars())
 }
 
-fn base_env_from(nic: bool, get: impl Fn(&str) -> Option<String>) -> Vec<(&'static str, String)> {
+/// Aligns an env-inheriting child (git, language servers) with the lane rule
+/// base_env applies to cleared ones: a guest with its own NIC must not be
+/// steered into the loopback relay.
+pub fn align_proxy_env(cmd: &mut Command) {
+    align_proxy_env_for(cmd, has_nic());
+}
+
+fn align_proxy_env_for(cmd: &mut Command, nic: bool) {
+    if !nic {
+        return;
+    }
+    for key in FORWARDED {
+        cmd.env_remove(key);
+    }
+}
+
+fn compose_env<'a>(nic: bool, proxy: &'a [(&'static str, String)]) -> Vec<(&'static str, &'a str)> {
     let mut env = vec![
         (
             "PATH",
-            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string(),
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         ),
-        ("TERM", "xterm-256color".to_string()),
+        ("TERM", "xterm-256color"),
     ];
-    if nic {
-        return env;
-    }
-    for key in FORWARDED {
-        if let Some(v) = get(key)
-            && !v.is_empty()
-        {
-            env.push((key, v));
-        }
+    if !nic {
+        env.extend(proxy.iter().map(|(k, v)| (*k, v.as_str())));
     }
     env
+}
+
+/// The FORWARDED values present in silkd's own environment, read once: the
+/// unit environment is fixed at service start and silkd never mutates it.
+fn proxy_vars() -> &'static [(&'static str, String)] {
+    static PROXY_VARS: OnceLock<Vec<(&'static str, String)>> = OnceLock::new();
+    PROXY_VARS.get_or_init(|| snapshot_proxy(|key| std::env::var(key).ok()))
+}
+
+fn snapshot_proxy(get: impl Fn(&str) -> Option<String>) -> Vec<(&'static str, String)> {
+    FORWARDED
+        .iter()
+        .filter_map(|&key| match get(key) {
+            Some(v) if !v.is_empty() => Some((key, v)),
+            _ => None,
+        })
+        .collect()
 }
 
 /// Whether the guest has a NIC beyond lo/sit0. Read per call: cheap against a
@@ -311,16 +337,16 @@ mod tests {
     /// anyone asking; nothing else of silkd's environment is the guest's.
     #[test]
     fn base_env_forwards_only_the_proxy_variables() {
-        let vars = |key: &str| match key {
+        let proxy = snapshot_proxy(|key| match key {
             "http_proxy" => Some("http://127.0.0.1:3128".to_string()),
             "HTTPS_PROXY" => Some(String::new()),
             _ => Some("2048".to_string()),
-        };
-        let env = base_env_from(false, vars);
+        });
+        let env = compose_env(false, &proxy);
         assert_eq!(
             env.iter()
                 .find(|(k, _)| *k == "http_proxy")
-                .map(|(_, v)| v.as_str()),
+                .map(|(_, v)| *v),
             Some("http://127.0.0.1:3128"),
         );
         assert!(
@@ -337,11 +363,26 @@ mod tests {
     /// which is closed unless the host armed a proxy for this sandbox.
     #[test]
     fn base_env_forwards_nothing_when_a_nic_is_present() {
-        let env = base_env_from(true, |_| Some("http://127.0.0.1:3128".to_string()));
+        let proxy = snapshot_proxy(|_| Some("http://127.0.0.1:3128".to_string()));
+        let env = compose_env(true, &proxy);
         assert!(
             !env.iter().any(|(k, _)| *k == "http_proxy"),
             "proxy variables must stay off a lane with its own NIC",
         );
+    }
+
+    /// Env-inheriting children (git, language servers) follow the same lane
+    /// rule as cleared ones: scrubbed with a NIC, inherited without.
+    #[test]
+    fn align_proxy_env_scrubs_only_on_a_nic_lane() {
+        let removed = |cmd: &Command| cmd.as_std().get_envs().filter(|(_, v)| v.is_none()).count();
+        let mut with_nic = Command::new("true");
+        align_proxy_env_for(&mut with_nic, true);
+        assert_eq!(removed(&with_nic), FORWARDED.len());
+
+        let mut without_nic = Command::new("true");
+        align_proxy_env_for(&mut without_nic, false);
+        assert_eq!(removed(&without_nic), 0);
     }
 
     #[test]

--- a/silkd/tests/git_e2e.rs
+++ b/silkd/tests/git_e2e.rs
@@ -1,5 +1,5 @@
 //! git verb E2E against a real git binary in temp repos. Local verbs run on
-//! any host; the none-lane guard is exercised via SILKD_NET.
+//! any host; the none-lane guard is exercised via the test lane override.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)] // test code, like #[cfg(test)]
 mod common;
@@ -113,14 +113,11 @@ async fn commit_failure_surfaces_git_error() {
     assert_eq!(type_of(&frames[0]), "error");
 }
 
-// One test owns SILKD_NET so the two lane cases can't race a shared env var
-// against parallel test threads.
+// One test owns the lane override so the two cases cannot fight over it.
 #[tokio::test]
 async fn clone_lane_behavior() {
     // none lane refuses with a typed error pointing at fs.push.
-    // SAFETY: this test is the binary's only SILKD_NET accessor (see the
-    // ownership note above), so no thread races the mutation.
-    unsafe { std::env::set_var("SILKD_NET", "none") };
+    silkd::net::override_egress_for_tests(Some(false));
     let none = exchange(&[json!({
         "op":"git_clone","url":"https://example.com/x.git","path":"/tmp/silkd-x"
     })
@@ -137,17 +134,13 @@ async fn clone_lane_behavior() {
     git(src.path(), &["commit", "-qm", "init"]);
     let dst = tempfile::tempdir().unwrap();
     let target = dst.path().join("clone");
-    // SAFETY: this test is the binary's only SILKD_NET accessor (see the
-    // ownership note above), so no thread races the mutation.
-    unsafe { std::env::set_var("SILKD_NET", "egress") };
+    silkd::net::override_egress_for_tests(Some(true));
     let ok = exchange(&[json!({
         "op":"git_clone", "url": src.path().to_str().unwrap(), "path": target.to_str().unwrap()
     })
     .to_string()])
     .await;
-    // SAFETY: this test is the binary's only SILKD_NET accessor (see the
-    // ownership note above), so no thread races the mutation.
-    unsafe { std::env::remove_var("SILKD_NET") };
+    silkd::net::override_egress_for_tests(None);
     assert_eq!(type_of(last(&ok)), "done", "clone failed: {ok:?}");
     assert!(target.join("r.txt").exists());
 }


### PR DESCRIPTION
A `net=none` sandbox has no NIC at all: its egress is spliced over vsock to a
host-side proxy. That path worked, but only for a guest that had been told about
it — an unconfigured `curl` inside the sandbox still failed, which makes the
lane useless as a default.

**Bake the proxy into the guest.** The base image sets the proxy variables on
silkd's unit, so the lane is usable the moment a sandbox is claimed.

**Forward them into every exec — but only where they help.** `sysutil::base_env`
deliberately does not inherit silkd's environment, so silkd now forwards exactly
the six proxy variables — and only when the guest has no NIC beyond `lo`/`sit0`.
On a lane with its own NIC the loopback relay's host side is closed unless a
policy is armed, so forwarding there would steer every env-honoring client into
a dead proxy while the direct NIC works. Children that inherit silkd's
environment instead of starting from base_env (git, language servers) follow
the same lane rule via align_proxy_env. The proxy values are snapshotted once
(the unit environment is fixed at service start); the allow-list and the lane
gate are both pinned by test.

**Let a node name what its proxy may reach.** The proxy's SSRF guard refuses
private destinations, which also refuses the internal services a sandbox
legitimately needs. `egress_internal_allow` names the prefixes to re-admit —
node-wide: every pool and tenant on the node gets the same re-admission. The
guard's shape is pinned by test: re-admitting the named ranges must not re-admit
the guest bridges, which are themselves ULA/RFC1918 — a blanket "permit private"
would let one sandbox reach another and the host's own gateway. The fully-open
form is pinned separately so that choosing it stays deliberate.

Verified on a 20-node fleet: from a guest whose `ip link` lists only `lo` and
`sit0`, an unconfigured `curl` reaches a public host, an internal v4 host and a
v6-only internal host — all without proxy arguments.

`go test ./...` green; golangci-lint (pinned v2.12.2) clean on `GOOS=linux` and
`GOOS=darwin`; silkd `cargo fmt --check`, `cargo clippy --all-targets -- -D
warnings` and `cargo test` clean.
