### PR TITLE
Reclaim creating-state stale VMs safely; document dense-node host tuning

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -212,11 +212,6 @@ dominates fill throughput:
   no-network lane but overshoots the bridge lane: rtnl does not plateau under
   pressure, it collapses — on a quiet host RC 256 halves the fill rate RC 64
   achieves.
-- **Shard when one daemon is not enough.** Several sandboxd instances per
-  host (each with its own `data_dir`, `listen`, and bridges) joined by the
-  mesh behave as one capacity pool, measured ~3x the fill rate of a single
-  daemon at matched total concurrency — besides multiplying the 1024-port
-  bridge ceiling headroom.
 
 ### Reserving CPU for the control plane
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -187,6 +187,50 @@ The last setting also removes the VMM's network-namespace quarantine. On a
 measurement. Pause `cocoon daemon` or lengthen its reconcile interval during a
 mass fill.
 
+### Host tuning for dense egress-lane nodes
+
+The no-network lane is CPU-bound and needs none of this. The egress lane
+serializes on the kernel's global rtnl lock — tap create, bridge attach, and
+the VMM's own tap open all take it — so at hundreds of VMs host configuration
+dominates fill throughput:
+
+- **Keep the kernel console quiet** (`loglevel=4` on the kernel cmdline, or
+  drop `console=ttyS0`; dmesg and the journal keep everything either way).
+  Bridge port transitions printk synchronously to every registered console
+  *while holding rtnl*: measured on a serial+fbcon host, one bridge attach is
+  44 ms noisy vs 3 ms quiet, and a 1000-VM fill roughly triples. Fix the
+  console before tuning anything else — netlink-level optimizations are
+  unmeasurable, or negative, on a noisy console.
+- **Keep udev off the sandbox taps.** Every tap add/remove fires a udev
+  event; rule evaluation plus hooks like `ifupdown-hotplug` (a fork+exec per
+  interface) contend on the same rtnl lock — stopping the udev exec queue
+  during a fill measured ~4x throughput, and a backed-up event queue can
+  collapse a fill outright. Shadow the net-setup rules for these taps, or
+  pause the exec queue around planned mass fills.
+- **Set `refill_concurrency` explicitly (~64) on egress-heavy nodes.** The
+  auto default scales with cores (a 384-core node gets 256), which suits the
+  no-network lane but overshoots the bridge lane: rtnl does not plateau under
+  pressure, it collapses — on a quiet host RC 256 halves the fill rate RC 64
+  achieves.
+- **Shard when one daemon is not enough.** Several sandboxd instances per
+  host (each with its own `data_dir`, `listen`, and bridges) joined by the
+  mesh behave as one capacity pool, measured ~3x the fill rate of a single
+  daemon at matched total concurrency — besides multiplying the 1024-port
+  bridge ceiling headroom.
+
+### Reserving CPU for the control plane
+
+A saturated node can leave clone/wake execution and sandboxd itself nothing
+to run on — under full-node load CH clone p95 has measured in the tens of
+seconds. cocoon newer than v0.5.8 runs every VMM in its own cgroup v2 CPU
+scope (Guaranteed-at-N: a VM's CPU count is also its hard host-CPU cap) and
+adds `cgroup_cpus`, a one-time cpuset fence keeping the whole VM population —
+including the virtio and io-wq worker threads vCPU affinity cannot reach —
+off reserved host cores. On dense nodes set the fence in cocoon's config
+(e.g. `cgroup_cpus: "0-379"` on a 384-core host) so the reserved cores stay
+free for sandboxd, its cocoon invocations, and the OS; cocoon's CPU-isolation
+docs cover validation semantics and the per-VM knobs.
+
 ### Auth model
 
 Three token kinds. The root `api_token` has full access — operators and
@@ -210,7 +254,11 @@ sandboxd -config /etc/sandboxd/config.json
 ```
 
 On start the node reconciles: persisted claims whose VMs still run are
-re-adopted, everything else `sbx-`-prefixed is removed. Then the refill loop
+re-adopted, everything else `sbx-`-prefixed is removed. A record still in
+cocoon's `creating` state is reclaimed through `vm reconcile-stale-create`
+(cocoon ≥ v0.5.8), which refuses while a clone is in flight instead of
+deleting the VM out from under it; older cocoons fall back to forced
+removal. Then the refill loop
 builds one golden snapshot per pool (a one-time cold boot + snapshot export,
 tens of seconds) and keeps each pool topped up with claim-ready clones.
 `GET /v1/info` shows `"golden": true` and `warm` at target when the node is

--- a/e2e/fakeengine_test.go
+++ b/e2e/fakeengine_test.go
@@ -61,6 +61,10 @@ func (f *fakeEngine) Remove(_ context.Context, name string) error {
 	return nil
 }
 
+func (f *fakeEngine) ReconcileStaleCreate(context.Context, string) (engine.StaleCreateOutcome, error) {
+	return engine.StaleCreateNotCreating, nil
+}
+
 func (f *fakeEngine) SnapshotSave(_ context.Context, _, _ string) error { return nil }
 
 func (f *fakeEngine) SnapshotExport(_ context.Context, _, toDir string) error {

--- a/protocol/wire/frame.go
+++ b/protocol/wire/frame.go
@@ -713,8 +713,7 @@ func fastBulk(tag string, slow func([]byte) (Response, error), mk func([]byte) R
 
 // AppendBulkRequest renders a data-carrying request frame —
 // {"v":1,"op":<op>,"data":"<base64>"} plus newline — into buf, reused across
-// calls: the zero-alloc twin of EncodeRequest for the bulk send paths
-// (base64's alphabet needs no JSON escaping).
+// calls on the bulk send paths (base64's alphabet needs no JSON escaping).
 func AppendBulkRequest(buf []byte, op string, data []byte) []byte {
 	buf = append(buf[:0], requestHead...)
 	buf = append(buf, op...)

--- a/sandboxd/engine/engine.go
+++ b/sandboxd/engine/engine.go
@@ -32,6 +32,12 @@ const (
 	// RequiredCocoon carries the snapshot/store performance baseline.
 	RequiredCocoon = "v0.5.2"
 
+	// Stale-create verdicts, mirroring cocoon's reconcile-stale-create verb.
+	StaleCreateCollected   StaleCreateOutcome = "collected"
+	StaleCreateBusy        StaleCreateOutcome = "busy"
+	StaleCreateNotCreating StaleCreateOutcome = "not-creating"
+	StaleCreateNotFound    StaleCreateOutcome = "not-found"
+
 	argName       = "--name"
 	argOutput     = "--output"
 	argNetwork    = "--network"
@@ -58,6 +64,9 @@ var capacitySignatures = []string{
 	"exchange full",
 	"no space left on device",
 }
+
+// StaleCreateOutcome reports what reconcile-stale-create did with a record.
+type StaleCreateOutcome string
 
 // Engine runs cocoon commands on the local node.
 type Engine struct {
@@ -139,6 +148,22 @@ func (e *Engine) RunCold(ctx context.Context, name string, key types.PoolKey) (t
 func (e *Engine) Remove(ctx context.Context, name string) error {
 	_, err := e.run(ctx, "vm", "rm", "--force", name)
 	return err
+}
+
+// ReconcileStaleCreate reclaims a creating-state record via cocoon's
+// free-ops-lock predicate — safe against an in-flight clone where rm --force is not.
+func (e *Engine) ReconcileStaleCreate(ctx context.Context, name string) (StaleCreateOutcome, error) {
+	out, err := e.run(ctx, "vm", "reconcile-stale-create", name, argOutput, formatJSON)
+	if err != nil {
+		return "", err
+	}
+	var res struct {
+		Outcome StaleCreateOutcome `json:"outcome"`
+	}
+	if err := json.Unmarshal(out, &res); err != nil {
+		return "", fmt.Errorf("parse reconcile-stale-create: %w", err)
+	}
+	return res.Outcome, nil
 }
 
 // SnapshotSave snapshots a running VM under snapName.

--- a/sandboxd/pool/archive.go
+++ b/sandboxd/pool/archive.go
@@ -67,12 +67,7 @@ func (m *Manager) archiveOnce(ctx context.Context) {
 		logger := log.WithFunc("pool.archiveOnce")
 		m.runBounded(ctx, len(victims), func(ctx context.Context, i int) {
 			sb := victims[i]
-			switch err := m.archive(ctx, sb); {
-			case err == nil:
-				logger.Infof(ctx, "archived %s", sb.ID)
-			case !benignSweepErr(err):
-				logger.Errorf(ctx, err, "archive %s", sb.ID)
-			}
+			logSweepResult(ctx, logger, m.archive(ctx, sb), "archived "+sb.ID, "archive "+sb.ID)
 		}).Wait()
 	}()
 }

--- a/sandboxd/pool/claim.go
+++ b/sandboxd/pool/claim.go
@@ -363,12 +363,7 @@ func (m *Manager) reapOnce(ctx context.Context) {
 			m.purgeArchiveCk(ctx, v.id, v.ck, v.tenant)
 			logger.Infof(ctx, "purged archived sandbox %s", v.id)
 		case reapArchive:
-			switch err := m.archive(ctx, v.sb); {
-			case err == nil:
-				logger.Infof(ctx, "archived expired sandbox %s", v.id)
-			case !benignSweepErr(err):
-				logger.Errorf(ctx, err, "archive expired %s", v.id)
-			}
+			logSweepResult(ctx, logger, m.archive(ctx, v.sb), "archived expired sandbox "+v.id, "archive expired sandbox "+v.id)
 		default:
 			m.disarmEgress(v.id, m.removeOrRetry(ctx, v.vmName, v.id, ""))
 			m.dropSnap(ctx, v.snap)

--- a/sandboxd/pool/hibernate.go
+++ b/sandboxd/pool/hibernate.go
@@ -220,12 +220,7 @@ func (m *Manager) idleOnce(ctx context.Context) {
 		logger := log.WithFunc("pool.idleOnce")
 		m.runBounded(ctx, len(victims), func(ctx context.Context, i int) {
 			v := victims[i]
-			switch err := m.idleHibernate(ctx, v.id, v.token, now); {
-			case err == nil:
-				logger.Infof(ctx, "idle-hibernated %s", v.id)
-			case !benignSweepErr(err):
-				logger.Errorf(ctx, err, "idle-hibernate %s", v.id)
-			}
+			logSweepResult(ctx, logger, m.idleHibernate(ctx, v.id, v.token, now), "idle-hibernated "+v.id, "idle-hibernate "+v.id)
 		}).Wait()
 	}()
 }

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -152,8 +152,9 @@ type Gauges struct {
 }
 
 type pendingRemoval struct {
-	sandboxID string
-	tap       string
+	sandboxID   string
+	tap         string
+	staleCreate bool
 }
 
 type pool struct {

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
 	"github.com/cocoonstack/sandbox/sandboxd/egress"
+	"github.com/cocoonstack/sandbox/sandboxd/engine"
 	"github.com/cocoonstack/sandbox/sandboxd/netfilter"
 	"github.com/cocoonstack/sandbox/sandboxd/store"
 	"github.com/cocoonstack/sandbox/sandboxd/store/dir"
@@ -73,6 +74,7 @@ const (
 	hibernatePrefix = "sbx-hib-"
 	forkPrefix      = "sbx-fork-"
 	vmStateRunning  = "running"
+	vmStateCreating = "creating"
 
 	caSidecarSuffix = ".cafp"
 )
@@ -100,6 +102,7 @@ type Engine interface {
 	CloneSnap(ctx context.Context, snap, name string, key types.PoolKey) (types.VMRecord, error)
 	RunCold(ctx context.Context, name string, key types.PoolKey) (types.VMRecord, error)
 	Remove(ctx context.Context, name string) error
+	ReconcileStaleCreate(ctx context.Context, name string) (engine.StaleCreateOutcome, error)
 	SnapshotSave(ctx context.Context, vmName, snapName string) error
 	SnapshotExport(ctx context.Context, snapName, toDir string) error
 	SnapshotRemove(ctx context.Context, snapName string) error

--- a/sandboxd/pool/pool.go
+++ b/sandboxd/pool/pool.go
@@ -689,6 +689,16 @@ func tenantOwns(tenant, owner string) bool {
 
 // benignSweepErr reports whether err is the expected outcome of a housekeeping
 // sweep (victim released, woke mid-sweep, or a lane that never hibernates).
+// logSweepResult reports one background-sweep outcome; benign races stay silent.
+func logSweepResult(ctx context.Context, logger *log.Fields, err error, okMsg, failMsg string) {
+	switch {
+	case err == nil:
+		logger.Info(ctx, okMsg)
+	case !benignSweepErr(err):
+		logger.Error(ctx, err, failMsg)
+	}
+}
+
 func benignSweepErr(err error) bool {
 	return errors.Is(err, ErrUnknownSandbox) || errors.Is(err, errWokeMeanwhile) ||
 		errors.Is(err, ErrNoEgressHibernate)

--- a/sandboxd/pool/pool_test.go
+++ b/sandboxd/pool/pool_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
 	"github.com/cocoonstack/sandbox/sandboxd/egress"
+	"github.com/cocoonstack/sandbox/sandboxd/engine"
 	"github.com/cocoonstack/sandbox/sandboxd/types"
 )
 
@@ -765,8 +766,12 @@ type fakeEngine struct {
 	hibernates, restores, snapRemoves []string
 	snapSaves, exports, snapshots     []string
 	caInstalls                        []string // vsock sockets InstallCACert was called on
+	staleReconciles                   []string // VM names ReconcileStaleCreate was called on
 	installCAErr                      error
 	stopped                           map[string]bool
+	creating                          map[string]bool // VMs List reports in the creating state
+	staleOutcome                      engine.StaleCreateOutcome
+	staleErr                          error
 	pids                              map[string]int // VM name → PID, for Stats' resident-set lookup
 	vsockLateN                        int            // List calls that report no socket yet
 
@@ -787,7 +792,7 @@ type fakeEngine struct {
 }
 
 func newFakeEngine() *fakeEngine {
-	return &fakeEngine{vms: map[string]string{}, stopped: map[string]bool{}, pids: map[string]int{}}
+	return &fakeEngine{vms: map[string]string{}, stopped: map[string]bool{}, creating: map[string]bool{}, pids: map[string]int{}}
 }
 
 func (f *fakeEngine) Clone(_ context.Context, fromDir, name string, _ types.PoolKey) (types.VMRecord, error) {
@@ -828,6 +833,24 @@ func (f *fakeEngine) Remove(ctx context.Context, name string) error {
 	f.removes = append(f.removes, name)
 	delete(f.vms, name)
 	return nil
+}
+
+func (f *fakeEngine) ReconcileStaleCreate(ctx context.Context, name string) (engine.StaleCreateOutcome, error) {
+	// Models exec.CommandContext: a canceled ctx never runs cocoon at all.
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.staleReconciles = append(f.staleReconciles, name)
+	if f.staleErr != nil {
+		return "", f.staleErr
+	}
+	if f.staleOutcome == engine.StaleCreateCollected || f.staleOutcome == engine.StaleCreateNotFound {
+		delete(f.vms, name)
+		delete(f.creating, name)
+	}
+	return f.staleOutcome, nil
 }
 
 func (f *fakeEngine) SnapshotSave(_ context.Context, _, snapName string) error {
@@ -918,7 +941,10 @@ func (f *fakeEngine) List(_ context.Context, filters ...string) ([]types.VMRecor
 		}
 		sock = f.lateVsock(sock)
 		state := vmStateRunning
-		if f.stopped[name] {
+		switch {
+		case f.creating[name]:
+			state = vmStateCreating
+		case f.stopped[name]:
 			state = "stopped"
 		}
 		rec := types.VMRecord{State: state, PID: f.pids[name], VsockSocket: sock, Config: types.VMConfig{Name: name}}

--- a/sandboxd/pool/reconcile.go
+++ b/sandboxd/pool/reconcile.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/projecteru2/core/log"
 
+	"github.com/cocoonstack/sandbox/sandboxd/engine"
 	"github.com/cocoonstack/sandbox/sandboxd/netfilter"
 	"github.com/cocoonstack/sandbox/sandboxd/types"
 )
@@ -131,7 +132,7 @@ func (m *Manager) sweepStaleVMs(ctx context.Context, live map[string]types.VMRec
 	}
 	gone := make([]bool, len(stale)) // distinct indices: no lock under the Wait barrier
 	m.runBounded(ctx, len(stale), func(ctx context.Context, i int) {
-		if m.removeOrRetry(ctx, stale[i], "", live[stale[i]].TapDevice()) {
+		if m.removeStaleVM(ctx, stale[i], live[stale[i]]) {
 			gone[i] = true
 			logger.Infof(ctx, "removed stale VM %s", stale[i])
 		}
@@ -143,6 +144,30 @@ func (m *Manager) sweepStaleVMs(ctx context.Context, live map[string]types.VMRec
 		}
 	}
 	return removed
+}
+
+// removeStaleVM reclaims one unowned VM, reporting whether it is gone; a
+// creating-state record goes through reconcile-stale-create first, since
+// rm --force would queue on the ops lock and then delete the VM an
+// in-flight clone just produced.
+func (m *Manager) removeStaleVM(ctx context.Context, name string, rec types.VMRecord) bool {
+	logger := log.WithFunc("pool.removeStaleVM")
+	if rec.State == vmStateCreating {
+		// Cancellation-immune like removeVM: a canceled ctx must not skip
+		// the busy check and fall through to the forced remove it guards.
+		switch outcome, err := m.eng.ReconcileStaleCreate(context.WithoutCancel(ctx), name); {
+		case err != nil:
+			// Verb missing (cocoon < v0.5.8) or failed: keep the old sweep.
+			logger.Warnf(ctx, "reconcile stale create %s: %v; removing", name, err)
+		case outcome == engine.StaleCreateCollected, outcome == engine.StaleCreateNotFound:
+			return true
+		case outcome == engine.StaleCreateBusy:
+			logger.Infof(ctx, "stale create %s has an in-flight owner; left alone", name)
+			return false
+		}
+		// not-creating: the record moved on under the lock; remove normally.
+	}
+	return m.removeOrRetry(ctx, name, "", rec.TapDevice())
 }
 
 // resyncEgress re-locks adopted egress claims after a restart, quarantines any

--- a/sandboxd/pool/reconcile.go
+++ b/sandboxd/pool/reconcile.go
@@ -163,6 +163,7 @@ func (m *Manager) removeStaleVM(ctx context.Context, name string, rec types.VMRe
 			return true
 		case outcome == engine.StaleCreateBusy:
 			logger.Infof(ctx, "stale create %s has an in-flight owner; left alone", name)
+			m.queueStaleCreate(name, rec.TapDevice())
 			return false
 		}
 		// not-creating: the record moved on under the lock; remove normally.

--- a/sandboxd/pool/reconcile.go
+++ b/sandboxd/pool/reconcile.go
@@ -162,7 +162,7 @@ func (m *Manager) removeStaleVM(ctx context.Context, name string, rec types.VMRe
 		case outcome == engine.StaleCreateCollected, outcome == engine.StaleCreateNotFound:
 			return true
 		case outcome == engine.StaleCreateBusy:
-			logger.Infof(ctx, "stale create %s has an in-flight owner; left alone", name)
+			logger.Infof(ctx, "stale create %s has an in-flight owner; queued for retry", name)
 			m.queueStaleCreate(name, rec.TapDevice())
 			return false
 		}

--- a/sandboxd/pool/reconcile_test.go
+++ b/sandboxd/pool/reconcile_test.go
@@ -11,14 +11,7 @@ import (
 )
 
 func TestReconcileStaleCreateSweep(t *testing.T) {
-	tests := []struct {
-		name        string
-		outcome     engine.StaleCreateOutcome
-		err         error
-		wantPresent bool
-		wantRemove  bool
-		wantPending bool
-	}{
+	tests := []staleCreateCase{
 		{"collected frees the record", engine.StaleCreateCollected, nil, false, false, false},
 		{"not-found treats the record as gone", engine.StaleCreateNotFound, nil, false, false, false},
 		{"busy leaves the in-flight clone", engine.StaleCreateBusy, nil, true, false, true},
@@ -59,14 +52,7 @@ func TestReconcileStaleCreateSweep(t *testing.T) {
 }
 
 func TestBusyStaleCreateRetryConverges(t *testing.T) {
-	tests := []struct {
-		name        string
-		outcome     engine.StaleCreateOutcome
-		err         error
-		wantPresent bool
-		wantRemove  bool
-		wantPending bool
-	}{
+	tests := []staleCreateCase{
 		{"collected", engine.StaleCreateCollected, nil, false, false, false},
 		{"not-found", engine.StaleCreateNotFound, nil, false, false, false},
 		{"not-creating", engine.StaleCreateNotCreating, nil, false, true, false},
@@ -164,4 +150,15 @@ func TestReconcileStaleRunningVMSkipsVerb(t *testing.T) {
 	if !eng.removed("sbx-orphan-1") {
 		t.Error("unowned running VM not removed")
 	}
+}
+
+// staleCreateCase drives both the startup sweep and the reap-tick retry
+// through the same outcome/end-state row shape.
+type staleCreateCase struct {
+	name        string
+	outcome     engine.StaleCreateOutcome
+	err         error
+	wantPresent bool
+	wantRemove  bool
+	wantPending bool
 }

--- a/sandboxd/pool/reconcile_test.go
+++ b/sandboxd/pool/reconcile_test.go
@@ -15,14 +15,15 @@ func TestReconcileStaleCreateSweep(t *testing.T) {
 		name        string
 		outcome     engine.StaleCreateOutcome
 		err         error
-		wantPresent bool // the VM survives the sweep
-		wantRemove  bool // rm --force ran
+		wantPresent bool
+		wantRemove  bool
+		wantPending bool
 	}{
-		{"collected frees the record", engine.StaleCreateCollected, nil, false, false},
-		{"not-found treats the record as gone", engine.StaleCreateNotFound, nil, false, false},
-		{"busy leaves the in-flight clone", engine.StaleCreateBusy, nil, true, false},
-		{"not-creating removes normally", engine.StaleCreateNotCreating, nil, false, true},
-		{"verb failure falls back to remove", "", errors.New("unknown command"), false, true},
+		{"collected frees the record", engine.StaleCreateCollected, nil, false, false, false},
+		{"not-found treats the record as gone", engine.StaleCreateNotFound, nil, false, false, false},
+		{"busy leaves the in-flight clone", engine.StaleCreateBusy, nil, true, false, true},
+		{"not-creating removes normally", engine.StaleCreateNotCreating, nil, false, true, false},
+		{"verb failure falls back to remove", "", errors.New("unknown command"), false, true, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -47,6 +48,59 @@ func TestReconcileStaleCreateSweep(t *testing.T) {
 			if eng.removed("sbx-stale-1") != tt.wantRemove {
 				t.Errorf("removed=%v, want %v", eng.removed("sbx-stale-1"), tt.wantRemove)
 			}
+			m.mu.Lock()
+			_, pending := m.pendingRemovals["sbx-stale-1"]
+			m.mu.Unlock()
+			if pending != tt.wantPending {
+				t.Errorf("pending=%v, want %v", pending, tt.wantPending)
+			}
+		})
+	}
+}
+
+func TestBusyStaleCreateRetryConverges(t *testing.T) {
+	tests := []struct {
+		name        string
+		outcome     engine.StaleCreateOutcome
+		err         error
+		wantPresent bool
+		wantRemove  bool
+		wantPending bool
+	}{
+		{"collected", engine.StaleCreateCollected, nil, false, false, false},
+		{"not-found", engine.StaleCreateNotFound, nil, false, false, false},
+		{"not-creating", engine.StaleCreateNotCreating, nil, false, true, false},
+		{"still busy", engine.StaleCreateBusy, nil, true, false, true},
+		{"verb failure", "", errors.New("temporary failure"), true, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eng := newFakeEngine()
+			eng.vms["sbx-stale-1"] = "/vsock/sbx-stale-1"
+			eng.creating["sbx-stale-1"] = true
+			eng.staleOutcome = engine.StaleCreateBusy
+			m := newTestManager(t, eng)
+
+			if err := m.Reconcile(t.Context()); err != nil {
+				t.Fatalf("Reconcile: %v", err)
+			}
+			eng.mu.Lock()
+			eng.staleOutcome, eng.staleErr = tt.outcome, tt.err
+			eng.mu.Unlock()
+			m.retryRemovals(t.Context()).Wait()
+
+			eng.mu.Lock()
+			_, present := eng.vms["sbx-stale-1"]
+			eng.mu.Unlock()
+			m.mu.Lock()
+			_, pending := m.pendingRemovals["sbx-stale-1"]
+			m.mu.Unlock()
+			removed := eng.removed("sbx-stale-1")
+			if present != tt.wantPresent || removed != tt.wantRemove || pending != tt.wantPending {
+				t.Errorf("present=%v removed=%v pending=%v, want %v %v %v",
+					present, removed, pending,
+					tt.wantPresent, tt.wantRemove, tt.wantPending)
+			}
 		})
 	}
 }
@@ -66,6 +120,12 @@ func TestReconcileBusyStaleCreateKeepsTap(t *testing.T) {
 	}
 	if !gotKeep["tap-busy"] {
 		t.Error("busy VM's tap not kept; the sweep would tear down an in-flight clone's tables")
+	}
+	m.mu.Lock()
+	pending, ok := m.pendingRemovals["sbx-stale-1"]
+	m.mu.Unlock()
+	if !ok || !pending.staleCreate || pending.tap != "tap-busy" {
+		t.Errorf("pending=%+v present=%v, want stale-create retry with tap-busy", pending, ok)
 	}
 }
 

--- a/sandboxd/pool/reconcile_test.go
+++ b/sandboxd/pool/reconcile_test.go
@@ -1,0 +1,107 @@
+package pool
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/cocoonstack/sandbox/sandboxd/engine"
+	"github.com/cocoonstack/sandbox/sandboxd/types"
+)
+
+func TestReconcileStaleCreateSweep(t *testing.T) {
+	tests := []struct {
+		name        string
+		outcome     engine.StaleCreateOutcome
+		err         error
+		wantPresent bool // the VM survives the sweep
+		wantRemove  bool // rm --force ran
+	}{
+		{"collected frees the record", engine.StaleCreateCollected, nil, false, false},
+		{"not-found treats the record as gone", engine.StaleCreateNotFound, nil, false, false},
+		{"busy leaves the in-flight clone", engine.StaleCreateBusy, nil, true, false},
+		{"not-creating removes normally", engine.StaleCreateNotCreating, nil, false, true},
+		{"verb failure falls back to remove", "", errors.New("unknown command"), false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eng := newFakeEngine()
+			eng.vms["sbx-stale-1"] = "/vsock/sbx-stale-1"
+			eng.creating["sbx-stale-1"] = true
+			eng.staleOutcome, eng.staleErr = tt.outcome, tt.err
+			m := newTestManager(t, eng)
+
+			if err := m.Reconcile(t.Context()); err != nil {
+				t.Fatalf("Reconcile: %v", err)
+			}
+			if !slices.Contains(eng.staleReconciles, "sbx-stale-1") {
+				t.Fatal("reconcile-stale-create not attempted for the creating VM")
+			}
+			eng.mu.Lock()
+			_, present := eng.vms["sbx-stale-1"]
+			eng.mu.Unlock()
+			if present != tt.wantPresent {
+				t.Errorf("present=%v, want %v", present, tt.wantPresent)
+			}
+			if eng.removed("sbx-stale-1") != tt.wantRemove {
+				t.Errorf("removed=%v, want %v", eng.removed("sbx-stale-1"), tt.wantRemove)
+			}
+		})
+	}
+}
+
+func TestReconcileBusyStaleCreateKeepsTap(t *testing.T) {
+	eng := newFakeEngine()
+	eng.tap = "tap-busy"
+	eng.vms["sbx-stale-1"] = "/vsock/sbx-stale-1"
+	eng.creating["sbx-stale-1"] = true
+	eng.staleOutcome = engine.StaleCreateBusy
+	m := newTestManager(t, eng)
+
+	var gotKeep map[string]bool
+	m.sweep = func(keep map[string]bool) error { gotKeep = keep; return nil }
+	if err := m.Reconcile(t.Context()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if !gotKeep["tap-busy"] {
+		t.Error("busy VM's tap not kept; the sweep would tear down an in-flight clone's tables")
+	}
+}
+
+func TestRemoveStaleVMCanceledCtxStillChecksBusy(t *testing.T) {
+	eng := newFakeEngine()
+	eng.vms["sbx-stale-1"] = "/vsock/sbx-stale-1"
+	eng.creating["sbx-stale-1"] = true
+	eng.staleOutcome = engine.StaleCreateBusy
+	m := newTestManager(t, eng)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	rec := types.VMRecord{State: vmStateCreating, Config: types.VMConfig{Name: "sbx-stale-1"}}
+	if m.removeStaleVM(ctx, "sbx-stale-1", rec) {
+		t.Error("busy VM reported gone under a canceled ctx")
+	}
+	if len(eng.staleReconciles) != 1 {
+		t.Errorf("verb ran %d times, want 1 (cancellation-immune)", len(eng.staleReconciles))
+	}
+	if eng.removed("sbx-stale-1") {
+		t.Error("canceled ctx fell through to the forced remove the verb guards")
+	}
+}
+
+func TestReconcileStaleRunningVMSkipsVerb(t *testing.T) {
+	eng := newFakeEngine()
+	eng.vms["sbx-orphan-1"] = "/vsock/sbx-orphan-1"
+	m := newTestManager(t, eng)
+
+	if err := m.Reconcile(t.Context()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if len(eng.staleReconciles) != 0 {
+		t.Errorf("reconcile-stale-create ran on a running VM: %v", eng.staleReconciles)
+	}
+	if !eng.removed("sbx-orphan-1") {
+		t.Error("unowned running VM not removed")
+	}
+}

--- a/sandboxd/pool/remove.go
+++ b/sandboxd/pool/remove.go
@@ -85,8 +85,7 @@ func (m *Manager) retryRemovals(ctx context.Context) *sync.WaitGroup {
 
 func (m *Manager) retryRemoval(ctx context.Context, name string, pending pendingRemoval) {
 	if pending.staleCreate {
-		outcome, err := m.eng.ReconcileStaleCreate(ctx, name)
-		switch {
+		switch outcome, err := m.eng.ReconcileStaleCreate(ctx, name); {
 		case err != nil:
 			log.WithFunc("pool.retryRemoval").Warnf(ctx, "reconcile stale create %s: %v; retrying", name, err)
 			m.queueStaleCreate(name, pending.tap)

--- a/sandboxd/pool/remove.go
+++ b/sandboxd/pool/remove.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/projecteru2/core/log"
 
+	"github.com/cocoonstack/sandbox/sandboxd/engine"
 	"github.com/cocoonstack/sandbox/sandboxd/netfilter"
 )
 
@@ -58,6 +59,12 @@ func (m *Manager) queueRemoval(name, sandboxID, tap string) {
 	m.mu.Unlock()
 }
 
+func (m *Manager) queueStaleCreate(name, tap string) {
+	m.mu.Lock()
+	m.pendingRemovals[name] = pendingRemoval{tap: tap, staleCreate: true}
+	m.mu.Unlock()
+}
+
 // retryRemovals dispatches by emptying the queue, so absence also means "in
 // flight" and the next tick cannot double-dispatch; a failed retry re-queues
 // itself on completion. Callers that need completion Wait.
@@ -77,10 +84,29 @@ func (m *Manager) retryRemovals(ctx context.Context) *sync.WaitGroup {
 }
 
 func (m *Manager) retryRemoval(ctx context.Context, name string, pending pendingRemoval) {
+	if pending.staleCreate {
+		outcome, err := m.eng.ReconcileStaleCreate(ctx, name)
+		switch {
+		case err != nil:
+			log.WithFunc("pool.retryRemoval").Warnf(ctx, "reconcile stale create %s: %v; retrying", name, err)
+			m.queueStaleCreate(name, pending.tap)
+			return
+		case outcome == engine.StaleCreateBusy:
+			m.queueStaleCreate(name, pending.tap)
+			return
+		case outcome == engine.StaleCreateCollected, outcome == engine.StaleCreateNotFound:
+			m.finishRemoval(pending)
+			return
+		}
+	}
 	if !m.removeVM(ctx, name) {
 		m.queueRemoval(name, pending.sandboxID, pending.tap)
 		return
 	}
+	m.finishRemoval(pending)
+}
+
+func (m *Manager) finishRemoval(pending pendingRemoval) {
 	if pending.sandboxID != "" {
 		m.disarmEgress(pending.sandboxID, true)
 	} else if pending.tap != "" {

--- a/sandboxd/store/peer/peer.go
+++ b/sandboxd/store/peer/peer.go
@@ -57,7 +57,6 @@ func (h *Healer) Pull(ctx context.Context, id, staging string, validate Validate
 	return h.pullFrom(ctx, id, staging, addrs, budget, validate)
 }
 
-// pullFrom tries each owner in turn, giving each an even slice of budget.
 func (h *Healer) pullFrom(ctx context.Context, id, staging string, addrs []string, budget time.Duration, validate Validate) error {
 	perOwner := budget / time.Duration(len(addrs))
 	var errs []error

--- a/sandboxd/store/peer/peer_test.go
+++ b/sandboxd/store/peer/peer_test.go
@@ -98,13 +98,9 @@ func TestHealErrorIsReported(t *testing.T) {
 	}
 }
 
-// TestPullDoesNotDedupConcurrentCalls: Pull used to share one singleflight
-// result across concurrent callers, which was only safe because every
-// caller happened to pass the SAME staging dir. With independent dirs (the
-// only safe assumption once dedup is not Pull's job), sharing a result would
-// leave whichever caller did not trigger the shared call with an untouched,
-// empty directory published as if it were a real record. Two concurrent
-// Pulls for one id but different dirs must each run their own full transfer.
+// TestPullDoesNotDedupConcurrentCalls: concurrent Pulls for one id but
+// different staging dirs must each run their own transfer — sharing a result
+// would leave one caller's dir empty but published as real.
 func TestPullDoesNotDedupConcurrentCalls(t *testing.T) {
 	puller := &fakePuller{records: map[string]map[string]string{"peer-a:7777": record()}}
 	h := NewHealer(func(string) []string { return []string{"peer-a:7777"} }, puller)

--- a/sandboxd/store/peer/transport.go
+++ b/sandboxd/store/peer/transport.go
@@ -52,7 +52,6 @@ type HTTPPuller struct {
 	Token  string
 }
 
-// Pull implements Puller.
 func (p *HTTPPuller) Pull(ctx context.Context, addr, id, dst string) error {
 	ctx, cancel := context.WithTimeout(ctx, pullTimeout)
 	defer cancel()

--- a/sdk/go/checkpoint.go
+++ b/sdk/go/checkpoint.go
@@ -3,7 +3,6 @@ package sandbox
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 )
@@ -35,28 +34,15 @@ func (ck *Checkpoint) New(ctx context.Context, opts ...Option) (*Sandbox, error)
 	if err := claim.rejectPinnedAxes(); err != nil {
 		return nil, err
 	}
-	body, err := encodeBody("checkpoint claim", checkpointClaimRequest{TTLSeconds: claim.TTLSeconds})
-	if err != nil {
-		return nil, err
-	}
-	cr, err := ck.claimAt(ctx, ck.addr, body)
-	if err != nil {
-		return nil, err
-	}
-	if len(cr.Redirect) == 0 {
-		return ck.c.handleFrom(ck.addr, cr), nil
-	}
-	body, err = encodeBody("checkpoint claim", checkpointClaimRequest{TTLSeconds: claim.TTLSeconds, NoRedirect: true})
-	if err != nil {
-		return nil, err
-	}
-	addr, target, err := redirectFallback(ck.addr, cr.Redirect, func(a string) (claimResponse, error) {
+	addr, cr, err := claimFollow(ck.addr, "claim checkpoint", func(noRedirect bool) ([]byte, error) {
+		return encodeBody("checkpoint claim", checkpointClaimRequest{TTLSeconds: claim.TTLSeconds, NoRedirect: noRedirect})
+	}, func(a string, body []byte) (claimResponse, error) {
 		return ck.claimAt(ctx, a, body)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("claim checkpoint: %w", err)
+		return nil, err
 	}
-	return ck.c.handleFrom(addr, target), nil
+	return ck.c.handleFrom(addr, cr), nil
 }
 
 // Delete removes the checkpoint from its node and asks every peer that node

--- a/sdk/go/checkpoint_test.go
+++ b/sdk/go/checkpoint_test.go
@@ -124,10 +124,8 @@ func TestCheckpointNewRedirectFallbackHeals(t *testing.T) {
 	}
 }
 
-// TestCheckpointNewRedirectNeverYieldsEmptyID is a regression test: New used
-// to hand a bare redirect reply straight to handleFrom, producing a Sandbox
-// with no id/token. It must now follow the redirect and fail loudly when no
-// candidate answers, never return a Sandbox with an empty ID.
+// TestCheckpointNewRedirectNeverYieldsEmptyID: New must fail loudly, not
+// return a Sandbox with an empty ID, when no redirect candidate answers.
 func TestCheckpointNewRedirectNeverYieldsEmptyID(t *testing.T) {
 	entry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(claimResponse{Redirect: []string{"127.0.0.1:1"}})

--- a/sdk/go/client.go
+++ b/sdk/go/client.go
@@ -46,30 +46,16 @@ func (c *Client) New(ctx context.Context, template string, opts ...Option) (*San
 	for _, opt := range opts {
 		opt(&claim)
 	}
-	body, err := encodeBody("claim", claim)
-	if err != nil {
-		return nil, err
-	}
-
-	cr, err := c.claimAt(ctx, c.addr, body)
-	if err != nil {
-		return nil, err
-	}
-	if len(cr.Redirect) == 0 {
-		return c.handleFrom(c.addr, cr), nil
-	}
-	claim.NoRedirect = true
-	body, err = encodeBody("claim", claim)
-	if err != nil {
-		return nil, err
-	}
-	addr, target, err := redirectFallback(c.addr, cr.Redirect, func(a string) (claimResponse, error) {
+	addr, cr, err := claimFollow(c.addr, "claim", func(noRedirect bool) ([]byte, error) {
+		claim.NoRedirect = noRedirect
+		return encodeBody("claim", claim)
+	}, func(a string, body []byte) (claimResponse, error) {
 		return c.claimAt(ctx, a, body)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("claim: %w", err)
+		return nil, err
 	}
-	return c.handleFrom(addr, target), nil
+	return c.handleFrom(addr, cr), nil
 }
 
 // Lookup relocates a sandbox handle whose owner address was lost, given its
@@ -222,6 +208,14 @@ func doJSON[T any](ctx context.Context, c *Client, method, addr, path string, bo
 	return out, nil
 }
 
+func doJSONPtr[T any](ctx context.Context, c *Client, method, addr, path string, body io.Reader, bearer, verb string) (*T, error) {
+	out, err := doJSON[T](ctx, c, method, addr, path, body, bearer, verb)
+	if err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
 // doNoContent is doJSON's reply-less twin: 204 or an apiError.
 func doNoContent(ctx context.Context, c *Client, method, addr, path string, body io.Reader, bearer, verb string) error {
 	resp, err := c.roundTrip(ctx, method, addr, path, body, bearer)
@@ -295,6 +289,33 @@ func retryTransient(err error) bool {
 // an auth rejection, a conflict) skips the fallback: origin would fail the
 // same way. A second-level redirect (a compliant server never sends one
 // once no_redirect is set) fails the candidate rather than being followed.
+// claimFollow runs the claim protocol from origin: claim there, and on a
+// redirect re-encode with no_redirect and follow via redirectFallback. Only
+// the fallback error carries the verb — first-contact errors return raw.
+func claimFollow(origin, verb string, encode func(noRedirect bool) ([]byte, error), claimAt func(addr string, body []byte) (claimResponse, error)) (string, claimResponse, error) {
+	body, err := encode(false)
+	if err != nil {
+		return "", claimResponse{}, err
+	}
+	cr, err := claimAt(origin, body)
+	if err != nil {
+		return "", claimResponse{}, err
+	}
+	if len(cr.Redirect) == 0 {
+		return origin, cr, nil
+	}
+	if body, err = encode(true); err != nil {
+		return "", claimResponse{}, err
+	}
+	addr, target, err := redirectFallback(origin, cr.Redirect, func(a string) (claimResponse, error) {
+		return claimAt(a, body)
+	})
+	if err != nil {
+		return "", claimResponse{}, fmt.Errorf("%s: %w", verb, err)
+	}
+	return addr, target, nil
+}
+
 func redirectFallback(origin string, candidates []string, claimAt func(addr string) (claimResponse, error)) (string, claimResponse, error) {
 	claimNoRedirect := func(target string) (claimResponse, error) {
 		cr, err := claimAt(target)

--- a/sdk/go/drain.go
+++ b/sdk/go/drain.go
@@ -8,18 +8,10 @@ import (
 // Drain cordons the entry node (root token): new claims/forks/branches are
 // refused, live claims run to their leases; poll Info until Claimed is zero.
 func (c *Client) Drain(ctx context.Context) (*NodeInfo, error) {
-	info, err := doJSON[NodeInfo](ctx, c, http.MethodPost, c.addr, "/v1/drain", nil, c.apiToken, "drain")
-	if err != nil {
-		return nil, err
-	}
-	return &info, nil
+	return doJSONPtr[NodeInfo](ctx, c, http.MethodPost, c.addr, "/v1/drain", nil, c.apiToken, "drain")
 }
 
 // Uncordon lifts a drain on the entry node (root token).
 func (c *Client) Uncordon(ctx context.Context) (*NodeInfo, error) {
-	info, err := doJSON[NodeInfo](ctx, c, http.MethodDelete, c.addr, "/v1/drain", nil, c.apiToken, "uncordon")
-	if err != nil {
-		return nil, err
-	}
-	return &info, nil
+	return doJSONPtr[NodeInfo](ctx, c, http.MethodDelete, c.addr, "/v1/drain", nil, c.apiToken, "uncordon")
 }

--- a/sdk/go/files_test.go
+++ b/sdk/go/files_test.go
@@ -93,8 +93,6 @@ func TestSessionLifecycle(t *testing.T) {
 	}
 }
 
-// fakeSandbox wires a Sandbox whose data plane is served by a temp-dir-backed
-// silkd Fake behind a hijacking agent endpoint.
 func TestReadFileMultiChunk(t *testing.T) {
 	sb := fakeSandbox(t)
 	ctx := t.Context()
@@ -111,6 +109,8 @@ func TestReadFileMultiChunk(t *testing.T) {
 	}
 }
 
+// fakeSandbox wires a Sandbox whose data plane is served by a temp-dir-backed
+// silkd Fake behind a hijacking agent endpoint.
 func fakeSandbox(t *testing.T) *Sandbox {
 	t.Helper()
 	fake := silkdtest.NewFake(t.TempDir())

--- a/sdk/go/info.go
+++ b/sdk/go/info.go
@@ -38,11 +38,7 @@ type PoolStatus struct {
 
 // Info reports the entry node's pools, claim counts, and mesh peers.
 func (c *Client) Info(ctx context.Context) (*NodeInfo, error) {
-	info, err := doJSON[NodeInfo](ctx, c, http.MethodGet, c.addr, "/v1/info", nil, c.apiToken, "info")
-	if err != nil {
-		return nil, err
-	}
-	return &info, nil
+	return doJSONPtr[NodeInfo](ctx, c, http.MethodGet, c.addr, "/v1/info", nil, c.apiToken, "info")
 }
 
 // peers fetches the cluster's node addresses, best-effort (nil on failure).

--- a/sdk/go/pools.go
+++ b/sdk/go/pools.go
@@ -73,9 +73,5 @@ func (c *Client) setPoolsAt(ctx context.Context, addr string, pools []PoolSpec) 
 	if err != nil {
 		return nil, err
 	}
-	info, err := doJSON[NodeInfo](ctx, c, http.MethodPut, addr, "/v1/pools", bytes.NewReader(body), c.apiToken, "pools")
-	if err != nil {
-		return nil, err
-	}
-	return &info, nil
+	return doJSONPtr[NodeInfo](ctx, c, http.MethodPut, addr, "/v1/pools", bytes.NewReader(body), c.apiToken, "pools")
 }

--- a/sdk/go/pty_test.go
+++ b/sdk/go/pty_test.go
@@ -31,7 +31,6 @@ func TestPtyEchoAndExit(t *testing.T) {
 		t.Errorf("read %q, want ping", line)
 	}
 
-	// Resize is a separate RPC.
 	if err := pty.Resize(t.Context(), 120, 40); err != nil {
 		t.Fatalf("resize: %v", err)
 	}

--- a/sdk/go/silkd/silkdtest/fake.go
+++ b/sdk/go/silkd/silkdtest/fake.go
@@ -19,13 +19,13 @@ import (
 	"github.com/cocoonstack/sandbox/protocol/wire"
 )
 
+// readChunk mirrors silkd's BULK_CHUNK so downloads exercise real framing.
+const readChunk = 256 * 1024
+
 // Fake is a stateful silkd fake backing the fs verbs with a real directory
 // and tracking sessions, so an SDK write-then-read round-trips through it.
 // exec/info reuse the stateless handlers. It exists for host-side unit tests;
 // the authoritative fs/session behavior is silkd's own Rust test suite.
-// readChunk mirrors silkd's BULK_CHUNK so downloads exercise real framing.
-const readChunk = 256 * 1024
-
 type Fake struct {
 	Root string
 

--- a/silkd/src/sysutil.rs
+++ b/silkd/src/sysutil.rs
@@ -1,6 +1,7 @@
 //! Small OS helpers: the base environment for spawned commands, best-effort
-//! user de-escalation, and the one signal syscall — all the crate's unsafe
-//! lives here.
+//! user de-escalation, and the one signal syscall — the crate's unsafe work
+//! lives here (pty.rs holds the one other unsafe block, its pre_exec
+//! registration).
 
 use std::fmt::Write as _;
 use std::io::Read;


### PR DESCRIPTION
## What

Two robustness items consuming the cocoon v0.5.8 line:

1. **Startup sweep: `vm reconcile-stale-create` for creating-state records.** The reconcile sweep force-removed every unowned `sbx-` VM, but `rm --force` queues on the VM ops lock — against a clone still in flight from a previous daemon life it waits, then deletes the VM the clone just produced. Creating-state records now go through cocoon's stale-create verb (cocoonstack/cocoon#173), which collects only when the ops lock is free:
   - `collected`/`not-found` → gone, no forced remove;
   - `busy` → left to its in-flight owner and queued for the reap tick, which re-runs the verb until it converges (collected/not-found, or not-creating → normal removal); its tap stays out of the reconcile-time egress table sweep meanwhile;
   - `not-creating` → the record moved on under the lock; normal removal;
   - verb error (cocoon < v0.5.8) → fall back to the previous forced remove, so older fleets keep today's behavior.

   The verb call is cancellation-immune like `removeVM`: a SIGTERM landing mid-reconcile must not skip the busy check and fall through to the forced remove it guards (mutation-verified by `TestRemoveStaleVMCanceledCtxStillChecksBusy`).

2. **docs/deploy.md: dense-node host tuning + control-plane CPU fence.** Records what the dense-node measurement rounds settled on: quiet kernel console (bridge-port printk runs synchronously to every registered console while holding rtnl — one attach 44 ms noisy vs 3 ms quiet), udev kept off sandbox taps (~4x fill), an explicit ~64 `refill_concurrency` for egress-heavy nodes (rtnl collapses rather than plateaus; the auto default overshoots), and cocoon's post-v0.5.8 `cgroup_cpus` cpuset fence + per-VM cgroup scopes keeping reserved cores free for sandboxd, its cocoon invocations, and the OS.

## Hot-path cost

Zero. The verb runs only in the startup sweep, one call per creating-state stale VM (a crash-recovery-only condition), inside the existing `runBounded` budget. The docs change is documentation.

## Evidence

- `make go-test` green across all modules; `make go-lint` 0 issues on both GOOS after a lint cache clean; `asl ./...` clean on both GOOS for the sandboxd and e2e modules.
- New tests: outcome tables for the startup sweep and the reap-tick retry (collected / not-found / busy / not-creating / verb-error), busy keeps the tap in the egress sweep's keep set and lands in the retry queue, canceled-ctx cancellation-immunity (fails if `WithoutCancel` is removed — verified by mutation), running-state orphans never touch the verb.
- Docs claims cross-checked against cocoon source: the verb and its four outcomes are in v0.5.8 (`git tag --contains`), the cgroup work is post-v0.5.8 (untagged), `cgroup_cpus` is a real config key, and the auto `refill_concurrency` formula yields 256 on 384 cores as stated.
