### PR TITLE
pool: write archive-delete markers at delete attempts, not archive time

### DIFF
--- a/sandboxd/pool/archive.go
+++ b/sandboxd/pool/archive.go
@@ -97,9 +97,6 @@ func (m *Manager) archive(ctx context.Context, sb *types.Sandbox) error {
 	m.pendingCks[ckID] = struct{}{}
 	m.mu.Unlock()
 	defer m.untrack(m.pendingCks, ckID)
-	if err := m.markArchiveCk(ckID); err != nil {
-		return fmt.Errorf("track archive checkpoint: %w", err)
-	}
 	// A hibernated source is copied from its wake image, so no VM starts.
 	ck, srcSnap, err := m.publishCheckpoint(ctx, sb, ckID, "archive", sb.Tenant, true)
 	if err != nil {
@@ -196,13 +193,15 @@ func (m *Manager) wakeArchived(ctx context.Context, sb *types.Sandbox) (string, 
 		return "", fmt.Errorf("wake %s: persist claims", sb.ID)
 	}
 	// Consumed into the live VM; drop the store copy, and its now-dead lock.
+	// The wake is committed (ArchiveCk cleared, unpinned), so a failed delete
+	// marks the ck for the retry sweep instead of leaking it.
 	if delErr := m.ckpts.Delete(ctx, ck); delErr != nil {
 		log.WithFunc("pool.wakeArchived").Warnf(ctx, "delete consumed archive ck %s: %v", ck, delErr)
+		if markErr := m.markArchiveCk(ck); markErr != nil {
+			log.WithFunc("pool.wakeArchived").Warnf(ctx, "mark archive ck %s: %v", ck, markErr)
+		}
 	} else {
 		consumed = true
-		if clearErr := m.clearArchiveCk(ck); clearErr != nil {
-			log.WithFunc("pool.wakeArchived").Warnf(ctx, "clear archive ck %s: %v", ck, clearErr)
-		}
 	}
 	// Only the none lane reaches here (the egress guard above fails closed), so
 	// this rebinds the none-lane proxy; there is no NIC to re-lock.
@@ -252,6 +251,10 @@ func (m *Manager) deleteOrphanArchiveCk(ctx context.Context, ckID string) {
 	}
 }
 
+// markArchiveCk records durable delete intent for a ck. It must land before
+// the claims commit that drops the ck's last journal reference: restart
+// recovery sees only the journal (reclaimOrphanArchiveCks) and these markers
+// (retryArchiveDeletes), and an unreferenced, unmarked ck is invisible to both.
 func (m *Manager) markArchiveCk(ckID string) error {
 	if !store.CheckpointIDRe.MatchString(ckID) {
 		return fmt.Errorf("invalid checkpoint id %q", ckID)

--- a/sandboxd/pool/archive.go
+++ b/sandboxd/pool/archive.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/projecteru2/core/log"
@@ -265,17 +266,31 @@ func (m *Manager) markArchiveCk(ckID string) error {
 	return os.WriteFile(filepath.Join(dir, ckID), nil, 0o600)
 }
 
-func (m *Manager) clearCanceledArchiveDeletes(ctx context.Context, claims map[string]*types.Sandbox) {
-	logger := log.WithFunc("pool.clearCanceledArchiveDeletes")
+func (m *Manager) archiveDeleteMarkers() ([]string, error) {
 	entries, err := os.ReadDir(filepath.Join(m.dataDir, archiveDeleteDir))
 	if errors.Is(err, fs.ErrNotExist) {
-		return
+		return nil, nil
 	}
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Type().IsRegular() && store.CheckpointIDRe.MatchString(entry.Name()) {
+			ids = append(ids, entry.Name())
+		}
+	}
+	return ids, nil
+}
+
+func (m *Manager) clearCanceledArchiveDeletes(ctx context.Context, claims map[string]*types.Sandbox) {
+	logger := log.WithFunc("pool.clearCanceledArchiveDeletes")
+	ids, err := m.archiveDeleteMarkers()
 	if err != nil {
 		logger.Warnf(ctx, "list: %v", err)
 		return
 	}
-	if len(entries) == 0 {
+	if len(ids) == 0 {
 		return
 	}
 	live := make(map[string]struct{})
@@ -284,15 +299,12 @@ func (m *Manager) clearCanceledArchiveDeletes(ctx context.Context, claims map[st
 			live[sb.ArchiveCk] = struct{}{}
 		}
 	}
-	for _, entry := range entries {
-		if !entry.Type().IsRegular() || !store.CheckpointIDRe.MatchString(entry.Name()) {
+	for _, id := range ids {
+		if _, ok := live[id]; !ok {
 			continue
 		}
-		if _, ok := live[entry.Name()]; !ok {
-			continue
-		}
-		if err := m.clearArchiveCk(entry.Name()); err != nil {
-			logger.Warnf(ctx, "clear %s: %v", entry.Name(), err)
+		if err := m.clearArchiveCk(id); err != nil {
+			logger.Warnf(ctx, "clear %s: %v", id, err)
 		}
 	}
 }
@@ -323,27 +335,16 @@ func (m *Manager) retryArchiveDeletes(ctx context.Context) {
 		return
 	}
 	defer m.archiveDeleteSweep.Store(false)
-	entries, err := os.ReadDir(filepath.Join(m.dataDir, archiveDeleteDir))
-	if errors.Is(err, fs.ErrNotExist) {
-		return
-	}
+	ids, err := m.archiveDeleteMarkers()
 	if err != nil {
 		log.WithFunc("pool.retryArchiveDeletes").Warnf(ctx, "list: %v", err)
 		return
 	}
-	if len(entries) == 0 {
+	if len(ids) == 0 {
 		return
 	}
 	pinned := m.pinnedArchiveCks()
-	ids := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if !entry.Type().IsRegular() || !store.CheckpointIDRe.MatchString(entry.Name()) {
-			continue
-		}
-		if _, ok := pinned[entry.Name()]; !ok {
-			ids = append(ids, entry.Name())
-		}
-	}
+	ids = slices.DeleteFunc(ids, func(id string) bool { _, ok := pinned[id]; return ok })
 	m.runBounded(ctx, len(ids), func(ctx context.Context, i int) {
 		m.retryArchiveDelete(ctx, ids[i])
 	}).Wait()

--- a/sandboxd/pool/archive.go
+++ b/sandboxd/pool/archive.go
@@ -184,6 +184,10 @@ func (m *Manager) wakeArchived(ctx context.Context, sb *types.Sandbox) (string, 
 	if err != nil {
 		return "", fmt.Errorf("wake %s: %w", sb.ID, err)
 	}
+	if markErr := m.markArchiveCk(ck); markErr != nil {
+		m.destroy(ctx, built.VMName)
+		return "", fmt.Errorf("wake %s: track archive checkpoint: %w", sb.ID, markErr)
+	}
 	live, saved := m.commitWake(ctx, sb, built.VMName, built.VsockSocket)
 	if !live || !saved {
 		m.destroy(ctx, built.VMName) // released, or persist rolled back to archived
@@ -192,16 +196,14 @@ func (m *Manager) wakeArchived(ctx context.Context, sb *types.Sandbox) (string, 
 		}
 		return "", fmt.Errorf("wake %s: persist claims", sb.ID)
 	}
-	// Consumed into the live VM; drop the store copy, and its now-dead lock.
-	// The wake is committed (ArchiveCk cleared, unpinned), so a failed delete
-	// marks the ck for the retry sweep instead of leaking it.
+	// The pre-commit marker keeps a failed delete retryable after the journal update.
 	if delErr := m.ckpts.Delete(ctx, ck); delErr != nil {
 		log.WithFunc("pool.wakeArchived").Warnf(ctx, "delete consumed archive ck %s: %v", ck, delErr)
-		if markErr := m.markArchiveCk(ck); markErr != nil {
-			log.WithFunc("pool.wakeArchived").Warnf(ctx, "mark archive ck %s: %v", ck, markErr)
-		}
 	} else {
 		consumed = true
+		if clearErr := m.clearArchiveCk(ck); clearErr != nil {
+			log.WithFunc("pool.wakeArchived").Warnf(ctx, "clear archive ck %s: %v", ck, clearErr)
+		}
 	}
 	// Only the none lane reaches here (the egress guard above fails closed), so
 	// this rebinds the none-lane proxy; there is no NIC to re-lock.
@@ -251,10 +253,7 @@ func (m *Manager) deleteOrphanArchiveCk(ctx context.Context, ckID string) {
 	}
 }
 
-// markArchiveCk records durable delete intent for a ck. It must land before
-// the claims commit that drops the ck's last journal reference: restart
-// recovery sees only the journal (reclaimOrphanArchiveCks) and these markers
-// (retryArchiveDeletes), and an unreferenced, unmarked ck is invisible to both.
+// markArchiveCk records durable delete intent before the journal drops its reference.
 func (m *Manager) markArchiveCk(ckID string) error {
 	if !store.CheckpointIDRe.MatchString(ckID) {
 		return fmt.Errorf("invalid checkpoint id %q", ckID)
@@ -264,6 +263,38 @@ func (m *Manager) markArchiveCk(ckID string) error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(dir, ckID), nil, 0o600)
+}
+
+func (m *Manager) clearCanceledArchiveDeletes(ctx context.Context, claims map[string]*types.Sandbox) {
+	logger := log.WithFunc("pool.clearCanceledArchiveDeletes")
+	entries, err := os.ReadDir(filepath.Join(m.dataDir, archiveDeleteDir))
+	if errors.Is(err, fs.ErrNotExist) {
+		return
+	}
+	if err != nil {
+		logger.Warnf(ctx, "list: %v", err)
+		return
+	}
+	if len(entries) == 0 {
+		return
+	}
+	live := make(map[string]struct{})
+	for _, sb := range claims {
+		if sb.ArchiveCk != "" {
+			live[sb.ArchiveCk] = struct{}{}
+		}
+	}
+	for _, entry := range entries {
+		if !entry.Type().IsRegular() || !store.CheckpointIDRe.MatchString(entry.Name()) {
+			continue
+		}
+		if _, ok := live[entry.Name()]; !ok {
+			continue
+		}
+		if err := m.clearArchiveCk(entry.Name()); err != nil {
+			logger.Warnf(ctx, "clear %s: %v", entry.Name(), err)
+		}
+	}
 }
 
 func (m *Manager) clearArchiveCk(ckID string) error {

--- a/sandboxd/pool/archive_test.go
+++ b/sandboxd/pool/archive_test.go
@@ -36,10 +36,6 @@ func TestArchivePublishWindowPinsCheckpoint(t *testing.T) {
 	archived := make(chan error, 1)
 	go func() { archived <- m.archive(t.Context(), sb) }()
 	ck := <-stall.published
-	m.retryArchiveDeletes(t.Context())
-	if !ckExists(t, m, ck) {
-		t.Fatal("archive delete retry removed a checkpoint still being published")
-	}
 
 	if ckpts, err := m.Checkpoints(t.Context(), ""); err != nil || len(ckpts) != 0 {
 		t.Errorf("mid-publish checkpoint visible: %v, %v", ckpts, err)
@@ -421,29 +417,32 @@ func TestArchiveDeleteRetryAfterRestart(t *testing.T) {
 	}
 }
 
-func TestReconcileAdoptsLegacyArchiveMarker(t *testing.T) {
+// TestArchiveSteadyStateLeavesNoMarker: markers mean "delete attempted, not
+// yet done" — an archived claim in steady state, across a restart, must leave
+// the marker directory empty so the retry sweep stays a free no-op.
+func TestArchiveSteadyStateLeavesNoMarker(t *testing.T) {
 	eng := newFakeEngine()
 	dataDir := t.TempDir()
 	m := newTestManagerAt(t, eng, dataDir, archivePool(3600))
 	sb := mustClaim(t, m, testKey)
 	mustArchive(t, m, sb)
 	id, token, ck := sb.ID, sb.Token, sb.ArchiveCk
-	if err := m.clearArchiveCk(ck); err != nil {
-		t.Fatalf("clear marker: %v", err)
+	if archiveCkMarked(m, ck) {
+		t.Fatal("archive left a delete marker for its live checkpoint")
 	}
 
 	m2 := newTestManagerAt(t, eng, dataDir, archivePool(3600))
 	if err := m2.Reconcile(t.Context()); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
-	if !ckExists(t, m2, ck) || !archiveCkMarked(m2, ck) {
-		t.Fatal("reconcile did not retain and mark the live archive")
+	if !ckExists(t, m2, ck) || archiveCkMarked(m2, ck) {
+		t.Fatal("reconcile did not retain the live archive unmarked")
 	}
 	if _, err := m2.WakeAgentSocket(t.Context(), id, token); err != nil {
 		t.Fatalf("wake: %v", err)
 	}
 	if archiveCkMarked(m2, ck) {
-		t.Fatal("wake left the archive cleanup marker")
+		t.Fatal("wake left an archive delete marker")
 	}
 }
 
@@ -513,12 +512,67 @@ func TestArchiveRemovalCommitPinsCheckpoint(t *testing.T) {
 	}
 }
 
+// TestArchiveRemovalRequiresDeleteMarker: a removal whose delete-intent marker
+// cannot land must abort before the claims commit — committing would drop the
+// journal's last reference to an unmarked ck, leaking it past every recovery
+// path (restart reclaim skips cks of unknown sandboxes).
+func TestArchiveRemovalRequiresDeleteMarker(t *testing.T) {
+	for _, action := range []string{testArchiveRelease, testArchiveReap} {
+		t.Run(action, func(t *testing.T) {
+			eng := newFakeEngine()
+			m := newTestManager(t, eng, archivePool(3600))
+			sb := mustClaim(t, m, testKey)
+			id, token := sb.ID, sb.Token
+			mustArchive(t, m, sb)
+			ck := sb.ArchiveCk
+			blocker := filepath.Join(m.dataDir, archiveDeleteDir)
+			if err := os.WriteFile(blocker, nil, 0o600); err != nil {
+				t.Fatalf("block marker dir: %v", err)
+			}
+
+			switch action {
+			case testArchiveRelease:
+				if err := m.Release(t.Context(), id, Cred{Token: token}); err == nil {
+					t.Fatal("release succeeded with an unwritable marker dir")
+				}
+			case testArchiveReap:
+				m.mu.Lock()
+				sb.Deadline = time.Now().Add(-time.Second)
+				m.mu.Unlock()
+				m.reapOnce(t.Context())
+			}
+			if _, ok := m.claim(id, token); !ok {
+				t.Fatal("claim dropped despite an unmarkable delete intent")
+			}
+			if !pinnedHidden(t, m, ck) {
+				t.Error("kept ck is not pinned after an aborted removal")
+			}
+
+			if err := os.Remove(blocker); err != nil {
+				t.Fatalf("unblock marker dir: %v", err)
+			}
+			if err := m.Release(t.Context(), id, Cred{Token: token}); err != nil {
+				t.Fatalf("release after heal: %v", err)
+			}
+			if ckExists(t, m, ck) || archiveCkMarked(m, ck) {
+				t.Fatal("healed release did not delete the checkpoint")
+			}
+		})
+	}
+}
+
+// TestArchiveDeleteRetryRechecksWakeRollback: no marking site writes a marker
+// for a live claim's current ck, so one is seeded to prove the retry's pinned
+// re-check under the record lock still refuses a ck a wake rollback restored.
 func TestArchiveDeleteRetryRechecksWakeRollback(t *testing.T) {
 	eng := newFakeEngine()
 	m := newTestManager(t, eng, archivePool(3600))
 	sb := mustClaim(t, m, testKey)
 	mustArchive(t, m, sb)
 	id, token, ck := sb.ID, sb.Token, sb.ArchiveCk
+	if err := m.markArchiveCk(ck); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
 
 	m.store.mu.Lock()
 	locked := true

--- a/sandboxd/pool/archive_test.go
+++ b/sandboxd/pool/archive_test.go
@@ -417,10 +417,7 @@ func TestArchiveDeleteRetryAfterRestart(t *testing.T) {
 	}
 }
 
-// TestArchiveSteadyStateLeavesNoMarker: markers mean "delete attempted, not
-// yet done" — an archived claim in steady state, across a restart, must leave
-// the marker directory empty so the retry sweep stays a free no-op.
-func TestArchiveSteadyStateLeavesNoMarker(t *testing.T) {
+func TestReconcileClearsLiveArchiveMarker(t *testing.T) {
 	eng := newFakeEngine()
 	dataDir := t.TempDir()
 	m := newTestManagerAt(t, eng, dataDir, archivePool(3600))
@@ -429,6 +426,9 @@ func TestArchiveSteadyStateLeavesNoMarker(t *testing.T) {
 	id, token, ck := sb.ID, sb.Token, sb.ArchiveCk
 	if archiveCkMarked(m, ck) {
 		t.Fatal("archive left a delete marker for its live checkpoint")
+	}
+	if err := m.markArchiveCk(ck); err != nil {
+		t.Fatalf("seed live archive marker: %v", err)
 	}
 
 	m2 := newTestManagerAt(t, eng, dataDir, archivePool(3600))
@@ -443,6 +443,78 @@ func TestArchiveSteadyStateLeavesNoMarker(t *testing.T) {
 	}
 	if archiveCkMarked(m2, ck) {
 		t.Fatal("wake left an archive delete marker")
+	}
+}
+
+func TestArchiveWakeDeleteFailureRetries(t *testing.T) {
+	eng := newFakeEngine()
+	m := newTestManager(t, eng, archivePool(3600))
+	sb := mustClaim(t, m, testKey)
+	mustArchive(t, m, sb)
+	ck := sb.ArchiveCk
+	base := m.ckpts
+	failed := &failingDeleteStore{Store: base, attempts: make(chan string, 1)}
+	m.ckpts = failed
+
+	if _, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err != nil {
+		t.Fatalf("wake: %v", err)
+	}
+	select {
+	case got := <-failed.attempts:
+		if got != ck {
+			t.Fatalf("deleted checkpoint %s, want %s", got, ck)
+		}
+	default:
+		t.Fatal("wake did not attempt archive deletion")
+	}
+	if !ckExists(t, m, ck) || !archiveCkMarked(m, ck) {
+		t.Fatal("failed wake deletion did not retain the checkpoint and cleanup marker")
+	}
+
+	m.ckpts = base
+	m.retryArchiveDeletes(t.Context())
+	if ckExists(t, m, ck) || archiveCkMarked(m, ck) {
+		t.Fatal("retry did not finish wake archive deletion")
+	}
+}
+
+func TestArchiveWakeRequiresDeleteMarker(t *testing.T) {
+	eng := newFakeEngine()
+	m := newTestManager(t, eng, archivePool(3600))
+	sb := mustClaim(t, m, testKey)
+	mustArchive(t, m, sb)
+	ck := sb.ArchiveCk
+	blocker := filepath.Join(m.dataDir, archiveDeleteDir)
+	if err := os.WriteFile(blocker, nil, 0o600); err != nil {
+		t.Fatalf("block marker dir: %v", err)
+	}
+	removesBefore := len(eng.removedNames())
+
+	if _, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err == nil {
+		t.Fatal("wake succeeded with an unwritable marker dir")
+	}
+	m.mu.Lock()
+	archived := m.claimed[sb.ID] == sb && sb.ArchiveCk == ck && sb.VMName == ""
+	m.mu.Unlock()
+	if !archived || !ckExists(t, m, ck) {
+		t.Fatal("failed wake did not retain the archived claim and checkpoint")
+	}
+	claims, err := m.store.load()
+	if err != nil || claims[sb.ID] == nil || claims[sb.ID].ArchiveCk != ck {
+		t.Fatalf("failed wake changed the durable archive claim: %+v, %v", claims[sb.ID], err)
+	}
+	if got := len(eng.removedNames()); got != removesBefore+1 {
+		t.Errorf("failed wake removed %d VMs, want 1", got-removesBefore)
+	}
+
+	if err := os.Remove(blocker); err != nil {
+		t.Fatalf("unblock marker dir: %v", err)
+	}
+	if _, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err != nil {
+		t.Fatalf("wake after heal: %v", err)
+	}
+	if ckExists(t, m, ck) || archiveCkMarked(m, ck) {
+		t.Fatal("healed wake did not delete the checkpoint")
 	}
 }
 
@@ -512,10 +584,6 @@ func TestArchiveRemovalCommitPinsCheckpoint(t *testing.T) {
 	}
 }
 
-// TestArchiveRemovalRequiresDeleteMarker: a removal whose delete-intent marker
-// cannot land must abort before the claims commit — committing would drop the
-// journal's last reference to an unmarked ck, leaking it past every recovery
-// path (restart reclaim skips cks of unknown sandboxes).
 func TestArchiveRemovalRequiresDeleteMarker(t *testing.T) {
 	for _, action := range []string{testArchiveRelease, testArchiveReap} {
 		t.Run(action, func(t *testing.T) {
@@ -561,18 +629,12 @@ func TestArchiveRemovalRequiresDeleteMarker(t *testing.T) {
 	}
 }
 
-// TestArchiveDeleteRetryRechecksWakeRollback: no marking site writes a marker
-// for a live claim's current ck, so one is seeded to prove the retry's pinned
-// re-check under the record lock still refuses a ck a wake rollback restored.
 func TestArchiveDeleteRetryRechecksWakeRollback(t *testing.T) {
 	eng := newFakeEngine()
 	m := newTestManager(t, eng, archivePool(3600))
 	sb := mustClaim(t, m, testKey)
 	mustArchive(t, m, sb)
 	id, token, ck := sb.ID, sb.Token, sb.ArchiveCk
-	if err := m.markArchiveCk(ck); err != nil {
-		t.Fatalf("seed marker: %v", err)
-	}
 
 	m.store.mu.Lock()
 	locked := true
@@ -591,6 +653,9 @@ func TestArchiveDeleteRetryRechecksWakeRollback(t *testing.T) {
 		defer m.mu.Unlock()
 		return sb.ArchiveCk == ""
 	})
+	if !archiveCkMarked(m, ck) {
+		t.Fatal("wake dropped the journal reference before marking the checkpoint")
+	}
 	retried := make(chan struct{})
 	go func() {
 		m.retryArchiveDeletes(t.Context())
@@ -615,6 +680,12 @@ func TestArchiveDeleteRetryRechecksWakeRollback(t *testing.T) {
 		t.Fatal("retry deleted the archive restored by wake rollback")
 	}
 	healStore(t, m)
+	if _, err := m.WakeAgentSocket(t.Context(), id, token); err != nil {
+		t.Fatalf("wake after rollback: %v", err)
+	}
+	if ckExists(t, m, ck) || archiveCkMarked(m, ck) {
+		t.Fatal("wake after rollback did not delete the checkpoint")
+	}
 }
 
 // TestIdleOnceSkipsArchived guards the fix where the idle sweep tried to

--- a/sandboxd/pool/claim.go
+++ b/sandboxd/pool/claim.go
@@ -167,6 +167,18 @@ func (m *Manager) releaseResolved(ctx context.Context, id string, sb *types.Sand
 	}
 	js := m.store.snapshot(m.claimed)
 	m.mu.Unlock()
+	if ck != "" {
+		// An unmarkable ck must abort before the commit: committing would drop
+		// the journal's last reference and leave no recovery path to the ck.
+		if markErr := m.markArchiveCk(ck); markErr != nil {
+			m.mu.Lock()
+			m.claimed[id] = sb
+			m.tenantDelta(sb.Tenant, 1)
+			delete(m.pendingCks, ck)
+			m.mu.Unlock()
+			return fmt.Errorf("release %s: track archive checkpoint: %w", id, markErr)
+		}
+	}
 	if saveErr := m.store.commit(js); saveErr != nil {
 		m.mu.Lock()
 		m.claimed[id] = sb // roll back so memory matches the still-durable claim; the restored claim re-pins ck
@@ -174,6 +186,11 @@ func (m *Manager) releaseResolved(ctx context.Context, id string, sb *types.Sand
 		delete(m.pendingCks, ck)
 		rb := m.store.snapshot(m.claimed)
 		m.mu.Unlock()
+		if ck != "" {
+			if clearErr := m.clearArchiveCk(ck); clearErr != nil {
+				log.WithFunc("pool.releaseResolved").Warnf(ctx, "clear archive ck %s: %v", ck, clearErr)
+			}
+		}
 		m.recommit(ctx, rb)
 		log.WithFunc("pool.releaseResolved").Errorf(ctx, saveErr, "persist release of %s", id)
 		return fmt.Errorf("release %s: %w", id, saveErr)
@@ -335,31 +352,60 @@ func (m *Manager) reapOnce(ctx context.Context) {
 			m.tenantDelta(sb.Tenant, -1)
 		}
 	}
-	var js claimSnapshot
-	if len(expired) > 0 {
-		js = m.store.snapshot(m.claimed)
-	}
 	m.mu.Unlock()
+	if len(expired) == 0 {
+		return
+	}
 
 	logger := log.WithFunc("pool.reapOnce")
-	if len(expired) > 0 {
-		if saveErr := m.store.commit(js); saveErr != nil {
-			m.mu.Lock()
-			for _, v := range expired {
-				if v.action == reapArchive {
-					delete(m.archiving, v.id) // never removed from m.claimed
-				} else {
-					m.claimed[v.id] = v.sb // roll back so memory matches the still-durable claim
-					m.tenantDelta(v.tenant, 1)
-					delete(m.pendingCks, v.ck)
-				}
+	// A purge victim whose delete-intent marker cannot land is restored
+	// un-reaped: committing would drop the journal's last reference and leave
+	// no recovery path to the ck.
+	var purgeCks []string
+	keep := expired[:0]
+	for _, v := range expired {
+		if v.action == reapPurge {
+			if markErr := m.markArchiveCk(v.ck); markErr != nil {
+				logger.Errorf(ctx, markErr, "mark archive ck %s; keeping %s", v.ck, v.id)
+				m.mu.Lock()
+				m.claimed[v.id] = v.sb
+				m.tenantDelta(v.tenant, 1)
+				delete(m.pendingCks, v.ck)
+				m.mu.Unlock()
+				continue
 			}
-			rb := m.store.snapshot(m.claimed)
-			m.mu.Unlock()
-			m.recommit(ctx, rb)
-			logger.Error(ctx, saveErr, "persist reap; rolled back")
-			return
+			purgeCks = append(purgeCks, v.ck)
 		}
+		keep = append(keep, v)
+	}
+	expired = keep
+	if len(expired) == 0 {
+		return
+	}
+	m.mu.Lock()
+	js := m.store.snapshot(m.claimed)
+	m.mu.Unlock()
+	if saveErr := m.store.commit(js); saveErr != nil {
+		m.mu.Lock()
+		for _, v := range expired {
+			if v.action == reapArchive {
+				delete(m.archiving, v.id) // never removed from m.claimed
+			} else {
+				m.claimed[v.id] = v.sb // roll back so memory matches the still-durable claim
+				m.tenantDelta(v.tenant, 1)
+				delete(m.pendingCks, v.ck)
+			}
+		}
+		rb := m.store.snapshot(m.claimed)
+		m.mu.Unlock()
+		for _, ck := range purgeCks {
+			if clearErr := m.clearArchiveCk(ck); clearErr != nil {
+				logger.Warnf(ctx, "clear archive ck %s: %v", ck, clearErr)
+			}
+		}
+		m.recommit(ctx, rb)
+		logger.Error(ctx, saveErr, "persist reap; rolled back")
+		return
 	}
 	// Engine subprocesses (worst case minutes on a hung stop): fan out bounded
 	// so a big batch never stalls the ticker loop.
@@ -384,10 +430,14 @@ func (m *Manager) reapOnce(ctx context.Context) {
 }
 
 // purgeArchiveCk deletes an archived claim's store checkpoint and records the
-// retention billing event; shared by Release and reapOnce's purge.
+// retention billing event; shared by Release and reapOnce's purge, whose
+// pre-commit marking makes deleteArchiveCk's re-mark redundant here.
 func (m *Manager) purgeArchiveCk(ctx context.Context, id, ck, tenant string) {
-	if err := m.deleteArchiveCk(ctx, ck); err != nil {
-		log.WithFunc("pool.purgeArchiveCk").Warnf(ctx, "delete archive ck %s: %v", ck, err)
+	logger := log.WithFunc("pool.purgeArchiveCk")
+	if err := m.deleteCkLocked(ctx, ck); err != nil {
+		logger.Warnf(ctx, "delete archive ck %s: %v", ck, err)
+	} else if err := m.clearArchiveCk(ck); err != nil {
+		logger.Warnf(ctx, "clear archive ck %s: %v", ck, err)
 	}
 	m.counters.archiveDeletes.Add(1)
 	m.recordUsage(ctx, usageEvent{Event: "archive_delete", ID: id, Reference: ck, Tenant: tenant})

--- a/sandboxd/pool/claim.go
+++ b/sandboxd/pool/claim.go
@@ -159,26 +159,18 @@ func (m *Manager) releaseResolved(ctx context.Context, id string, sb *types.Sand
 		m.mu.Unlock()
 		return ErrUnknownSandbox
 	}
-	delete(m.claimed, id)
-	m.tenantDelta(sb.Tenant, -1)
 	snap, ck, vmName := sb.HibernateSnap, sb.ArchiveCk, sb.VMName
 	if ck != "" {
-		m.pendingCks[ck] = struct{}{}
-	}
-	js := m.store.snapshot(m.claimed)
-	m.mu.Unlock()
-	if ck != "" {
-		// An unmarkable ck must abort before the commit: committing would drop
-		// the journal's last reference and leave no recovery path to the ck.
 		if markErr := m.markArchiveCk(ck); markErr != nil {
-			m.mu.Lock()
-			m.claimed[id] = sb
-			m.tenantDelta(sb.Tenant, 1)
-			delete(m.pendingCks, ck)
 			m.mu.Unlock()
 			return fmt.Errorf("release %s: track archive checkpoint: %w", id, markErr)
 		}
+		m.pendingCks[ck] = struct{}{}
 	}
+	delete(m.claimed, id)
+	m.tenantDelta(sb.Tenant, -1)
+	js := m.store.snapshot(m.claimed)
+	m.mu.Unlock()
 	if saveErr := m.store.commit(js); saveErr != nil {
 		m.mu.Lock()
 		m.claimed[id] = sb // roll back so memory matches the still-durable claim; the restored claim re-pins ck
@@ -335,9 +327,6 @@ func (m *Manager) reapOnce(ctx context.Context) {
 		switch {
 		case sb.ArchiveCk != "":
 			expired = append(expired, victim{action: reapPurge, id: id, ck: sb.ArchiveCk, tenant: sb.Tenant, sb: sb})
-			m.pendingCks[sb.ArchiveCk] = struct{}{}
-			delete(m.claimed, id)
-			m.tenantDelta(sb.Tenant, -1)
 		case sb.HibernateSnap != "" && m.archiveEnabledFor(sb.Key):
 			// End-of-lease hibernated + archive-enabled: archive instead of
 			// destroy, kept in m.claimed for archive() to re-validate and move.
@@ -358,23 +347,13 @@ func (m *Manager) reapOnce(ctx context.Context) {
 	}
 
 	logger := log.WithFunc("pool.reapOnce")
-	// A purge victim whose delete-intent marker cannot land is restored
-	// un-reaped: committing would drop the journal's last reference and leave
-	// no recovery path to the ck.
-	var purgeCks []string
 	keep := expired[:0]
 	for _, v := range expired {
 		if v.action == reapPurge {
 			if markErr := m.markArchiveCk(v.ck); markErr != nil {
 				logger.Errorf(ctx, markErr, "mark archive ck %s; keeping %s", v.ck, v.id)
-				m.mu.Lock()
-				m.claimed[v.id] = v.sb
-				m.tenantDelta(v.tenant, 1)
-				delete(m.pendingCks, v.ck)
-				m.mu.Unlock()
 				continue
 			}
-			purgeCks = append(purgeCks, v.ck)
 		}
 		keep = append(keep, v)
 	}
@@ -383,6 +362,25 @@ func (m *Manager) reapOnce(ctx context.Context) {
 		return
 	}
 	m.mu.Lock()
+	keep = expired[:0]
+	var purgeCks []string
+	for _, v := range expired {
+		if v.action == reapPurge {
+			if m.claimed[v.id] != v.sb || v.sb.ArchiveCk != v.ck {
+				continue
+			}
+			m.pendingCks[v.ck] = struct{}{}
+			delete(m.claimed, v.id)
+			m.tenantDelta(v.tenant, -1)
+			purgeCks = append(purgeCks, v.ck)
+		}
+		keep = append(keep, v)
+	}
+	expired = keep
+	if len(expired) == 0 {
+		m.mu.Unlock()
+		return
+	}
 	js := m.store.snapshot(m.claimed)
 	m.mu.Unlock()
 	if saveErr := m.store.commit(js); saveErr != nil {
@@ -429,9 +427,6 @@ func (m *Manager) reapOnce(ctx context.Context) {
 	})
 }
 
-// purgeArchiveCk deletes an archived claim's store checkpoint and records the
-// retention billing event; shared by Release and reapOnce's purge, whose
-// pre-commit marking makes deleteArchiveCk's re-mark redundant here.
 func (m *Manager) purgeArchiveCk(ctx context.Context, id, ck, tenant string) {
 	logger := log.WithFunc("pool.purgeArchiveCk")
 	if err := m.deleteCkLocked(ctx, ck); err != nil {

--- a/sandboxd/pool/reconcile.go
+++ b/sandboxd/pool/reconcile.go
@@ -27,6 +27,7 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	m.clearCanceledArchiveDeletes(ctx, claims)
 	vms, err := m.eng.List(ctx)
 	if err != nil {
 		return fmt.Errorf("list vms: %w", err)

--- a/sandboxd/pool/reconcile.go
+++ b/sandboxd/pool/reconcile.go
@@ -27,13 +27,6 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	for _, sb := range claims {
-		if sb.ArchiveCk != "" {
-			if markErr := m.markArchiveCk(sb.ArchiveCk); markErr != nil {
-				return fmt.Errorf("track archive checkpoint %s: %w", sb.ArchiveCk, markErr)
-			}
-		}
-	}
 	vms, err := m.eng.List(ctx)
 	if err != nil {
 		return fmt.Errorf("list vms: %w", err)


### PR DESCRIPTION
Closes #62.

Implements the narrowing as designed in #62, with one correction the implementation surfaced, then a follow-up commit that closes the remaining recovery windows by making the invariant uniform.

## Correction to the issue's window-2 analysis

`reclaimOrphanArchiveCks` deliberately skips Archive-flagged checkpoints whose sandbox is absent from the journal — on a shared store they may back another node's live claim. So once a release/reap-purge claims commit lands, the journal no longer identifies the ck as ours, and a failure between that commit and the first `markArchiveCk` inside `deleteArchiveCk` leaves the ck with no marker, no journal reference, and no API that can reach it (listings, deletes and the TTL sweep all filter `Archive` records). The issue's claim that window 2 "recovers via reclaimOrphanArchiveCks either way" does not hold there — and the window is reachable without a crash: an unwritable marker dir fails the pre-commit mark *and* the purge's internal mark, so the delete never runs while the release still succeeds (reproduced in a test before the fix).

## Design as landed

One invariant on all three delete paths: **the delete-intent marker durably exists before the claims journal drops or clears its last reference to the ck**, and a mark failure aborts before anything commits.

- `archive()` no longer marks; `Reconcile` no longer re-marks adopted claims (no restart rewrites).
- `releaseResolved`: marks under `m.mu` before removing the claim — a mark failure aborts with nothing to roll back; the commit-failure rollback clears the marker.
- `reapOnce`: two-phase — collect without mutating, mark outside the lock (a failed mark just keeps that victim), then re-check `claimed[id]==sb && ArchiveCk==ck` under `m.mu` before pinning and removing; the batch rollback clears the marked cks.
- `wakeArchived`: marks after provision, before `commitWake`; a mark failure destroys the built VM and fails the wake. A failed consumed-delete stays retryable via the marker; success clears it. This also covers the release-races-mid-wake orphan that journal-based recovery alone missed.
- `Reconcile` gained `clearCanceledArchiveDeletes`: a marker naming a live journaled claim's current `ArchiveCk` is a removal that never committed — cleared at startup, so crashed rollbacks cannot leave the retry tick paying the pinned scan forever.
- `purgeArchiveCk` deletes and clears without re-marking (its callers guarantee the mark); `deleteArchiveCk` keeps mark→delete→clear for the unmarked callers (orphan cleanup, restart reclaim). `retryArchiveDeletes`/`retryArchiveDelete` and the pinned re-check are unchanged; marker listing is shared via one `archiveDeleteMarkers` helper.

Stale markers (a consumed or already-deleted ck) self-heal on the next tick: store `Delete` is idempotent on a missing id for both backends, so the retry deletes nothing and clears the marker. The one known residual — a persist-failure wake rollback leaves a pinned marker until the next lifecycle event or restart — is bounded (one non-free tick loop) and deliberately not patched inline: every inline clear variant reintroduces a leak window against a racing removal's marker.

Steady state: the marker dir holds no entries, so the 5s retry tick early-returns before touching `m.mu`; restarts write no markers. The pre-commit marking makes the diff net-positive in lines rather than the issue's −15 estimate — the delta is the leak fix above.

## Tests

- `TestReconcileAdoptsLegacyArchiveMarker` → `TestReconcileClearsLiveArchiveMarker`: archive leaves no marker, and a seeded marker on a live archived claim is cleared by restart.
- New `TestArchiveRemovalRequiresDeleteMarker` / `TestArchiveWakeRequiresDeleteMarker`: an unwritable marker dir aborts release, reap-purge and wake before their commits; healing the dir lets each complete.
- New `TestArchiveWakeDeleteFailureRetries`: a failed consumed-delete retains ck + marker; the retry tick converges.
- `TestArchiveDeleteRetryRechecksWakeRollback`: now exercises the real pre-commit wake marker (no synthetic seeding) against the recLock serialization and the pinned re-check, and asserts the post-rollback wake converges.
- `TestArchivePublishWindowPinsCheckpoint` drops its now-vacuous mid-publish retry call; `TestArchiveDeleteRetryAfterRestart` and `TestArchiveRemovalCommitPinsCheckpoint` pass unchanged.

## Evidence (rerun at HEAD)

- `go test -race -count=1 ./...` (sandboxd module): all 12 packages ok
- `make go-lint` (run + fmt, GOOS linux+darwin, all Go modules): 0 issues
- `asl ./sandboxd/...` both GOOS: zero findings on touched files (the 3 `pool.go` findings pre-exist on main, file untouched here)
- Steady-state tick re-benchmarked at HEAD: 13.1–13.3 µs / 1.5 KB / 7 allocs, independent of claim count (vs 0.71 ms @1k and 88 ms @100k archived claims with lifetime markers); `markArchiveCk` itself is ~18 µs — the pair now paid under `m.mu` only on an archived claim's release.

Hot-path cost: zero on the claim/exec/wake fast paths and on the steady-state 5s tick; an archived claim's release/purge/wake pays one marker write + one clear on its own cold path.
