### PR TITLE
Language-idiom round: one-buffer shell quoting, AfterFunc drain, synctest suite

### DIFF
--- a/sandboxd/main.go
+++ b/sandboxd/main.go
@@ -156,15 +156,14 @@ func main() {
 	}
 
 	drained := make(chan struct{})
-	go func() {
+	context.AfterFunc(ctx, func() {
 		defer close(drained)
-		<-ctx.Done()
 		// Must outlive the canceled signal ctx to bound the drain.
 		sctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), shutdownGrace)
 		defer cancel()
 		_ = httpSrv.Shutdown(sctx)
 		srv.CloseRelays()
-	}()
+	})
 
 	logger.Infof(ctx, "sandboxd listening on %s", cfg.Listen)
 	if err := httpSrv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {

--- a/sandboxd/pool/archive_test.go
+++ b/sandboxd/pool/archive_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
@@ -207,51 +208,53 @@ func TestClaimCheckpointRefusesArchive(t *testing.T) {
 // claim→idle-hibernate→archive→wake, and asserts the id/token survive the
 // store round-trip while the local VM and its wake image are reclaimed.
 func TestArchiveLifecycleRoundTrip(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, archivePool(3600))
-	sb := mustClaim(t, m, testKey)
-	id, token, origVM := sb.ID, sb.Token, sb.VMName
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, archivePool(3600))
+		sb := mustClaim(t, m, testKey)
+		id, token, origVM := sb.ID, sb.Token, sb.VMName
 
-	backdate(m, sb, 5*time.Second)
-	m.idleOnce(t.Context())
-	waitFor(t, func() bool { return hibernated(m) == 1 })
+		backdate(m, sb, 5*time.Second)
+		m.idleOnce(t.Context())
+		waitFor(t, func() bool { return hibernated(m) == 1 })
 
-	m.archiveOnce(t.Context())
-	waitFor(t, func() bool { return archivedCount(m) == 1 })
+		m.archiveOnce(t.Context())
+		waitFor(t, func() bool { return archivedCount(m) == 1 })
 
-	m.mu.Lock()
-	ck, vm, snap := sb.ArchiveCk, sb.VMName, sb.HibernateSnap
-	m.mu.Unlock()
-	if ck == "" || vm != "" || snap != "" {
-		t.Fatalf("archived record ck=%q vm=%q snap=%q, want ck set + vm/snap cleared", ck, vm, snap)
-	}
-	if hibernated(m) != 0 {
-		t.Error("archived claim still counted as hibernated")
-	}
-	if !ckExists(t, m, ck) {
-		t.Fatal("archive did not publish the checkpoint")
-	}
-	waitFor(t, func() bool { return eng.removed(origVM) })
+		m.mu.Lock()
+		ck, vm, snap := sb.ArchiveCk, sb.VMName, sb.HibernateSnap
+		m.mu.Unlock()
+		if ck == "" || vm != "" || snap != "" {
+			t.Fatalf("archived record ck=%q vm=%q snap=%q, want ck set + vm/snap cleared", ck, vm, snap)
+		}
+		if hibernated(m) != 0 {
+			t.Error("archived claim still counted as hibernated")
+		}
+		if !ckExists(t, m, ck) {
+			t.Fatal("archive did not publish the checkpoint")
+		}
+		waitFor(t, func() bool { return eng.removed(origVM) })
 
-	sock, err := m.WakeAgentSocket(t.Context(), id, token)
-	if err != nil {
-		t.Fatalf("wake archived: %v", err)
-	}
-	if sock == "" {
-		t.Error("wake returned an empty socket")
-	}
-	m.mu.Lock()
-	wokeCk, wokeVM := sb.ArchiveCk, sb.VMName
-	m.mu.Unlock()
-	if wokeCk != "" || wokeVM == "" {
-		t.Errorf("woke record ck=%q vm=%q, want ck cleared + vm set", wokeCk, wokeVM)
-	}
-	if archivedCount(m) != 0 {
-		t.Error("woke claim still counted as archived")
-	}
-	if ckExists(t, m, ck) {
-		t.Error("wake left the consumed checkpoint in the store (double storage billing)")
-	}
+		sock, err := m.WakeAgentSocket(t.Context(), id, token)
+		if err != nil {
+			t.Fatalf("wake archived: %v", err)
+		}
+		if sock == "" {
+			t.Error("wake returned an empty socket")
+		}
+		m.mu.Lock()
+		wokeCk, wokeVM := sb.ArchiveCk, sb.VMName
+		m.mu.Unlock()
+		if wokeCk != "" || wokeVM == "" {
+			t.Errorf("woke record ck=%q vm=%q, want ck cleared + vm set", wokeCk, wokeVM)
+		}
+		if archivedCount(m) != 0 {
+			t.Error("woke claim still counted as archived")
+		}
+		if ckExists(t, m, ck) {
+			t.Error("wake left the consumed checkpoint in the store (double storage billing)")
+		}
+	})
 }
 
 // TestArchiveTTLSweepSparesLiveCheckpoint guards the fix where the checkpoint
@@ -304,35 +307,37 @@ func TestArchiveKeepsForeverWhenDeleteZero(t *testing.T) {
 // retention deadline drops from claims, deletes its checkpoint, and releases
 // its tenant slot.
 func TestArchiveRetentionPurge(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, archivePool(3600))
-	sb, err := m.ClaimProvision(t.Context(), testKey, time.Hour, "acme", "", nil)
-	if err != nil {
-		t.Fatalf("claim: %v", err)
-	}
-	mustArchive(t, m, sb)
-	ck := sb.ArchiveCk
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, archivePool(3600))
+		sb, err := m.ClaimProvision(t.Context(), testKey, time.Hour, "acme", "", nil)
+		if err != nil {
+			t.Fatalf("claim: %v", err)
+		}
+		mustArchive(t, m, sb)
+		ck := sb.ArchiveCk
 
-	m.mu.Lock()
-	sb.Deadline = time.Now().Add(-time.Second) // retention window elapsed
-	m.mu.Unlock()
+		m.mu.Lock()
+		sb.Deadline = time.Now().Add(-time.Second) // retention window elapsed
+		m.mu.Unlock()
 
-	m.reapOnce(t.Context())
-	waitFor(t, func() bool { return archivedCount(m) == 0 })
-	// archiveDeletes is the purge goroutine's last side effect, sequenced after
-	// the checkpoint delete; waiting on it makes both observable (a bare read
-	// races the async purge, flaking under -race).
-	waitFor(t, func() bool { return m.Counters().ArchiveDeletes > 0 })
-	if ckExists(t, m, ck) {
-		t.Error("purge did not delete the archived checkpoint")
-	}
+		m.reapOnce(t.Context())
+		waitFor(t, func() bool { return archivedCount(m) == 0 })
+		// archiveDeletes is the purge goroutine's last side effect, sequenced after
+		// the checkpoint delete; waiting on it makes both observable (a bare read
+		// races the async purge, flaking under -race).
+		waitFor(t, func() bool { return m.Counters().ArchiveDeletes > 0 })
+		if ckExists(t, m, ck) {
+			t.Error("purge did not delete the archived checkpoint")
+		}
 
-	m.mu.Lock()
-	live := m.tenantLive["acme"]
-	m.mu.Unlock()
-	if live != 0 {
-		t.Errorf("tenant acme has %d live after purge, want 0", live)
-	}
+		m.mu.Lock()
+		live := m.tenantLive["acme"]
+		m.mu.Unlock()
+		if live != 0 {
+			t.Errorf("tenant acme has %d live after purge, want 0", live)
+		}
+	})
 }
 
 // TestReleaseArchivedDeletesCheckpoint guards the fix where releasing an
@@ -364,55 +369,57 @@ func TestReleaseArchivedDeletesCheckpoint(t *testing.T) {
 func TestArchiveDeleteRetryAfterRestart(t *testing.T) {
 	for _, action := range []string{testArchiveRelease, testArchiveReap} {
 		t.Run(action, func(t *testing.T) {
-			eng := newFakeEngine()
-			dataDir := t.TempDir()
-			m := newTestManagerAt(t, eng, dataDir, archivePool(3600))
-			sb := mustClaim(t, m, testKey)
-			id, token := sb.ID, sb.Token
-			mustArchive(t, m, sb)
-			ck := sb.ArchiveCk
-			failed := &failingDeleteStore{Store: m.ckpts, attempts: make(chan string, 1)}
-			m.ckpts = failed
+			synctest.Test(t, func(t *testing.T) {
+				eng := newFakeEngine()
+				dataDir := t.TempDir()
+				m := newTestManagerAt(t, eng, dataDir, archivePool(3600))
+				sb := mustClaim(t, m, testKey)
+				id, token := sb.ID, sb.Token
+				mustArchive(t, m, sb)
+				ck := sb.ArchiveCk
+				failed := &failingDeleteStore{Store: m.ckpts, attempts: make(chan string, 1)}
+				m.ckpts = failed
 
-			switch action {
-			case testArchiveRelease:
-				if err := m.Release(t.Context(), id, Cred{Token: token}); err != nil {
-					t.Fatalf("release: %v", err)
-				}
-			case testArchiveReap:
-				m.mu.Lock()
-				sb.Deadline = time.Now().Add(-time.Second)
-				m.mu.Unlock()
-				m.reapOnce(t.Context())
-				select {
-				case <-failed.attempts:
-				case <-time.After(3 * time.Second):
-					t.Fatal("reap did not attempt archive deletion")
-				}
-				waitFor(t, func() bool {
+				switch action {
+				case testArchiveRelease:
+					if err := m.Release(t.Context(), id, Cred{Token: token}); err != nil {
+						t.Fatalf("release: %v", err)
+					}
+				case testArchiveReap:
 					m.mu.Lock()
-					defer m.mu.Unlock()
-					_, pending := m.pendingCks[ck]
-					return !pending
-				})
-			}
-			if _, ok := m.claim(id, token); ok {
-				t.Fatal("removed archive claim survived")
-			}
-			if !ckExists(t, m, ck) || !archiveCkMarked(m, ck) {
-				t.Fatal("failed deletion did not retain the checkpoint and cleanup marker")
-			}
+					sb.Deadline = time.Now().Add(-time.Second)
+					m.mu.Unlock()
+					m.reapOnce(t.Context())
+					select {
+					case <-failed.attempts:
+					case <-time.After(3 * time.Second):
+						t.Fatal("reap did not attempt archive deletion")
+					}
+					waitFor(t, func() bool {
+						m.mu.Lock()
+						defer m.mu.Unlock()
+						_, pending := m.pendingCks[ck]
+						return !pending
+					})
+				}
+				if _, ok := m.claim(id, token); ok {
+					t.Fatal("removed archive claim survived")
+				}
+				if !ckExists(t, m, ck) || !archiveCkMarked(m, ck) {
+					t.Fatal("failed deletion did not retain the checkpoint and cleanup marker")
+				}
 
-			m2 := newTestManagerAt(t, eng, dataDir, archivePool(3600))
-			if err := m2.Reconcile(t.Context()); err != nil {
-				t.Fatalf("Reconcile: %v", err)
-			}
-			if ckExists(t, m2, ck) || archiveCkMarked(m2, ck) {
-				t.Fatal("restart did not finish archive deletion")
-			}
-			if _, ok := m2.claim(id, token); ok {
-				t.Fatal("restart revived the removed claim")
-			}
+				m2 := newTestManagerAt(t, eng, dataDir, archivePool(3600))
+				if err := m2.Reconcile(t.Context()); err != nil {
+					t.Fatalf("Reconcile: %v", err)
+				}
+				if ckExists(t, m2, ck) || archiveCkMarked(m2, ck) {
+					t.Fatal("restart did not finish archive deletion")
+				}
+				if _, ok := m2.claim(id, token); ok {
+					t.Fatal("restart revived the removed claim")
+				}
+			})
 		})
 	}
 }
@@ -518,6 +525,9 @@ func TestArchiveWakeRequiresDeleteMarker(t *testing.T) {
 	}
 }
 
+// Not a synctest candidate: each subtest holds m.store.mu itself to force the
+// release/reap goroutine to block acquiring it — same plain-sync.Mutex shape
+// as TestArchiveDeleteRetryRechecksWakeRollback, already verified to deadlock.
 func TestArchiveRemovalCommitPinsCheckpoint(t *testing.T) {
 	for _, action := range []string{testArchiveRelease, testArchiveReap} {
 		t.Run(action, func(t *testing.T) {
@@ -629,6 +639,10 @@ func TestArchiveRemovalRequiresDeleteMarker(t *testing.T) {
 	}
 }
 
+// Not a synctest candidate: this test holds m.store.mu itself to force the
+// wake goroutine to block acquiring it — a plain sync.Mutex, never "durably
+// blocked" by synctest's rules, so the waitFor below can't fast-forward past
+// it. Verified as a real deadlock (times out), not a flake.
 func TestArchiveDeleteRetryRechecksWakeRollback(t *testing.T) {
 	eng := newFakeEngine()
 	m := newTestManager(t, eng, archivePool(3600))
@@ -691,21 +705,23 @@ func TestArchiveDeleteRetryRechecksWakeRollback(t *testing.T) {
 // TestIdleOnceSkipsArchived guards the fix where the idle sweep tried to
 // hibernate an archived (VM-less) claim, corrupting its record.
 func TestIdleOnceSkipsArchived(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, archivePool(3600))
-	sb := mustClaim(t, m, testKey)
-	mustArchive(t, m, sb)
-	hibBefore := eng.hibernateCount()
-	backdate(m, sb, time.Hour)
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, archivePool(3600))
+		sb := mustClaim(t, m, testKey)
+		mustArchive(t, m, sb)
+		hibBefore := eng.hibernateCount()
+		backdate(m, sb, time.Hour)
 
-	m.idleOnce(t.Context())
-	waitFor(t, func() bool { return !m.idleSweep.Load() })
-	if got := eng.hibernateCount(); got != hibBefore {
-		t.Errorf("idle sweep hibernated an archived claim: %d→%d", hibBefore, got)
-	}
-	if archivedCount(m) != 1 {
-		t.Error("idle sweep disturbed the archived claim")
-	}
+		m.idleOnce(t.Context())
+		waitFor(t, func() bool { return !m.idleSweep.Load() })
+		if got := eng.hibernateCount(); got != hibBefore {
+			t.Errorf("idle sweep hibernated an archived claim: %d→%d", hibBefore, got)
+		}
+		if archivedCount(m) != 1 {
+			t.Error("idle sweep disturbed the archived claim")
+		}
+	})
 }
 
 // TestDeleteCheckpointCannotBrickArchive guards the fix where the archive
@@ -739,135 +755,145 @@ func TestDeleteCheckpointCannotBrickArchive(t *testing.T) {
 // destroyed the local VM+snapshot before its transition reached disk: a failed
 // persist must roll the record back to hibernated and keep the local backing.
 func TestArchivePersistFailureRollsBack(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, archivePool(3600))
-	sb := mustClaim(t, m, testKey)
-	if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
-		t.Fatalf("hibernate: %v", err)
-	}
-	snap, vm := sb.HibernateSnap, sb.VMName
-	breakStore(t, m)
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, archivePool(3600))
+		sb := mustClaim(t, m, testKey)
+		if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
+			t.Fatalf("hibernate: %v", err)
+		}
+		snap, vm := sb.HibernateSnap, sb.VMName
+		breakStore(t, m)
 
-	if err := m.archive(t.Context(), sb); err == nil {
-		t.Fatal("archive succeeded despite a persist failure")
-	}
-	m.mu.Lock()
-	ck, gotSnap, gotVM := sb.ArchiveCk, sb.HibernateSnap, sb.VMName
-	m.mu.Unlock()
-	if ck != "" || gotSnap != snap || gotVM != vm {
-		t.Errorf("not rolled back: ArchiveCk=%q snap=%q vm=%q, want hibernated %q/%q", ck, gotSnap, gotVM, snap, vm)
-	}
-	if eng.removed(vm) {
-		t.Error("archive destroyed the VM after a failed persist")
-	}
-	if ckpts, err := m.Checkpoints(t.Context(), ""); err != nil || len(ckpts) != 0 {
-		t.Errorf("orphaned archive ck not cleaned up: %d records (%v)", len(ckpts), err)
-	}
-	healStore(t, m)
+		if err := m.archive(t.Context(), sb); err == nil {
+			t.Fatal("archive succeeded despite a persist failure")
+		}
+		m.mu.Lock()
+		ck, gotSnap, gotVM := sb.ArchiveCk, sb.HibernateSnap, sb.VMName
+		m.mu.Unlock()
+		if ck != "" || gotSnap != snap || gotVM != vm {
+			t.Errorf("not rolled back: ArchiveCk=%q snap=%q vm=%q, want hibernated %q/%q", ck, gotSnap, gotVM, snap, vm)
+		}
+		if eng.removed(vm) {
+			t.Error("archive destroyed the VM after a failed persist")
+		}
+		if ckpts, err := m.Checkpoints(t.Context(), ""); err != nil || len(ckpts) != 0 {
+			t.Errorf("orphaned archive ck not cleaned up: %d records (%v)", len(ckpts), err)
+		}
+		healStore(t, m)
+	})
 }
 
 // TestReleaseArchivedRollsBackOnPersistFailure guards the durability fix where
 // a release whose removal did not persist must roll back — the claim survives
 // and its ck stays pinned, so a restart still wakes it.
 func TestReleaseArchivedRollsBackOnPersistFailure(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, archivePool(3600))
-	sb := mustClaim(t, m, testKey)
-	id, token := sb.ID, sb.Token
-	mustArchive(t, m, sb)
-	ck := sb.ArchiveCk
-	breakStore(t, m)
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, archivePool(3600))
+		sb := mustClaim(t, m, testKey)
+		id, token := sb.ID, sb.Token
+		mustArchive(t, m, sb)
+		ck := sb.ArchiveCk
+		breakStore(t, m)
 
-	if err := m.Release(t.Context(), id, Cred{Token: token}); err == nil {
-		t.Fatal("release succeeded despite a persist failure")
-	}
-	if _, ok := m.claim(id, token); !ok {
-		t.Error("release dropped the claim despite a failed persist")
-	}
-	if !pinnedHidden(t, m, ck) {
-		t.Error("kept ck is not pinned after a failed release")
-	}
-	healStore(t, m)
+		if err := m.Release(t.Context(), id, Cred{Token: token}); err == nil {
+			t.Fatal("release succeeded despite a persist failure")
+		}
+		if _, ok := m.claim(id, token); !ok {
+			t.Error("release dropped the claim despite a failed persist")
+		}
+		if !pinnedHidden(t, m, ck) {
+			t.Error("kept ck is not pinned after a failed release")
+		}
+		healStore(t, m)
+	})
 }
 
 // TestWakeArchivedRollsBackOnPersistFailure guards the durability fix where a
 // wake whose cleared-ArchiveCk record did not persist must roll back to
 // archived, keeping the ck pinned.
 func TestWakeArchivedRollsBackOnPersistFailure(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, archivePool(3600))
-	sb := mustClaim(t, m, testKey)
-	id, token := sb.ID, sb.Token
-	mustArchive(t, m, sb)
-	ck := sb.ArchiveCk
-	breakStore(t, m)
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, archivePool(3600))
+		sb := mustClaim(t, m, testKey)
+		id, token := sb.ID, sb.Token
+		mustArchive(t, m, sb)
+		ck := sb.ArchiveCk
+		breakStore(t, m)
 
-	if _, err := m.WakeAgentSocket(t.Context(), id, token); err == nil {
-		t.Fatal("wake succeeded despite a persist failure")
-	}
-	m.mu.Lock()
-	archived := sb.ArchiveCk == ck && sb.VMName == ""
-	m.mu.Unlock()
-	if !archived {
-		t.Error("wake did not roll the record back to archived on a failed persist")
-	}
-	if !pinnedHidden(t, m, ck) {
-		t.Error("kept ck is not pinned after a failed wake")
-	}
-	healStore(t, m)
+		if _, err := m.WakeAgentSocket(t.Context(), id, token); err == nil {
+			t.Fatal("wake succeeded despite a persist failure")
+		}
+		m.mu.Lock()
+		archived := sb.ArchiveCk == ck && sb.VMName == ""
+		m.mu.Unlock()
+		if !archived {
+			t.Error("wake did not roll the record back to archived on a failed persist")
+		}
+		if !pinnedHidden(t, m, ck) {
+			t.Error("kept ck is not pinned after a failed wake")
+		}
+		healStore(t, m)
+	})
 }
 
 // TestReapPurgeRollsBackOnPersistFailure guards the same rollback on the reaper:
 // a retention purge that does not persist keeps the claim and its pinned ck.
 func TestReapPurgeRollsBackOnPersistFailure(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, archivePool(3600))
-	sb := mustClaim(t, m, testKey)
-	id := sb.ID
-	mustArchive(t, m, sb)
-	ck := sb.ArchiveCk
-	m.mu.Lock()
-	sb.Deadline = time.Now().Add(-time.Second) // retention elapsed
-	m.mu.Unlock()
-	breakStore(t, m)
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, archivePool(3600))
+		sb := mustClaim(t, m, testKey)
+		id := sb.ID
+		mustArchive(t, m, sb)
+		ck := sb.ArchiveCk
+		m.mu.Lock()
+		sb.Deadline = time.Now().Add(-time.Second) // retention elapsed
+		m.mu.Unlock()
+		breakStore(t, m)
 
-	m.reapOnce(t.Context())
-	m.mu.Lock()
-	_, present := m.claimed[id]
-	m.mu.Unlock()
-	if !present {
-		t.Error("reap dropped the archived claim despite a failed persist")
-	}
-	if !pinnedHidden(t, m, ck) {
-		t.Error("kept ck is not pinned after a failed reap purge")
-	}
-	healStore(t, m)
+		m.reapOnce(t.Context())
+		m.mu.Lock()
+		_, present := m.claimed[id]
+		m.mu.Unlock()
+		if !present {
+			t.Error("reap dropped the archived claim despite a failed persist")
+		}
+		if !pinnedHidden(t, m, ck) {
+			t.Error("kept ck is not pinned after a failed reap purge")
+		}
+		healStore(t, m)
+	})
 }
 
 // TestArchiveOnceSkipsInFlight guards the in-flight dedup: a sandbox already
 // being archived (marked by a racing reap) must not be exported twice.
 func TestArchiveOnceSkipsInFlight(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, archivePool(3600))
-	sb := mustClaim(t, m, testKey)
-	if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
-		t.Fatalf("hibernate: %v", err)
-	}
-	backdate(m, sb, time.Hour)
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, archivePool(3600))
+		sb := mustClaim(t, m, testKey)
+		if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
+			t.Fatalf("hibernate: %v", err)
+		}
+		backdate(m, sb, time.Hour)
 
-	m.mu.Lock()
-	m.archiving[sb.ID] = struct{}{} // a reap-triggered archive is already exporting it
-	m.mu.Unlock()
-	exportsBefore := eng.exportCount()
+		m.mu.Lock()
+		m.archiving[sb.ID] = struct{}{} // a reap-triggered archive is already exporting it
+		m.mu.Unlock()
+		exportsBefore := eng.exportCount()
 
-	m.archiveOnce(t.Context())
-	waitFor(t, func() bool { return !m.archiveSweep.Load() })
-	if got := eng.exportCount(); got != exportsBefore {
-		t.Errorf("archiveOnce double-exported an in-flight sandbox: %d→%d", exportsBefore, got)
-	}
-	if archivedCount(m) != 0 {
-		t.Error("archiveOnce archived a sandbox already being archived elsewhere")
-	}
+		m.archiveOnce(t.Context())
+		waitFor(t, func() bool { return !m.archiveSweep.Load() })
+		if got := eng.exportCount(); got != exportsBefore {
+			t.Errorf("archiveOnce double-exported an in-flight sandbox: %d→%d", exportsBefore, got)
+		}
+		if archivedCount(m) != 0 {
+			t.Error("archiveOnce archived a sandbox already being archived elsewhere")
+		}
+	})
 }
 
 // TestArchiveWakeEvictsRecLock proves the archive->wake cycle leaves no

--- a/sandboxd/pool/checkpoint_heal_test.go
+++ b/sandboxd/pool/checkpoint_heal_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cocoonstack/sandbox/sandboxd/store"
@@ -77,36 +78,38 @@ func TestClaimCheckpointAfterHealStaysLocal(t *testing.T) {
 // still get a genuinely valid, non-empty checkpoint out of it (the exact
 // case a caller-owned-staging-dir singleflight used to get wrong).
 func TestClaimCheckpointHealDedupsConcurrentPulls(t *testing.T) {
-	id := "ck_00000000000000bb"
-	ckpt := types.Checkpoint{ID: id, Key: testKey, CreatedAt: time.Now()}
-	m, puller := newHealManager(t, ckpt, []string{"peer-a:7777"})
-	puller.release = make(chan struct{})
+	synctest.Test(t, func(t *testing.T) {
+		id := "ck_00000000000000bb"
+		ckpt := types.Checkpoint{ID: id, Key: testKey, CreatedAt: time.Now()}
+		m, puller := newHealManager(t, ckpt, []string{"peer-a:7777"})
+		puller.release = make(chan struct{})
 
-	var wg sync.WaitGroup
-	sbs := make([]*types.Sandbox, 2)
-	errs := make([]error, 2)
-	for i := range 2 {
-		wg.Go(func() {
-			sbs[i], errs[i] = m.ClaimCheckpointHeal(t.Context(), id, time.Hour, "")
-		})
-	}
-	waitFor(t, func() bool { return puller.count() >= 1 })
-	time.Sleep(50 * time.Millisecond) // let the second goroutine join the same flight
-	close(puller.release)
-	wg.Wait()
+		var wg sync.WaitGroup
+		sbs := make([]*types.Sandbox, 2)
+		errs := make([]error, 2)
+		for i := range 2 {
+			wg.Go(func() {
+				sbs[i], errs[i] = m.ClaimCheckpointHeal(t.Context(), id, time.Hour, "")
+			})
+		}
+		waitFor(t, func() bool { return puller.count() >= 1 })
+		time.Sleep(50 * time.Millisecond) // let the second goroutine join the same flight
+		close(puller.release)
+		wg.Wait()
 
-	for i, err := range errs {
-		if err != nil {
-			t.Errorf("goroutine %d: %v", i, err)
-			continue
+		for i, err := range errs {
+			if err != nil {
+				t.Errorf("goroutine %d: %v", i, err)
+				continue
+			}
+			if sbs[i] == nil || sbs[i].FromCheckpoint != id {
+				t.Errorf("goroutine %d: sandbox = %+v, want a valid branch of %s", i, sbs[i], id)
+			}
 		}
-		if sbs[i] == nil || sbs[i].FromCheckpoint != id {
-			t.Errorf("goroutine %d: sandbox = %+v, want a valid branch of %s", i, sbs[i], id)
+		if got := puller.count(); got != 1 {
+			t.Errorf("puller called %d times for two concurrent heals of one id, want 1", got)
 		}
-	}
-	if got := puller.count(); got != 1 {
-		t.Errorf("puller called %d times for two concurrent heals of one id, want 1", got)
-	}
+	})
 }
 
 // TestDeleteVetoesInFlightHeal covers the Codex r2 blocker: a heal's transfer
@@ -118,29 +121,31 @@ func TestClaimCheckpointHealDedupsConcurrentPulls(t *testing.T) {
 // vetoes the pending heal, so the heal's own locked decide phase abandons
 // its publish instead of racing the delete to a stale conclusion.
 func TestDeleteVetoesInFlightHeal(t *testing.T) {
-	id := "ck_00000000000000bb"
-	ckpt := types.Checkpoint{ID: id, Key: testKey, CreatedAt: time.Now()}
-	m, puller := newHealManager(t, ckpt, []string{"peer-a:7777"})
-	puller.release = make(chan struct{})
+	synctest.Test(t, func(t *testing.T) {
+		id := "ck_00000000000000bb"
+		ckpt := types.Checkpoint{ID: id, Key: testKey, CreatedAt: time.Now()}
+		m, puller := newHealManager(t, ckpt, []string{"peer-a:7777"})
+		puller.release = make(chan struct{})
 
-	healDone := make(chan error, 1)
-	go func() {
-		_, err := m.ClaimCheckpointHeal(t.Context(), id, time.Hour, "")
-		healDone <- err
-	}()
-	waitFor(t, func() bool { return puller.count() >= 1 }) // heal is staging, unpublished
+		healDone := make(chan error, 1)
+		go func() {
+			_, err := m.ClaimCheckpointHeal(t.Context(), id, time.Hour, "")
+			healDone <- err
+		}()
+		waitFor(t, func() bool { return puller.count() >= 1 }) // heal is staging, unpublished
 
-	if err := m.DeleteCheckpoint(t.Context(), id, "", DeleteLocal); !errors.Is(err, ErrUnknownCheckpoint) {
-		t.Fatalf("delete while heal is staging: %v, want ErrUnknownCheckpoint (nothing local yet, and it must not block)", err)
-	}
+		if err := m.DeleteCheckpoint(t.Context(), id, "", DeleteLocal); !errors.Is(err, ErrUnknownCheckpoint) {
+			t.Fatalf("delete while heal is staging: %v, want ErrUnknownCheckpoint (nothing local yet, and it must not block)", err)
+		}
 
-	close(puller.release)
-	if err := <-healDone; !errors.Is(err, ErrUnknownCheckpoint) {
-		t.Errorf("heal after a concurrent delete: %v, want ErrUnknownCheckpoint (vetoed, must not publish)", err)
-	}
-	if m.HasCheckpoint(t.Context(), id) {
-		t.Error("checkpoint present after a delete vetoed the pending heal — resurrection")
-	}
+		close(puller.release)
+		if err := <-healDone; !errors.Is(err, ErrUnknownCheckpoint) {
+			t.Errorf("heal after a concurrent delete: %v, want ErrUnknownCheckpoint (vetoed, must not publish)", err)
+		}
+		if m.HasCheckpoint(t.Context(), id) {
+			t.Error("checkpoint present after a delete vetoed the pending heal — resurrection")
+		}
+	})
 }
 
 // TestClaimCheckpointHealCtxCancelReturnsPromptly: a caller that gives up
@@ -149,33 +154,35 @@ func TestDeleteVetoesInFlightHeal(t *testing.T) {
 // ctx.Err() as soon as its own ctx is canceled, while the transfer keeps
 // running and still lands.
 func TestClaimCheckpointHealCtxCancelReturnsPromptly(t *testing.T) {
-	id := "ck_00000000000000bb"
-	ckpt := types.Checkpoint{ID: id, Key: testKey, CreatedAt: time.Now()}
-	m, puller := newHealManager(t, ckpt, []string{"peer-a:7777"})
-	puller.release = make(chan struct{})
+	synctest.Test(t, func(t *testing.T) {
+		id := "ck_00000000000000bb"
+		ckpt := types.Checkpoint{ID: id, Key: testKey, CreatedAt: time.Now()}
+		m, puller := newHealManager(t, ckpt, []string{"peer-a:7777"})
+		puller.release = make(chan struct{})
 
-	ctx, cancel := context.WithCancel(t.Context())
-	done := make(chan error, 1)
-	go func() {
-		_, err := m.ClaimCheckpointHeal(ctx, id, time.Hour, "")
-		done <- err
-	}()
-	waitFor(t, func() bool { return puller.count() >= 1 }) // transfer started, unlocked
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan error, 1)
+		go func() {
+			_, err := m.ClaimCheckpointHeal(ctx, id, time.Hour, "")
+			done <- err
+		}()
+		waitFor(t, func() bool { return puller.count() >= 1 }) // transfer started, unlocked
 
-	cancel()
-	select {
-	case err := <-done:
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("ClaimCheckpointHeal after cancel: %v, want context.Canceled", err)
+		cancel()
+		select {
+		case err := <-done:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("ClaimCheckpointHeal after cancel: %v, want context.Canceled", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("ClaimCheckpointHeal did not return promptly after ctx cancellation")
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("ClaimCheckpointHeal did not return promptly after ctx cancellation")
-	}
 
-	// Detached from the canceled caller, the transfer must still complete
-	// and publish.
-	close(puller.release)
-	waitFor(t, func() bool { return m.HasCheckpoint(t.Context(), id) })
+		// Detached from the canceled caller, the transfer must still complete
+		// and publish.
+		close(puller.release)
+		waitFor(t, func() bool { return m.HasCheckpoint(t.Context(), id) })
+	})
 }
 
 // TestRecLockEvictionWaitsForAllHolders covers the lock-identity-split half

--- a/sandboxd/pool/drain_test.go
+++ b/sandboxd/pool/drain_test.go
@@ -5,51 +5,54 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
 )
 
 func TestDrainRefusesClaimsTrimsWarmAndUncordonRefills(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng)
-	goldenDir := filepath.Join(m.goldensDir(), testKey.Hash())
-	if err := os.MkdirAll(goldenDir, 0o750); err != nil {
-		t.Fatalf("setup golden: %v", err)
-	}
-	if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: testKey, Warm: 2}}); err != nil {
-		t.Fatalf("SetPools: %v", err)
-	}
-	waitFor(t, func() bool {
-		infos, _ := m.Info()
-		return len(infos) == 1 && infos[0].Warm == 2
-	})
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng)
+		goldenDir := filepath.Join(m.goldensDir(), testKey.Hash())
+		if err := os.MkdirAll(goldenDir, 0o750); err != nil {
+			t.Fatalf("setup golden: %v", err)
+		}
+		if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: testKey, Warm: 2}}); err != nil {
+			t.Fatalf("SetPools: %v", err)
+		}
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return len(infos) == 1 && infos[0].Warm == 2
+		})
 
-	m.Drain(t.Context())
+		m.Drain(t.Context())
 
-	if _, err := m.ClaimWarm(t.Context(), testKey, 0, "", "", nil); !errors.Is(err, ErrQuota) {
-		t.Fatalf("ClaimWarm during drain: %v, want ErrQuota", err)
-	}
-	if _, err := m.ClaimProvision(t.Context(), testKey, 0, "", "", nil); !errors.Is(err, ErrQuota) {
-		t.Fatalf("ClaimProvision during drain: %v, want ErrQuota", err)
-	}
-	infos, g := m.Info()
-	if !g.Draining || infos[0].Warm != 0 {
-		t.Fatalf("draining=%v warm=%d, want true/0", g.Draining, infos[0].Warm)
-	}
-	if removed := eng.removedNames(); len(removed) != 2 {
-		t.Fatalf("removed=%v, want both warm VMs destroyed", removed)
-	}
-	m.refillOnce(t.Context())
-	if infos, _ = m.Info(); infos[0].Warm != 0 || infos[0].Refilling != 0 {
-		t.Fatalf("refill ran during drain: %+v", infos)
-	}
-
-	m.Uncordon(t.Context())
-	waitFor(t, func() bool {
+		if _, err := m.ClaimWarm(t.Context(), testKey, 0, "", "", nil); !errors.Is(err, ErrQuota) {
+			t.Fatalf("ClaimWarm during drain: %v, want ErrQuota", err)
+		}
+		if _, err := m.ClaimProvision(t.Context(), testKey, 0, "", "", nil); !errors.Is(err, ErrQuota) {
+			t.Fatalf("ClaimProvision during drain: %v, want ErrQuota", err)
+		}
 		infos, g := m.Info()
-		return !g.Draining && len(infos) == 1 && infos[0].Warm == 2
+		if !g.Draining || infos[0].Warm != 0 {
+			t.Fatalf("draining=%v warm=%d, want true/0", g.Draining, infos[0].Warm)
+		}
+		if removed := eng.removedNames(); len(removed) != 2 {
+			t.Fatalf("removed=%v, want both warm VMs destroyed", removed)
+		}
+		m.refillOnce(t.Context())
+		if infos, _ = m.Info(); infos[0].Warm != 0 || infos[0].Refilling != 0 {
+			t.Fatalf("refill ran during drain: %+v", infos)
+		}
+
+		m.Uncordon(t.Context())
+		waitFor(t, func() bool {
+			infos, g := m.Info()
+			return !g.Draining && len(infos) == 1 && infos[0].Warm == 2
+		})
+		if _, err := claimAny(t.Context(), m, testKey, 0); err != nil {
+			t.Fatalf("claim after uncordon: %v", err)
+		}
 	})
-	if _, err := claimAny(t.Context(), m, testKey, 0); err != nil {
-		t.Fatalf("claim after uncordon: %v", err)
-	}
 }

--- a/sandboxd/pool/fork_test.go
+++ b/sandboxd/pool/fork_test.go
@@ -13,6 +13,11 @@ import (
 // TestForkRacingHibernateUsesPrivateSource pins the transition-locked source
 // decision: a hibernate landing between Fork's entry and its capture must
 // never let the fan-out clone the shared wake snapshot.
+//
+// Not a synctest candidate: Fork's block on sb.Transition (a plain
+// sync.Mutex) is never "durably blocked" by synctest's rules, so the bubble
+// can't fast-forward past the 20ms sleep that lets Fork reach it — verified
+// as a real deadlock (times out at 120s), not a flake.
 func TestForkRacingHibernateUsesPrivateSource(t *testing.T) {
 	eng := newFakeEngine()
 	m := newTestManager(t, eng)

--- a/sandboxd/pool/hibernate_test.go
+++ b/sandboxd/pool/hibernate_test.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"testing/synctest"
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
 	"github.com/cocoonstack/sandbox/sandboxd/types"
@@ -50,43 +51,45 @@ func TestHibernatePersistFailureSurfacesAndConverges(t *testing.T) {
 // (a fast-path retry keeps serving the awake VM — a restart adopts running
 // VMs, so the lag is harmless there), and it is reclaimed once a write lands.
 func TestWakePersistFailureSurfaces(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng)
-	sb := mustClaim(t, m, testKey)
-	if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
-		t.Fatalf("Hibernate: %v", err)
-	}
-	snap := eng.hibernates[0]
-	broken := filepath.Join(t.TempDir(), "gone", "claims.json")
-	m.store.path = broken
-
-	if _, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err == nil {
-		t.Fatal("wake reported success despite a persist failure")
-	}
-	if eng.snapRemoved(snap) {
-		t.Error("wake dropped the snapshot the lagging journal references")
-	}
-	if sock, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err != nil || sock == "" {
-		t.Fatalf("fast-path wake of the awake VM: %q, %v", sock, err)
-	}
-	if eng.snapRemoved(snap) {
-		t.Error("fast path dropped the snapshot while the journal still lags")
-	}
-	if err := os.MkdirAll(filepath.Dir(broken), 0o750); err != nil {
-		t.Fatalf("heal store dir: %v", err)
-	}
-	// The background recommit converges the journal; the next fast-path wake
-	// then reclaims the parked snapshot.
-	waitFor(t, func() bool {
-		if _, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err != nil {
-			t.Fatalf("fast-path wake: %v", err)
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng)
+		sb := mustClaim(t, m, testKey)
+		if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
+			t.Fatalf("Hibernate: %v", err)
 		}
-		return eng.snapRemoved(snap)
+		snap := eng.hibernates[0]
+		broken := filepath.Join(t.TempDir(), "gone", "claims.json")
+		m.store.path = broken
+
+		if _, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err == nil {
+			t.Fatal("wake reported success despite a persist failure")
+		}
+		if eng.snapRemoved(snap) {
+			t.Error("wake dropped the snapshot the lagging journal references")
+		}
+		if sock, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err != nil || sock == "" {
+			t.Fatalf("fast-path wake of the awake VM: %q, %v", sock, err)
+		}
+		if eng.snapRemoved(snap) {
+			t.Error("fast path dropped the snapshot while the journal still lags")
+		}
+		if err := os.MkdirAll(filepath.Dir(broken), 0o750); err != nil {
+			t.Fatalf("heal store dir: %v", err)
+		}
+		// The background recommit converges the journal; the next fast-path wake
+		// then reclaims the parked snapshot.
+		waitFor(t, func() bool {
+			if _, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err != nil {
+				t.Fatalf("fast-path wake: %v", err)
+			}
+			return eng.snapRemoved(snap)
+		})
+		got, loadErr := (&claimStore{path: broken}).load()
+		if loadErr != nil || got[sb.ID] == nil || got[sb.ID].HibernateSnap != "" {
+			t.Fatalf("journal after converge: %+v, %v", got[sb.ID], loadErr)
+		}
 	})
-	got, loadErr := (&claimStore{path: broken}).load()
-	if loadErr != nil || got[sb.ID] == nil || got[sb.ID].HibernateSnap != "" {
-		t.Fatalf("journal after converge: %+v, %v", got[sb.ID], loadErr)
-	}
 }
 
 // TestHibernateAmbiguousErrorTreatedAsDone: the engine can report failure
@@ -273,69 +276,73 @@ func TestWakeResolvesDanglingIntent(t *testing.T) {
 // nothing) must not strand the intent's real snapshot — resolvePendingSnap
 // sees the claim gone and drops the orphan itself.
 func TestResolvePendingSnapReleaseRaceDropsOrphan(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng)
-	sb := mustClaim(t, m, testKey)
-	// Drive to a dangling intent whose snapshot really exists.
-	eng.hibernateErr = errors.New("cli timeout")
-	eng.hibernateErrCompletes = true
-	eng.snapListErr = errors.New("cocoon unreachable")
-	if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err == nil {
-		t.Fatal("Hibernate reported success on an unconfirmed transition")
-	}
-	realSnap := eng.hibernates[0]
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng)
+		sb := mustClaim(t, m, testKey)
+		// Drive to a dangling intent whose snapshot really exists.
+		eng.hibernateErr = errors.New("cli timeout")
+		eng.hibernateErrCompletes = true
+		eng.snapListErr = errors.New("cocoon unreachable")
+		if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err == nil {
+			t.Fatal("Hibernate reported success on an unconfirmed transition")
+		}
+		realSnap := eng.hibernates[0]
 
-	// A wake resolves, but stalls inside SnapshotList; Release lands first.
-	eng.snapListErr = nil
-	eng.snapListStall = make(chan struct{})
-	callsBefore := eng.snapListCalls()
-	wakeErr := make(chan error, 1)
-	go func() {
-		_, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token)
-		wakeErr <- err
-	}()
-	waitFor(t, func() bool { return eng.snapListCalls() > callsBefore })
-	if err := m.Release(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
-		t.Fatalf("release: %v", err)
-	}
-	close(eng.snapListStall)
+		// A wake resolves, but stalls inside SnapshotList; Release lands first.
+		eng.snapListErr = nil
+		eng.snapListStall = make(chan struct{})
+		callsBefore := eng.snapListCalls()
+		wakeErr := make(chan error, 1)
+		go func() {
+			_, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token)
+			wakeErr <- err
+		}()
+		waitFor(t, func() bool { return eng.snapListCalls() > callsBefore })
+		if err := m.Release(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
+			t.Fatalf("release: %v", err)
+		}
+		close(eng.snapListStall)
 
-	if err := <-wakeErr; !errors.Is(err, ErrUnknownSandbox) {
-		t.Fatalf("wake: %v, want ErrUnknownSandbox", err)
-	}
-	waitFor(t, func() bool { return eng.snapRemoved(realSnap) })
+		if err := <-wakeErr; !errors.Is(err, ErrUnknownSandbox) {
+			t.Fatalf("wake: %v, want ErrUnknownSandbox", err)
+		}
+		waitFor(t, func() bool { return eng.snapRemoved(realSnap) })
+	})
 }
 
 // TestResolveAdoptBillsWhenPersistFails: a real transition must be billed even
 // when the adopting resolve's own journal write fails — memory is authoritative
 // and recommit converges disk, so it must not silently escape metering.
 func TestResolveAdoptBillsWhenPersistFails(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng)
-	sb := mustClaim(t, m, testKey)
-	eng.hibernateErr = errors.New("cli timeout")
-	eng.hibernateErrCompletes = true
-	eng.snapListErr = errors.New("cocoon unreachable")
-	if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err == nil {
-		t.Fatal("Hibernate reported success on an unconfirmed transition")
-	}
-	// The list recovers, but the claims journal is now unwritable.
-	eng.snapListErr = nil
-	broken := filepath.Join(t.TempDir(), "gone", "claims.json")
-	m.store.path = broken
-	if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err == nil {
-		t.Fatal("Hibernate reported success despite a persist failure")
-	}
-	if n := m.Counters().Hibernates; n != 1 {
-		t.Errorf("hibernates billed=%d, want 1 (billed even while the persist lags)", n)
-	}
-	// Heal so the background recommit converges (and its goroutine exits).
-	if err := os.MkdirAll(filepath.Dir(broken), 0o750); err != nil {
-		t.Fatalf("heal store dir: %v", err)
-	}
-	waitFor(t, func() bool {
-		got, err := (&claimStore{path: broken}).load()
-		return err == nil && got[sb.ID] != nil && got[sb.ID].HibernateSnap != ""
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng)
+		sb := mustClaim(t, m, testKey)
+		eng.hibernateErr = errors.New("cli timeout")
+		eng.hibernateErrCompletes = true
+		eng.snapListErr = errors.New("cocoon unreachable")
+		if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err == nil {
+			t.Fatal("Hibernate reported success on an unconfirmed transition")
+		}
+		// The list recovers, but the claims journal is now unwritable.
+		eng.snapListErr = nil
+		broken := filepath.Join(t.TempDir(), "gone", "claims.json")
+		m.store.path = broken
+		if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err == nil {
+			t.Fatal("Hibernate reported success despite a persist failure")
+		}
+		if n := m.Counters().Hibernates; n != 1 {
+			t.Errorf("hibernates billed=%d, want 1 (billed even while the persist lags)", n)
+		}
+		// Heal so the background recommit converges (and its goroutine exits).
+		if err := os.MkdirAll(filepath.Dir(broken), 0o750); err != nil {
+			t.Fatalf("heal store dir: %v", err)
+		}
+		waitFor(t, func() bool {
+			got, err := (&claimStore{path: broken}).load()
+			return err == nil && got[sb.ID] != nil && got[sb.ID].HibernateSnap != ""
+		})
 	})
 }
 
@@ -399,77 +406,81 @@ func TestFlushClaimsClosesShutdownWindow(t *testing.T) {
 }
 
 func TestHibernateWakeCycle(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng)
-	sb := mustClaim(t, m, testKey)
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng)
+		sb := mustClaim(t, m, testKey)
 
-	if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
-		t.Fatalf("Hibernate: %v", err)
-	}
-	if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
-		t.Fatalf("repeat Hibernate: %v", err)
-	}
-	if len(eng.hibernates) != 1 {
-		t.Errorf("engine hibernated %d times, want 1 (idempotent)", len(eng.hibernates))
-	}
-	if _, g := m.Info(); g.Hibernated != 1 {
-		t.Errorf("hibernated count %d, want 1", g.Hibernated)
-	}
-	if got, _ := newClaimStore(m.dataDir).load(); got[sb.ID] == nil || got[sb.ID].HibernateSnap == "" {
-		t.Error("hibernation flag not persisted")
-	}
-	hibSnap := eng.hibernates[0]
-	if !strings.HasPrefix(hibSnap, hibernatePrefix) {
-		t.Errorf("snapshot name %q, want %s prefix", hibSnap, hibernatePrefix)
-	}
+		if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
+			t.Fatalf("Hibernate: %v", err)
+		}
+		if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
+			t.Fatalf("repeat Hibernate: %v", err)
+		}
+		if len(eng.hibernates) != 1 {
+			t.Errorf("engine hibernated %d times, want 1 (idempotent)", len(eng.hibernates))
+		}
+		if _, g := m.Info(); g.Hibernated != 1 {
+			t.Errorf("hibernated count %d, want 1", g.Hibernated)
+		}
+		if got, _ := newClaimStore(m.dataDir).load(); got[sb.ID] == nil || got[sb.ID].HibernateSnap == "" {
+			t.Error("hibernation flag not persisted")
+		}
+		hibSnap := eng.hibernates[0]
+		if !strings.HasPrefix(hibSnap, hibernatePrefix) {
+			t.Errorf("snapshot name %q, want %s prefix", hibSnap, hibernatePrefix)
+		}
 
-	sock, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token)
-	if err != nil {
-		t.Fatalf("WakeAgentSocket: %v", err)
-	}
-	if sock != sb.VsockSocket {
-		t.Errorf("sock %q, want %q", sock, sb.VsockSocket)
-	}
-	if len(eng.restores) != 1 {
-		t.Errorf("engine restored %d times, want 1", len(eng.restores))
-	}
-	waitFor(t, func() bool { return eng.snapRemoved(hibSnap) }) // wake drops it off the return path
-	if _, g := m.Info(); g.Hibernated != 0 {
-		t.Errorf("hibernated count %d after wake, want 0", g.Hibernated)
-	}
+		sock, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token)
+		if err != nil {
+			t.Fatalf("WakeAgentSocket: %v", err)
+		}
+		if sock != sb.VsockSocket {
+			t.Errorf("sock %q, want %q", sock, sb.VsockSocket)
+		}
+		if len(eng.restores) != 1 {
+			t.Errorf("engine restored %d times, want 1", len(eng.restores))
+		}
+		waitFor(t, func() bool { return eng.snapRemoved(hibSnap) }) // wake drops it off the return path
+		if _, g := m.Info(); g.Hibernated != 0 {
+			t.Errorf("hibernated count %d after wake, want 0", g.Hibernated)
+		}
 
-	// Awake sandbox: the fast path must not touch the engine again.
-	if _, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err != nil {
-		t.Fatalf("fast-path WakeAgentSocket: %v", err)
-	}
-	if len(eng.restores) != 1 {
-		t.Errorf("fast path restored again: %d", len(eng.restores))
-	}
+		// Awake sandbox: the fast path must not touch the engine again.
+		if _, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err != nil {
+			t.Fatalf("fast-path WakeAgentSocket: %v", err)
+		}
+		if len(eng.restores) != 1 {
+			t.Errorf("fast path restored again: %d", len(eng.restores))
+		}
+	})
 }
 
 // TestWakeDropsSnapshotOffReturnPath: wake returns the socket without waiting
 // for the consumed snapshot's (subprocess) removal.
 func TestWakeDropsSnapshotOffReturnPath(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng)
-	sb := mustClaim(t, m, testKey)
-	if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
-		t.Fatalf("hibernate: %v", err)
-	}
-	eng.snapRemoveStall = make(chan struct{})
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng)
+		sb := mustClaim(t, m, testKey)
+		if err := m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
+			t.Fatalf("hibernate: %v", err)
+		}
+		eng.snapRemoveStall = make(chan struct{})
 
-	sock, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token)
-	if err != nil {
-		t.Fatalf("wake: %v", err)
-	}
-	if sock == "" {
-		t.Error("wake returned an empty socket")
-	}
-	if n := eng.snapRemoveCount(); n != 0 {
-		t.Errorf("snapshot removed %d times before wake returned, want it off the return path", n)
-	}
-	close(eng.snapRemoveStall)
-	waitFor(t, func() bool { return eng.snapRemoveCount() == 1 })
+		sock, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token)
+		if err != nil {
+			t.Fatalf("wake: %v", err)
+		}
+		if sock == "" {
+			t.Error("wake returned an empty socket")
+		}
+		if n := eng.snapRemoveCount(); n != 0 {
+			t.Errorf("snapshot removed %d times before wake returned, want it off the return path", n)
+		}
+		close(eng.snapRemoveStall)
+		waitFor(t, func() bool { return eng.snapRemoveCount() == 1 })
+	})
 }
 
 func TestWakeFailureKeepsHibernated(t *testing.T) {
@@ -512,34 +523,36 @@ func TestReleaseHibernatedDropsSnapshot(t *testing.T) {
 }
 
 func TestReleaseMidHibernateDropsOrphanSnapshot(t *testing.T) {
-	eng := newFakeEngine()
-	eng.hibernateStall = make(chan struct{})
-	m := newTestManager(t, eng)
-	sb := mustClaim(t, m, testKey)
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		eng.hibernateStall = make(chan struct{})
+		m := newTestManager(t, eng)
+		sb := mustClaim(t, m, testKey)
 
-	hibErr := make(chan error, 1)
-	go func() { hibErr <- m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}) }()
-	waitFor(t, func() bool {
-		eng.mu.Lock()
-		defer eng.mu.Unlock()
-		return len(eng.hibernates) == 1
+		hibErr := make(chan error, 1)
+		go func() { hibErr <- m.Hibernate(t.Context(), sb.ID, Cred{Token: sb.Token}) }()
+		waitFor(t, func() bool {
+			eng.mu.Lock()
+			defer eng.mu.Unlock()
+			return len(eng.hibernates) == 1
+		})
+
+		// Release lands while the engine transition is in flight: the claim is
+		// gone before Hibernate can commit, so its snapshot must not leak.
+		if err := m.Release(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
+			t.Fatalf("Release: %v", err)
+		}
+		close(eng.hibernateStall)
+		if err := <-hibErr; !errors.Is(err, ErrUnknownSandbox) {
+			t.Fatalf("Hibernate: %v, want ErrUnknownSandbox", err)
+		}
+		if !slices.Contains(eng.snapRemoves, eng.hibernates[0]) {
+			t.Errorf("snapRemoves=%v, want the orphaned snapshot dropped", eng.snapRemoves)
+		}
+		if _, g := m.Info(); g.Hibernated != 0 {
+			t.Errorf("hibernated count %d, want 0", g.Hibernated)
+		}
 	})
-
-	// Release lands while the engine transition is in flight: the claim is
-	// gone before Hibernate can commit, so its snapshot must not leak.
-	if err := m.Release(t.Context(), sb.ID, Cred{Token: sb.Token}); err != nil {
-		t.Fatalf("Release: %v", err)
-	}
-	close(eng.hibernateStall)
-	if err := <-hibErr; !errors.Is(err, ErrUnknownSandbox) {
-		t.Fatalf("Hibernate: %v, want ErrUnknownSandbox", err)
-	}
-	if !slices.Contains(eng.snapRemoves, eng.hibernates[0]) {
-		t.Errorf("snapRemoves=%v, want the orphaned snapshot dropped", eng.snapRemoves)
-	}
-	if _, g := m.Info(); g.Hibernated != 0 {
-		t.Errorf("hibernated count %d, want 0", g.Hibernated)
-	}
 }
 
 // TestReconcileAdoptsJournaledIntent: a hibernate that stopped the VM but
@@ -582,26 +595,28 @@ func TestReconcileAdoptsJournaledIntent(t *testing.T) {
 // would silently roll the sandbox back to pre-wake state. The claim drops,
 // the orphan sweeps.
 func TestReconcileIgnoresStaleOrphanSnapshot(t *testing.T) {
-	eng := newFakeEngine()
-	eng.vms["sbx-orphan-1"] = "/vsock/orphan"
-	eng.stopped["sbx-orphan-1"] = true
-	eng.snapshots = append(eng.snapshots, hibernatePrefix+"orphan-1-old111")
-	dataDir := t.TempDir()
-	claims := map[string]*types.Sandbox{
-		"sb_orp": {ID: "sb_orp", VMName: "sbx-orphan-1", Key: testKey, Token: "tok", VsockSocket: "/vsock/orphan"},
-	}
-	if err := newClaimStore(dataDir).save(claims); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-	m := newTestManagerAt(t, eng, dataDir)
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		eng.vms["sbx-orphan-1"] = "/vsock/orphan"
+		eng.stopped["sbx-orphan-1"] = true
+		eng.snapshots = append(eng.snapshots, hibernatePrefix+"orphan-1-old111")
+		dataDir := t.TempDir()
+		claims := map[string]*types.Sandbox{
+			"sb_orp": {ID: "sb_orp", VMName: "sbx-orphan-1", Key: testKey, Token: "tok", VsockSocket: "/vsock/orphan"},
+		}
+		if err := newClaimStore(dataDir).save(claims); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		m := newTestManagerAt(t, eng, dataDir)
 
-	if err := m.Reconcile(t.Context()); err != nil {
-		t.Fatalf("Reconcile: %v", err)
-	}
-	if _, g := m.Info(); g.Claimed != 0 {
-		t.Errorf("claimed %d, want the intent-less claim dropped", g.Claimed)
-	}
-	waitFor(t, func() bool { return eng.snapRemoved(hibernatePrefix + "orphan-1-old111") })
+		if err := m.Reconcile(t.Context()); err != nil {
+			t.Fatalf("Reconcile: %v", err)
+		}
+		if _, g := m.Info(); g.Claimed != 0 {
+			t.Errorf("claimed %d, want the intent-less claim dropped", g.Claimed)
+		}
+		waitFor(t, func() bool { return eng.snapRemoved(hibernatePrefix + "orphan-1-old111") })
+	})
 }
 
 // TestReconcileDropsIntentWithoutImage: an intent whose wake image is

--- a/sandboxd/pool/idle_test.go
+++ b/sandboxd/pool/idle_test.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
@@ -9,67 +10,73 @@ import (
 )
 
 func TestIdleOnceHibernatesPastThreshold(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1, IdleHibernateSeconds: 1})
-	sb := mustClaim(t, m, testKey)
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1, IdleHibernateSeconds: 1})
+		sb := mustClaim(t, m, testKey)
 
-	m.idleOnce(t.Context())
-	if hibernated(m) != 0 {
-		t.Fatal("fresh claim hibernated before its threshold")
-	}
+		m.idleOnce(t.Context())
+		if hibernated(m) != 0 {
+			t.Fatal("fresh claim hibernated before its threshold")
+		}
 
-	backdate(m, sb, 2*time.Second)
-	m.idleOnce(t.Context())
-	waitFor(t, func() bool { return hibernated(m) == 1 })
+		backdate(m, sb, 2*time.Second)
+		m.idleOnce(t.Context())
+		waitFor(t, func() bool { return hibernated(m) == 1 })
 
-	// Idempotent on an already-hibernated claim.
-	m.idleOnce(t.Context())
-	waitFor(t, func() bool { return !m.idleSweep.Load() })
-	if hibernated(m) != 1 {
-		t.Error("second sweep disturbed the hibernated claim")
-	}
+		// Idempotent on an already-hibernated claim.
+		m.idleOnce(t.Context())
+		waitFor(t, func() bool { return !m.idleSweep.Load() })
+		if hibernated(m) != 1 {
+			t.Error("second sweep disturbed the hibernated claim")
+		}
+	})
 }
 
 func TestIdleOncePolicyScope(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1})
-	m.idleDefault = time.Second // node default must NOT reach pooled keys
-	m.idleEnabled = true
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1})
+		m.idleDefault = time.Second // node default must NOT reach pooled keys
+		m.idleEnabled = true
 
-	sb := mustClaim(t, m, testKey)
-	backdate(m, sb, time.Hour)
-	m.idleOnce(t.Context())
-	waitFor(t, func() bool { return !m.idleSweep.Load() })
-	if hibernated(m) != 0 {
-		t.Fatal("pooled key without the policy was idle-hibernated by the node default")
-	}
+		sb := mustClaim(t, m, testKey)
+		backdate(m, sb, time.Hour)
+		m.idleOnce(t.Context())
+		waitFor(t, func() bool { return !m.idleSweep.Load() })
+		if hibernated(m) != 0 {
+			t.Fatal("pooled key without the policy was idle-hibernated by the node default")
+		}
 
-	// An unpooled key (template claim shape) takes the node default.
-	unpooled := types.PoolKey{Template: "tpl:v1", Net: types.NetNone, Size: types.SizeSmall}
-	sb2, err := m.ClaimProvision(t.Context(), unpooled, time.Hour, "", "", nil)
-	if err != nil {
-		t.Fatalf("provision: %v", err)
-	}
-	backdate(m, sb2, time.Hour)
-	m.idleOnce(t.Context())
-	waitFor(t, func() bool { return hibernated(m) == 1 })
+		// An unpooled key (template claim shape) takes the node default.
+		unpooled := types.PoolKey{Template: "tpl:v1", Net: types.NetNone, Size: types.SizeSmall}
+		sb2, err := m.ClaimProvision(t.Context(), unpooled, time.Hour, "", "", nil)
+		if err != nil {
+			t.Fatalf("provision: %v", err)
+		}
+		backdate(m, sb2, time.Hour)
+		m.idleOnce(t.Context())
+		waitFor(t, func() bool { return hibernated(m) == 1 })
+	})
 }
 
 func TestActivityStampsBlockIdleSweep(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1, IdleHibernateSeconds: 1})
-	sb := mustClaim(t, m, testKey)
-	backdate(m, sb, 2*time.Second)
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1, IdleHibernateSeconds: 1})
+		sb := mustClaim(t, m, testKey)
+		backdate(m, sb, 2*time.Second)
 
-	// A data-plane connection refreshes the stamp; the sweep must spare it.
-	if _, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err != nil {
-		t.Fatalf("WakeAgentSocket: %v", err)
-	}
-	m.idleOnce(t.Context())
-	waitFor(t, func() bool { return !m.idleSweep.Load() })
-	if hibernated(m) != 0 {
-		t.Fatal("active claim hibernated despite a fresh data-plane stamp")
-	}
+		// A data-plane connection refreshes the stamp; the sweep must spare it.
+		if _, err := m.WakeAgentSocket(t.Context(), sb.ID, sb.Token); err != nil {
+			t.Fatalf("WakeAgentSocket: %v", err)
+		}
+		m.idleOnce(t.Context())
+		waitFor(t, func() bool { return !m.idleSweep.Load() })
+		if hibernated(m) != 0 {
+			t.Fatal("active claim hibernated despite a fresh data-plane stamp")
+		}
+	})
 }
 
 func backdate(m *Manager, sb *types.Sandbox, by time.Duration) {

--- a/sandboxd/pool/pool_test.go
+++ b/sandboxd/pool/pool_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
@@ -269,22 +270,24 @@ func TestAgentSocketValidatesToken(t *testing.T) {
 }
 
 func TestReapDestroysExpiredClaims(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng)
-	sb := mustClaim(t, m, testKey)
-	m.mu.Lock()
-	m.claimed[sb.ID].Deadline = time.Now().Add(-time.Second)
-	m.mu.Unlock()
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng)
+		sb := mustClaim(t, m, testKey)
+		m.mu.Lock()
+		m.claimed[sb.ID].Deadline = time.Now().Add(-time.Second)
+		m.mu.Unlock()
 
-	m.reapOnce(t.Context())
-	// The destroy batch is fanned off the ticker loop; poll for it.
-	waitFor(t, func() bool { return eng.removed(sb.VMName) })
-	if _, g := m.Info(); g.Claimed != 0 {
-		t.Errorf("claimed=%d, want 0", g.Claimed)
-	}
-	if got, _ := newClaimStore(m.dataDir).load(); len(got) != 0 {
-		t.Errorf("reap not persisted: %d entries", len(got))
-	}
+		m.reapOnce(t.Context())
+		// The destroy batch is fanned off the ticker loop; poll for it.
+		waitFor(t, func() bool { return eng.removed(sb.VMName) })
+		if _, g := m.Info(); g.Claimed != 0 {
+			t.Errorf("claimed=%d, want 0", g.Claimed)
+		}
+		if got, _ := newClaimStore(m.dataDir).load(); len(got) != 0 {
+			t.Errorf("reap not persisted: %d entries", len(got))
+		}
+	})
 }
 
 func TestReconcile(t *testing.T) {
@@ -331,88 +334,94 @@ func TestReconcile(t *testing.T) {
 }
 
 func TestRefillTopsUpToTarget(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 2})
-	m.pools[testKey].goldenDir = "/goldens/x"
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 2})
+		m.pools[testKey].goldenDir = "/goldens/x"
 
-	m.refillOnce(t.Context())
-	waitFor(t, func() bool {
-		infos, _ := m.Info()
-		return infos[0].Warm == 2 && infos[0].Refilling == 0
+		m.refillOnce(t.Context())
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return infos[0].Warm == 2 && infos[0].Refilling == 0
+		})
+		if n := eng.cloneCount(); n != 2 {
+			t.Errorf("clones=%d, want 2", n)
+		}
 	})
-	if n := eng.cloneCount(); n != 2 {
-		t.Errorf("clones=%d, want 2", n)
-	}
 }
 
 func TestSetPoolsGrowShrinkAndDrain(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng)
-	goldenDir := filepath.Join(m.goldensDir(), testKey.Hash())
-	if err := os.MkdirAll(goldenDir, 0o750); err != nil {
-		t.Fatalf("setup golden: %v", err)
-	}
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng)
+		goldenDir := filepath.Join(m.goldensDir(), testKey.Hash())
+		if err := os.MkdirAll(goldenDir, 0o750); err != nil {
+			t.Fatalf("setup golden: %v", err)
+		}
 
-	if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: testKey, Warm: 2}}); err != nil {
-		t.Fatalf("SetPools grow: %v", err)
-	}
-	waitFor(t, func() bool {
+		if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: testKey, Warm: 2}}); err != nil {
+			t.Fatalf("SetPools grow: %v", err)
+		}
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return len(infos) == 1 && infos[0].Target == 2 && infos[0].Warm == 2 && infos[0].Golden
+		})
+		if n := eng.cloneCount(); n != 2 {
+			t.Fatalf("clones=%d, want 2", n)
+		}
+
+		if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: testKey, Warm: 1}}); err != nil {
+			t.Fatalf("SetPools shrink: %v", err)
+		}
 		infos, _ := m.Info()
-		return len(infos) == 1 && infos[0].Target == 2 && infos[0].Warm == 2 && infos[0].Golden
+		if len(infos) != 1 || infos[0].Target != 1 || infos[0].Warm != 1 {
+			t.Fatalf("after shrink info=%+v, want target=1 warm=1", infos)
+		}
+		if removed := eng.removedNames(); len(removed) != 1 {
+			t.Fatalf("removed=%v, want one trimmed VM", removed)
+		}
+
+		if err := m.SetPools(t.Context(), nil); err != nil {
+			t.Fatalf("SetPools drain: %v", err)
+		}
+		infos, _ = m.Info()
+		if len(infos) != 0 {
+			t.Fatalf("after drain info=%+v, want no configured pools", infos)
+		}
+		if removed := eng.removedNames(); len(removed) != 2 {
+			t.Fatalf("removed=%v, want both warm VMs destroyed", removed)
+		}
 	})
-	if n := eng.cloneCount(); n != 2 {
-		t.Fatalf("clones=%d, want 2", n)
-	}
-
-	if err := m.SetPools(t.Context(), []config.PoolSpec{{PoolKey: testKey, Warm: 1}}); err != nil {
-		t.Fatalf("SetPools shrink: %v", err)
-	}
-	infos, _ := m.Info()
-	if len(infos) != 1 || infos[0].Target != 1 || infos[0].Warm != 1 {
-		t.Fatalf("after shrink info=%+v, want target=1 warm=1", infos)
-	}
-	if removed := eng.removedNames(); len(removed) != 1 {
-		t.Fatalf("removed=%v, want one trimmed VM", removed)
-	}
-
-	if err := m.SetPools(t.Context(), nil); err != nil {
-		t.Fatalf("SetPools drain: %v", err)
-	}
-	infos, _ = m.Info()
-	if len(infos) != 0 {
-		t.Fatalf("after drain info=%+v, want no configured pools", infos)
-	}
-	if removed := eng.removedNames(); len(removed) != 2 {
-		t.Fatalf("removed=%v, want both warm VMs destroyed", removed)
-	}
 }
 
 func TestRefillServicesEveryPoolUnderTightBudget(t *testing.T) {
-	key2 := types.PoolKey{Template: "rt:24.04", Net: types.NetNone, Size: types.SizeMedium}
-	m := newTestManager(t, newFakeEngine(),
-		config.PoolSpec{PoolKey: testKey, Warm: 3},
-		config.PoolSpec{PoolKey: key2, Warm: 3})
-	m.refillSem = make(chan struct{}, 1)
-	m.probeSem = make(chan struct{}, 1)
-	m.mu.Lock()
-	m.pools[testKey].goldenDir = "/goldens/a"
-	m.pools[key2].goldenDir = "/goldens/b"
-	m.mu.Unlock()
+	synctest.Test(t, func(t *testing.T) {
+		key2 := types.PoolKey{Template: "rt:24.04", Net: types.NetNone, Size: types.SizeMedium}
+		m := newTestManager(t, newFakeEngine(),
+			config.PoolSpec{PoolKey: testKey, Warm: 3},
+			config.PoolSpec{PoolKey: key2, Warm: 3})
+		m.refillSem = make(chan struct{}, 1)
+		m.probeSem = make(chan struct{}, 1)
+		m.mu.Lock()
+		m.pools[testKey].goldenDir = "/goldens/a"
+		m.pools[key2].goldenDir = "/goldens/b"
+		m.mu.Unlock()
 
-	m.refillOnce(t.Context())
+		m.refillOnce(t.Context())
 
-	both := func() bool {
-		infos, _ := m.Info()
-		return len(infos) == 2 && infos[0].Warm == 3 && infos[1].Warm == 3
-	}
-	deadline := time.Now().Add(3 * time.Second)
-	for !both() && time.Now().Before(deadline) {
-		time.Sleep(5 * time.Millisecond)
-	}
-	if !both() {
-		infos, _ := m.Info()
-		t.Fatalf("one refill tick did not chain both pools to target: %+v", infos)
-	}
+		both := func() bool {
+			infos, _ := m.Info()
+			return len(infos) == 2 && infos[0].Warm == 3 && infos[1].Warm == 3
+		}
+		deadline := time.Now().Add(3 * time.Second)
+		for !both() && time.Now().Before(deadline) {
+			time.Sleep(5 * time.Millisecond)
+		}
+		if !both() {
+			infos, _ := m.Info()
+			t.Fatalf("one refill tick did not chain both pools to target: %+v", infos)
+		}
+	})
 }
 
 func TestSetPoolsRemovalShedsArchivePolicy(t *testing.T) {
@@ -472,90 +481,98 @@ func TestSetPoolsRejectsEgress(t *testing.T) {
 }
 
 func TestRefillRespectsSemaphore(t *testing.T) {
-	eng := newFakeEngine()
-	eng.probeStall = make(chan struct{})
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 7})
-	m.refillSem = make(chan struct{}, 2)
-	m.probeSem = make(chan struct{}, 2)
-	m.pools[testKey].goldenDir = "/goldens/x"
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		eng.probeStall = make(chan struct{})
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 7})
+		m.refillSem = make(chan struct{}, 2)
+		m.probeSem = make(chan struct{}, 2)
+		m.pools[testKey].goldenDir = "/goldens/x"
 
-	m.refillOnce(t.Context())
-	waitFor(t, func() bool { return eng.cloneCount() == 4 && eng.probeCount() == 2 })
-	time.Sleep(50 * time.Millisecond)
-	if clones, probes := eng.cloneCount(), eng.probeCount(); clones != 4 || probes != 2 {
-		t.Errorf("stalled pipeline clones=%d probes=%d, want 4/2", clones, probes)
-	}
-	infos, _ := m.Info()
-	if infos[0].Warm != 0 || infos[0].Refilling != 4 {
-		t.Errorf("stalled pipeline info=%+v, want warm=0 refilling=4", infos[0])
-	}
-
-	close(eng.probeStall)
-	waitFor(t, func() bool {
+		m.refillOnce(t.Context())
+		waitFor(t, func() bool { return eng.cloneCount() == 4 && eng.probeCount() == 2 })
+		time.Sleep(50 * time.Millisecond)
+		if clones, probes := eng.cloneCount(), eng.probeCount(); clones != 4 || probes != 2 {
+			t.Errorf("stalled pipeline clones=%d probes=%d, want 4/2", clones, probes)
+		}
 		infos, _ := m.Info()
-		return infos[0].Warm == 7 && infos[0].Refilling == 0
+		if infos[0].Warm != 0 || infos[0].Refilling != 4 {
+			t.Errorf("stalled pipeline info=%+v, want warm=0 refilling=4", infos[0])
+		}
+
+		close(eng.probeStall)
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return infos[0].Warm == 7 && infos[0].Refilling == 0
+		})
 	})
 }
 
 func TestRefillCloneStageIsBounded(t *testing.T) {
-	eng := newFakeEngine()
-	eng.cloneStall = make(chan struct{})
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 5})
-	m.refillSem = make(chan struct{}, 2)
-	m.probeSem = make(chan struct{}, 2)
-	m.pools[testKey].goldenDir = "/goldens/x"
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		eng.cloneStall = make(chan struct{})
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 5})
+		m.refillSem = make(chan struct{}, 2)
+		m.probeSem = make(chan struct{}, 2)
+		m.pools[testKey].goldenDir = "/goldens/x"
 
-	m.refillOnce(t.Context())
-	waitFor(t, func() bool { return eng.cloneCount() == 2 })
-	time.Sleep(50 * time.Millisecond)
-	if got := eng.cloneCount(); got != 2 {
-		t.Errorf("clones=%d while clone stage stalled, want 2", got)
-	}
-	close(eng.cloneStall)
-	waitFor(t, func() bool {
-		infos, _ := m.Info()
-		return infos[0].Warm == 5 && infos[0].Refilling == 0
+		m.refillOnce(t.Context())
+		waitFor(t, func() bool { return eng.cloneCount() == 2 })
+		time.Sleep(50 * time.Millisecond)
+		if got := eng.cloneCount(); got != 2 {
+			t.Errorf("clones=%d while clone stage stalled, want 2", got)
+		}
+		close(eng.cloneStall)
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return infos[0].Warm == 5 && infos[0].Refilling == 0
+		})
 	})
 }
 
 func TestRefillProbeFailureCleansUp(t *testing.T) {
-	eng := newFakeEngine()
-	eng.probeErr = errors.New("never ready")
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1})
-	m.pools[testKey].goldenDir = "/goldens/x"
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		eng.probeErr = errors.New("never ready")
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1})
+		m.pools[testKey].goldenDir = "/goldens/x"
 
-	m.refillOnce(t.Context())
-	waitFor(t, func() bool {
-		infos, _ := m.Info()
-		return infos[0].Warm == 0 && infos[0].Refilling == 0 && len(eng.removedNames()) == 1
-	})
-	eng.mu.Lock()
-	eng.probeErr = nil
-	eng.mu.Unlock()
-	m.refillOnce(t.Context())
-	waitFor(t, func() bool {
-		infos, _ := m.Info()
-		return infos[0].Warm == 1 && infos[0].Refilling == 0
+		m.refillOnce(t.Context())
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return infos[0].Warm == 0 && infos[0].Refilling == 0 && len(eng.removedNames()) == 1
+		})
+		eng.mu.Lock()
+		eng.probeErr = nil
+		eng.mu.Unlock()
+		m.refillOnce(t.Context())
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return infos[0].Warm == 1 && infos[0].Refilling == 0
+		})
 	})
 }
 
 func TestRefillCanceledWhileWaitingForProbeCleansUp(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1})
-	m.refillSem = make(chan struct{}, 1)
-	m.probeSem = make(chan struct{}, 1)
-	m.probeSem <- struct{}{}
-	m.pools[testKey].goldenDir = "/goldens/x"
-	ctx, cancel := context.WithCancel(t.Context())
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1})
+		m.refillSem = make(chan struct{}, 1)
+		m.probeSem = make(chan struct{}, 1)
+		m.probeSem <- struct{}{}
+		m.pools[testKey].goldenDir = "/goldens/x"
+		ctx, cancel := context.WithCancel(t.Context())
 
-	m.refillOnce(ctx)
-	waitFor(t, func() bool { return eng.cloneCount() == 1 && len(m.refillSem) == 0 })
-	cancel()
-	waitFor(t, func() bool {
-		infos, _ := m.Info()
-		return infos[0].Refilling == 0 && len(eng.removedNames()) == 1
+		m.refillOnce(ctx)
+		waitFor(t, func() bool { return eng.cloneCount() == 1 && len(m.refillSem) == 0 })
+		cancel()
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return infos[0].Refilling == 0 && len(eng.removedNames()) == 1
+		})
+		<-m.probeSem
 	})
-	<-m.probeSem
 }
 
 func TestDirectClaimSkipsProbeGate(t *testing.T) {
@@ -589,98 +606,106 @@ func TestRefillBudgetFollowsConfig(t *testing.T) {
 // TestRefillReactivelyFillsToTarget: one trigger fills the whole target (not
 // just the concurrency budget), since a finished refill chains the next.
 func TestRefillReactivelyFillsToTarget(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 10})
-	m.pools[testKey].goldenDir = "/goldens/x"
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 10})
+		m.pools[testKey].goldenDir = "/goldens/x"
 
-	m.refillOnce(t.Context())
-	waitFor(t, func() bool {
-		infos, _ := m.Info()
-		return infos[0].Warm == 10 && infos[0].Refilling == 0
+		m.refillOnce(t.Context())
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return infos[0].Warm == 10 && infos[0].Refilling == 0
+		})
+		if n := eng.cloneCount(); n != 10 {
+			t.Errorf("clones=%d, want 10", n)
+		}
 	})
-	if n := eng.cloneCount(); n != 10 {
-		t.Errorf("clones=%d, want 10", n)
-	}
 }
 
 func TestGoldenBuildPipeline(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1})
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1})
 
-	m.refillOnce(t.Context())
-	waitFor(t, func() bool {
-		infos, _ := m.Info()
-		return infos[0].Golden
-	})
-	m.mu.Lock()
-	golden := m.pools[testKey].goldenDir
-	m.mu.Unlock()
-	if fi, err := os.Stat(golden); err != nil || !fi.IsDir() {
-		t.Errorf("golden dir not exported: %v", err)
-	}
-	builder := vmPrefix + "gb-" + testKey.Hash()
-	if removed := eng.removedNames(); !slices.Contains(removed, builder) {
-		t.Errorf("removes=%v, want builder VM %s destroyed", removed, builder)
-	}
+		m.refillOnce(t.Context())
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return infos[0].Golden
+		})
+		m.mu.Lock()
+		golden := m.pools[testKey].goldenDir
+		m.mu.Unlock()
+		if fi, err := os.Stat(golden); err != nil || !fi.IsDir() {
+			t.Errorf("golden dir not exported: %v", err)
+		}
+		builder := vmPrefix + "gb-" + testKey.Hash()
+		if removed := eng.removedNames(); !slices.Contains(removed, builder) {
+			t.Errorf("removes=%v, want builder VM %s destroyed", removed, builder)
+		}
 
-	m.refillOnce(t.Context())
-	waitFor(t, func() bool {
-		infos, _ := m.Info()
-		return infos[0].Warm == 1
+		m.refillOnce(t.Context())
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return infos[0].Warm == 1
+		})
 	})
 }
 
 func TestGoldenBuildFailureBacksOff(t *testing.T) {
-	eng := newFakeEngine()
-	eng.runColdErr = errors.New("image pull failed")
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1})
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		eng.runColdErr = errors.New("image pull failed")
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1})
 
-	m.refillOnce(t.Context())
-	waitFor(t, func() bool {
-		m.mu.Lock()
-		defer m.mu.Unlock()
-		p := m.pools[testKey]
-		return !p.building && p.nextBuild.After(time.Now())
+		m.refillOnce(t.Context())
+		waitFor(t, func() bool {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			p := m.pools[testKey]
+			return !p.building && p.nextBuild.After(time.Now())
+		})
+
+		m.refillOnce(t.Context())
+		time.Sleep(20 * time.Millisecond)
+		if n := eng.coldCount(); n != 1 {
+			t.Errorf("cold boots=%d after failed build, want 1 (backoff)", n)
+		}
 	})
-
-	m.refillOnce(t.Context())
-	time.Sleep(20 * time.Millisecond)
-	if n := eng.coldCount(); n != 1 {
-		t.Errorf("cold boots=%d after failed build, want 1 (backoff)", n)
-	}
 }
 
 func TestReapBatchDoesNotStallTheLoop(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng)
-	// More expired claims than the concurrency budget (defaultRefill here) so
-	// the batch would block the submit loop if it acquired the semaphore there
-	// instead of per-goroutine.
-	const n = defaultRefill + 3
-	var sbs []*types.Sandbox
-	for range n {
-		sbs = append(sbs, mustClaim(t, m, testKey))
-	}
-	m.mu.Lock()
-	for _, sb := range sbs {
-		m.claimed[sb.ID].Deadline = time.Now().Add(-time.Second)
-	}
-	m.mu.Unlock()
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng)
+		// More expired claims than the concurrency budget (defaultRefill here) so
+		// the batch would block the submit loop if it acquired the semaphore there
+		// instead of per-goroutine.
+		const n = defaultRefill + 3
+		var sbs []*types.Sandbox
+		for range n {
+			sbs = append(sbs, mustClaim(t, m, testKey))
+		}
+		m.mu.Lock()
+		for _, sb := range sbs {
+			m.claimed[sb.ID].Deadline = time.Now().Add(-time.Second)
+		}
+		m.mu.Unlock()
 
-	stall := make(chan struct{})
-	eng.mu.Lock()
-	eng.removeStall = stall
-	eng.mu.Unlock()
+		stall := make(chan struct{})
+		eng.mu.Lock()
+		eng.removeStall = stall
+		eng.mu.Unlock()
 
-	done := make(chan struct{})
-	go func() { m.reapOnce(t.Context()); close(done) }()
-	select {
-	case <-done: // returned while every destroy is parked: the loop never blocked
-	case <-time.After(2 * time.Second):
-		t.Fatal("reapOnce blocked on a batch larger than the budget")
-	}
-	close(stall)
-	waitFor(t, func() bool { return eng.removed(sbs[n-1].VMName) })
+		done := make(chan struct{})
+		go func() { m.reapOnce(t.Context()); close(done) }()
+		select {
+		case <-done: // returned while every destroy is parked: the loop never blocked
+		case <-time.After(2 * time.Second):
+			t.Fatal("reapOnce blocked on a batch larger than the budget")
+		}
+		close(stall)
+		waitFor(t, func() bool { return eng.removed(sbs[n-1].VMName) })
+	})
 }
 
 func TestProbeReadyWaitsForVsock(t *testing.T) {

--- a/sandboxd/pool/refillbackoff_test.go
+++ b/sandboxd/pool/refillbackoff_test.go
@@ -3,6 +3,7 @@ package pool
 import (
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
@@ -63,53 +64,55 @@ func TestBackoffGrowsAndIsCapped(t *testing.T) {
 // TestRefillOnceHonorsTheBackoff pins the property that saves the node:
 // while a pool is backed off, the ticker spawns nothing.
 func TestRefillOnceHonorsTheBackoff(t *testing.T) {
-	eng := newFakeEngine()
-	// Deliberately not a capacitySignature: that parks the node after one
-	// failure; the streak backoff is the fallback for unclassifiable errors.
-	eng.cloneErr = errors.New("clone: guest kernel panicked before vsock came up")
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 50})
-	m.pools[testKey].goldenDir = "/goldens/x"
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		// Deliberately not a capacitySignature: that parks the node after one
+		// failure; the streak backoff is the fallback for unclassifiable errors.
+		eng.cloneErr = errors.New("clone: guest kernel panicked before vsock came up")
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 50})
+		m.pools[testKey].goldenDir = "/goldens/x"
 
-	// Concurrency is bounded, so the streak accrues over several ticks.
-	backedOff := false
-	for range 50 {
+		// Concurrency is bounded, so the streak accrues over several ticks.
+		backedOff := false
+		for range 50 {
+			m.refillOnce(t.Context())
+			waitFor(t, func() bool {
+				infos, _ := m.Info()
+				return infos[0].Refilling == 0
+			})
+			m.mu.Lock()
+			backedOff = !m.pools[testKey].nextRefill.IsZero()
+			m.mu.Unlock()
+			if backedOff {
+				break
+			}
+		}
+		attempts := eng.cloneCount()
+		if !backedOff {
+			t.Fatal("a pool whose every refill failed is not backed off")
+		}
+
+		// Pin the expiry far out so the no-spawn assertions cannot race a short
+		// first backoff on a loaded machine.
+		m.mu.Lock()
+		m.pools[testKey].nextRefill = time.Now().Add(time.Hour)
+		m.mu.Unlock()
+		for range 5 {
+			m.refillOnce(t.Context())
+		}
+		if n := eng.cloneCount(); n != attempts {
+			t.Errorf("clones=%d after backing off, want %d: a backed-off pool must not attempt again", n, attempts)
+		}
+
+		// A pause, not a latch: once the wait expires a working engine fills.
+		m.mu.Lock()
+		m.pools[testKey].nextRefill = time.Now().Add(-time.Second)
+		m.mu.Unlock()
+		eng.cloneErr = nil
 		m.refillOnce(t.Context())
 		waitFor(t, func() bool {
 			infos, _ := m.Info()
-			return infos[0].Refilling == 0
+			return infos[0].Warm == 50
 		})
-		m.mu.Lock()
-		backedOff = !m.pools[testKey].nextRefill.IsZero()
-		m.mu.Unlock()
-		if backedOff {
-			break
-		}
-	}
-	attempts := eng.cloneCount()
-	if !backedOff {
-		t.Fatal("a pool whose every refill failed is not backed off")
-	}
-
-	// Pin the expiry far out so the no-spawn assertions cannot race a short
-	// first backoff on a loaded machine.
-	m.mu.Lock()
-	m.pools[testKey].nextRefill = time.Now().Add(time.Hour)
-	m.mu.Unlock()
-	for range 5 {
-		m.refillOnce(t.Context())
-	}
-	if n := eng.cloneCount(); n != attempts {
-		t.Errorf("clones=%d after backing off, want %d: a backed-off pool must not attempt again", n, attempts)
-	}
-
-	// A pause, not a latch: once the wait expires a working engine fills.
-	m.mu.Lock()
-	m.pools[testKey].nextRefill = time.Now().Add(-time.Second)
-	m.mu.Unlock()
-	eng.cloneErr = nil
-	m.refillOnce(t.Context())
-	waitFor(t, func() bool {
-		infos, _ := m.Info()
-		return infos[0].Warm == 50
 	})
 }

--- a/sandboxd/pool/refillkick_test.go
+++ b/sandboxd/pool/refillkick_test.go
@@ -3,6 +3,7 @@ package pool
 import (
 	"errors"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
@@ -26,43 +27,45 @@ func TestKickRefillCoalescesAndNeverBlocks(t *testing.T) {
 // TestNodeAtCapacityParksRefillInsteadOfRetrying pins the difference between
 // "this VM failed to start" and "this node cannot hold another VM".
 func TestNodeAtCapacityParksRefillInsteadOfRetrying(t *testing.T) {
-	eng := newFakeEngine()
-	eng.cloneErr = errors.New(`cocoon vm clone: exit status 1: Error: configure network: ` +
-		`cni add A/eth0: plugin type="bridge" failed (add): ` +
-		`failed to connect "veth3f2" to bridge cni0: exchange full`)
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 4})
-	m.pools[testKey].goldenDir = "/goldens/x"
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		eng.cloneErr = errors.New(`cocoon vm clone: exit status 1: Error: configure network: ` +
+			`cni add A/eth0: plugin type="bridge" failed (add): ` +
+			`failed to connect "veth3f2" to bridge cni0: exchange full`)
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 4})
+		m.pools[testKey].goldenDir = "/goldens/x"
 
-	m.refillOnce(t.Context())
-	waitFor(t, func() bool {
-		infos, _ := m.Info()
-		return infos[0].Refilling == 0
-	})
-	attempts := eng.cloneCount()
-	if attempts == 0 {
-		t.Fatal("no clone attempted, so the test proves nothing")
-	}
-
-	if _, g := m.Info(); !g.AtCapacity || g.AtCapacityReason == "" {
-		t.Fatalf("at-capacity not published: %+v", g)
-	}
-
-	// Every later tick is a no-op until the backoff expires.
-	for range 5 {
 		m.refillOnce(t.Context())
-	}
-	if n := eng.cloneCount(); n != attempts {
-		t.Errorf("clones=%d after parking, want %d: a parked node must not attempt again", n, attempts)
-	}
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return infos[0].Refilling == 0
+		})
+		attempts := eng.cloneCount()
+		if attempts == 0 {
+			t.Fatal("no clone attempted, so the test proves nothing")
+		}
 
-	// A park, not a latch: once the backoff expires refill resumes.
-	m.mu.Lock()
-	m.atCapacityUntil = time.Now().Add(-time.Second)
-	m.mu.Unlock()
-	eng.cloneErr = nil
-	m.refillOnce(t.Context())
-	waitFor(t, func() bool {
-		infos, _ := m.Info()
-		return infos[0].Warm == 4
+		if _, g := m.Info(); !g.AtCapacity || g.AtCapacityReason == "" {
+			t.Fatalf("at-capacity not published: %+v", g)
+		}
+
+		// Every later tick is a no-op until the backoff expires.
+		for range 5 {
+			m.refillOnce(t.Context())
+		}
+		if n := eng.cloneCount(); n != attempts {
+			t.Errorf("clones=%d after parking, want %d: a parked node must not attempt again", n, attempts)
+		}
+
+		// A park, not a latch: once the backoff expires refill resumes.
+		m.mu.Lock()
+		m.atCapacityUntil = time.Now().Add(-time.Second)
+		m.mu.Unlock()
+		eng.cloneErr = nil
+		m.refillOnce(t.Context())
+		waitFor(t, func() bool {
+			infos, _ := m.Info()
+			return infos[0].Warm == 4
+		})
 	})
 }

--- a/sandboxd/pool/volume_capture_test.go
+++ b/sandboxd/pool/volume_capture_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"slices"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
@@ -117,15 +118,17 @@ func TestReconcileRetainsVolumeCaptureGateWithoutCatalog(t *testing.T) {
 }
 
 func TestIdleOnceSkipsVolumeClaim(t *testing.T) {
-	eng := newFakeEngine()
-	m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1, IdleHibernateSeconds: 1})
-	sb := mustClaim(t, m, testKey)
-	sb.Volumes = []types.Volume{{Name: "dataset", Mount: "/datasets"}}
-	backdate(m, sb, 2*time.Second)
+	synctest.Test(t, func(t *testing.T) {
+		eng := newFakeEngine()
+		m := newTestManager(t, eng, config.PoolSpec{PoolKey: testKey, Warm: 1, IdleHibernateSeconds: 1})
+		sb := mustClaim(t, m, testKey)
+		sb.Volumes = []types.Volume{{Name: "dataset", Mount: "/datasets"}}
+		backdate(m, sb, 2*time.Second)
 
-	m.idleOnce(t.Context())
-	waitFor(t, func() bool { return !m.idleSweep.Load() })
-	if len(eng.hibernates) != 0 || hibernated(m) != 0 {
-		t.Errorf("idle sweep hibernated volume claim: engine=%v count=%d", eng.hibernates, hibernated(m))
-	}
+		m.idleOnce(t.Context())
+		waitFor(t, func() bool { return !m.idleSweep.Load() })
+		if len(eng.hibernates) != 0 || hibernated(m) != 0 {
+			t.Errorf("idle sweep hibernated volume claim: engine=%v count=%d", eng.hibernates, hibernated(m))
+		}
+	})
 }

--- a/sandboxd/pool/volume_rw_test.go
+++ b/sandboxd/pool/volume_rw_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
@@ -289,57 +290,61 @@ func TestVolumeAdmissionReleasedAfterSetupFailure(t *testing.T) {
 }
 
 func TestRollbackQuiescesWritableVolumesBeforeRemoval(t *testing.T) {
-	path := writeVolumeImage(t, "scratch.img", "data")
-	eng := newFakeEngine()
-	eng.vms["sbx-rw"] = "/vsock/rw"
-	m := newVolumeManager(t, eng, []config.VolumeSpec{{Name: "scratch", Path: path, Writable: true}})
-	if err := markVolumeDirty(path); err != nil {
-		t.Fatalf("mark dirty: %v", err)
-	}
-	sb := &types.Sandbox{
-		ID: "sb_rw", VMName: "sbx-rw", Key: testKey, VsockSocket: "/vsock/rw",
-		Volumes: []types.Volume{{Name: "scratch", Mount: "/volumes/scratch", Mode: types.VolumeModeRW}},
-	}
-	m.mu.Lock()
-	m.claimed[sb.ID] = sb
-	m.adoptVolumes(sb.Volumes)
-	m.mu.Unlock()
+	synctest.Test(t, func(t *testing.T) {
+		path := writeVolumeImage(t, "scratch.img", "data")
+		eng := newFakeEngine()
+		eng.vms["sbx-rw"] = "/vsock/rw"
+		m := newVolumeManager(t, eng, []config.VolumeSpec{{Name: "scratch", Path: path, Writable: true}})
+		if err := markVolumeDirty(path); err != nil {
+			t.Fatalf("mark dirty: %v", err)
+		}
+		sb := &types.Sandbox{
+			ID: "sb_rw", VMName: "sbx-rw", Key: testKey, VsockSocket: "/vsock/rw",
+			Volumes: []types.Volume{{Name: "scratch", Mount: "/volumes/scratch", Mode: types.VolumeModeRW}},
+		}
+		m.mu.Lock()
+		m.claimed[sb.ID] = sb
+		m.adoptVolumes(sb.Volumes)
+		m.mu.Unlock()
 
-	m.rollbackClaim(t.Context(), []*types.Sandbox{sb})
-	waitFor(t, m.store.synced)
+		m.rollbackClaim(t.Context(), []*types.Sandbox{sb})
+		waitFor(t, m.store.synced)
 
-	if seen := eng.opsAtRemoval(sb.VMName); !slices.Contains(seen, "umount:/volumes/scratch") {
-		t.Errorf("ops at removal=%v, want the unmount already done", seen)
-	}
-	if volumeDirty(path) {
-		t.Error("rollback left the image dirty after a clean unmount")
-	}
-	if holders := volumeHoldersOf(m, "scratch"); holders != (volumeHolders{}) {
-		t.Errorf("registry after rollback=%+v, want empty", holders)
-	}
+		if seen := eng.opsAtRemoval(sb.VMName); !slices.Contains(seen, "umount:/volumes/scratch") {
+			t.Errorf("ops at removal=%v, want the unmount already done", seen)
+		}
+		if volumeDirty(path) {
+			t.Error("rollback left the image dirty after a clean unmount")
+		}
+		if holders := volumeHoldersOf(m, "scratch"); holders != (volumeHolders{}) {
+			t.Errorf("registry after rollback=%+v, want empty", holders)
+		}
+	})
 }
 
 func TestReapQuiescesWritableVolumesBeforeRemoval(t *testing.T) {
-	path := writeVolumeImage(t, "scratch.img", "data")
-	eng := newFakeEngine()
-	m := newVolumeManager(t, eng, []config.VolumeSpec{{Name: "scratch", Path: path, Writable: true}})
-	sb, err := m.ClaimProvision(t.Context(), testKey, time.Hour, "", "", []types.Volume{{Name: "scratch", Mode: types.VolumeModeRW}})
-	if err != nil {
-		t.Fatalf("ClaimProvision: %v", err)
-	}
-	m.mu.Lock()
-	sb.Deadline = time.Now().Add(-time.Second)
-	m.mu.Unlock()
+	synctest.Test(t, func(t *testing.T) {
+		path := writeVolumeImage(t, "scratch.img", "data")
+		eng := newFakeEngine()
+		m := newVolumeManager(t, eng, []config.VolumeSpec{{Name: "scratch", Path: path, Writable: true}})
+		sb, err := m.ClaimProvision(t.Context(), testKey, time.Hour, "", "", []types.Volume{{Name: "scratch", Mode: types.VolumeModeRW}})
+		if err != nil {
+			t.Fatalf("ClaimProvision: %v", err)
+		}
+		m.mu.Lock()
+		sb.Deadline = time.Now().Add(-time.Second)
+		m.mu.Unlock()
 
-	m.reapOnce(t.Context())
-	waitFor(t, func() bool { return volumeHoldersOf(m, "scratch") == volumeHolders{} })
+		m.reapOnce(t.Context())
+		waitFor(t, func() bool { return volumeHoldersOf(m, "scratch") == volumeHolders{} })
 
-	if seen := eng.opsAtRemoval(sb.VMName); !slices.Contains(seen, "umount:/volumes/scratch") {
-		t.Errorf("ops at removal=%v, want the unmount already done", seen)
-	}
-	if volumeDirty(path) {
-		t.Error("reap left the image dirty after a clean unmount")
-	}
+		if seen := eng.opsAtRemoval(sb.VMName); !slices.Contains(seen, "umount:/volumes/scratch") {
+			t.Errorf("ops at removal=%v, want the unmount already done", seen)
+		}
+		if volumeDirty(path) {
+			t.Error("reap left the image dirty after a clean unmount")
+		}
+	})
 }
 
 func TestQuiesceFailureSyncsOnceAndKeepsMarkers(t *testing.T) {

--- a/silkd/src/find.rs
+++ b/silkd/src/find.rs
@@ -139,8 +139,7 @@ async fn scan_file<W: AsyncWrite + Unpin>(
 fn name_matches(path: &Path, name_re: Option<&Regex>) -> bool {
     let Some(re) = name_re else { return true };
     path.file_name()
-        .map(|n| re.is_match(&n.to_string_lossy()))
-        .unwrap_or(false)
+        .is_some_and(|n| re.is_match(&n.to_string_lossy()))
 }
 
 /// Compiles a `*`/`?` glob into an anchored regex over the whole file name;

--- a/silkd/src/session.rs
+++ b/silkd/src/session.rs
@@ -6,7 +6,6 @@
 //! pipe deadlock, which is the conventional interactive-shell behaviour.
 
 use std::collections::HashMap;
-use std::fmt::Write as _;
 use std::io;
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
@@ -83,10 +82,16 @@ impl Table {
         // real command reads a clean stream.
         let mut init = String::from("exec 2>&1\n");
         if let Some(dir) = cwd {
-            let _ = writeln!(init, "cd {} || exit 1", shell_quote(&dir));
+            init.push_str("cd ");
+            shell_quote_into(&mut init, &dir);
+            init.push_str(" || exit 1\n");
         }
         for (k, v) in env {
-            let _ = writeln!(init, "export {}={}", k, shell_quote(v));
+            init.push_str("export ");
+            init.push_str(k);
+            init.push('=');
+            shell_quote_into(&mut init, v);
+            init.push('\n');
         }
         {
             let mut io = session.io.lock().await;
@@ -169,11 +174,13 @@ impl Session {
     /// Returns whether the session shell is still alive; a dead shell is
     /// removed by the caller so its id stops resolving.
     pub async fn run<W: AsyncWrite + Unpin>(&self, argv: &[String], w: &mut W) -> bool {
-        let cmdline = argv
-            .iter()
-            .map(|a| shell_quote(a))
-            .collect::<Vec<_>>()
-            .join(" ");
+        let mut cmdline = String::new();
+        for (i, a) in argv.iter().enumerate() {
+            if i > 0 {
+                cmdline.push(' ');
+            }
+            shell_quote_into(&mut cmdline, a);
+        }
         let mut io = self.io.lock().await;
         let outcome = io.converse(&cmdline, Some(w)).await;
         // Stamp while io is still held: the reaper skips a session whose io lock
@@ -305,10 +312,9 @@ fn take_pipe<T>(pipe: Option<T>, name: &str) -> io::Result<T> {
     pipe.ok_or_else(|| io::Error::other(format!("child {name} not piped")))
 }
 
-/// POSIX single-quote quoting: wrap in '…', closing/reopening around any
-/// embedded single quote.
-fn shell_quote(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 2);
+/// POSIX single-quote quoting: wraps `s` in '…' onto the end of `out`,
+/// closing/reopening around any embedded single quote.
+fn shell_quote_into(out: &mut String, s: &str) {
     out.push('\'');
     for c in s.chars() {
         if c == '\'' {
@@ -318,5 +324,24 @@ fn shell_quote(s: &str) -> String {
         }
     }
     out.push('\'');
-    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shell_quote_into_pins_exact_output() {
+        let cases = [
+            ("plain", "'plain'"),
+            ("a b", "'a b'"),
+            ("it's", "'it'\\''s'"),
+            ("", "''"),
+        ];
+        for (input, want) in cases {
+            let mut out = String::new();
+            shell_quote_into(&mut out, input);
+            assert_eq!(out, want, "quoting {input:?}");
+        }
+    }
 }


### PR DESCRIPTION
Language-idiom round across the Go and Rust trees. Scan provenance: the
standalone `modernize` tool (all 23 analyzers) reports zero findings on every
module and clippy already denies `unwrap_used` — this round only carries what
those gates structurally cannot see. Production behavior is unchanged.

## silkd (Rust)

- `shell_quote` → `shell_quote_into`: session command lines are built in one
  buffer instead of N quoted temporaries + a `Vec` + `join` per exec; the
  `Table::create` cd/export init lines fold the same way. Quoting output is
  byte-identical, now pinned by a unit case table (plain, space, embedded
  quote, empty).
- `find.rs`: the one remaining `.map(...).unwrap_or(false)` becomes
  `is_some_and`, matching the file's existing idiom.
- Gate: `cargo fmt --check`, `clippy --all-targets`, and the full test suite
  (17 lib + 78 integration tests) run clean on Linux (rust 1.97.1 container on
  the testbed; cargo is unavailable on the dev host).

## sandboxd (Go)

- `main.go`: the shutdown-drain goroutine becomes `context.AfterFunc`,
  matching the preview-server shutdown a few lines above. Drained-channel
  semantics preserved.
- `pool` tests: 40 of the 43 timing-dependent tests now run under
  `testing/synctest` (stable since Go 1.25), so their 5ms–3s polling loops
  resolve on the bubble's virtual clock — deterministic timing, no more
  CI-tail latency on the 2–3s worst-case loops (0.00s under isolation;
  whole-package wall clock ~2.9s→1.9s). The three exceptions deliberately
  stall a goroutine while holding a real `sync.Mutex`, which synctest never
  treats as durably blocked (the bubble would deadlock); each carries a WHY
  comment with that root cause. `egress_test.go` is untouched — it arms real
  Unix-socket listeners.

## Considered and rejected (recorded so the next scan doesn't re-walk them)

- `os.Root` for data_dir/store/marker paths: every join is either pinned by
  an ID regex at the API boundary or an operator-configured path — ceremony,
  not safety.
- `unique.Make` interning of pool keys/tenants: Go string assignment doesn't
  copy backing bytes; the intern table would add lock indirection to the
  warm-claim path for nothing.
- boot/init micro-allocations (trim/format churn in 2ms poll loops):
  sleep-dominated by three orders of magnitude.
- mesh candidate iterators: placement jitter needs random index access; the
  materialized slices stay.

## Gates

- Go: build, `-race` across all 14 packages, dual-GOOS golangci-lint
  (cache-cleaned) 0 issues, gofmt/gofumpt/goimports clean, asl dual-GOOS zero
  findings.
- Rust: Linux container gate as above; `boot/init` untouched.
- Hot paths untouched: no production change lands on the warm-claim or wire
  data path; the silkd change trims allocations on the exec verb only.
