### PR TITLE
silkd: classify a missing fs.pull source as NotFound

### DIFF
--- a/silkd/src/tree.rs
+++ b/silkd/src/tree.rs
@@ -52,6 +52,11 @@ pub async fn pull<W: AsyncWrite + Unpin>(w: &mut W, path: String) -> io::Result<
         (Some(par), Some(n)) if !n.is_empty() => (par.to_path_buf(), n.to_os_string()),
         _ => return proto::error_frame(w, ErrorKind::BadRequest, "invalid path").await,
     };
+    // symlink_metadata, not metadata: a dangling symlink is a valid tar source
+    // (tar archives the link itself), and following it would wrongly 404 it.
+    if let Err(e) = tokio::fs::symlink_metadata(p).await {
+        return err_frame(w, &e, "stat source").await;
+    }
     let cwd = if parent.as_os_str().is_empty() {
         Path::new(".").to_path_buf()
     } else {

--- a/silkd/tests/tree_e2e.rs
+++ b/silkd/tests/tree_e2e.rs
@@ -139,8 +139,58 @@ async fn push_bad_archive_reports_tar_failure() {
 
 #[tokio::test]
 async fn pull_missing_path_errors() {
+    // Parent exists; the leaf itself is missing.
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("xyz");
+    let frames =
+        exchange(&[json!({"op":"fs_pull","path":missing.to_str().unwrap()}).to_string()]).await;
+    assert_eq!(
+        type_of(frames.last().unwrap()),
+        "error",
+        "missing leaf: {frames:?}"
+    );
+    assert_eq!(frames.last().unwrap()["kind"], "not_found");
+}
+
+#[tokio::test]
+async fn pull_missing_parent_errors_not_found() {
     let frames = exchange(&[json!({"op":"fs_pull","path":"/no/such/dir/xyz"}).to_string()]).await;
-    assert_eq!(type_of(frames.last().unwrap()), "error");
+    assert_eq!(
+        type_of(frames.last().unwrap()),
+        "error",
+        "missing parent: {frames:?}"
+    );
+    assert_eq!(frames.last().unwrap()["kind"], "not_found");
+}
+
+#[tokio::test]
+async fn pull_dangling_symlink_archives_the_link() {
+    use std::os::unix::fs::symlink;
+    let src = tempfile::tempdir().unwrap();
+    let link = src.path().join("dangling");
+    symlink("/no/such/target", &link).unwrap();
+
+    let frames =
+        exchange(&[json!({"op":"fs_pull","path":link.to_str().unwrap()}).to_string()]).await;
+    assert_eq!(
+        type_of(frames.last().unwrap()),
+        "done",
+        "pull of a dangling symlink must succeed: {frames:?}"
+    );
+    let archive = payload(&frames, "data");
+
+    let out = tempfile::tempdir().unwrap();
+    sys_tar_extract(&archive, out.path());
+    let extracted = out.path().join("dangling");
+    let meta = std::fs::symlink_metadata(&extracted).unwrap();
+    assert!(
+        meta.file_type().is_symlink(),
+        "archive must carry the link itself, not its (missing) target"
+    );
+    assert_eq!(
+        std::fs::read_link(&extracted).unwrap(),
+        Path::new("/no/such/target")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #74.

A pull of a nonexistent path died inside `tar -c` and was mapped to a
generic Internal error by the subprocess handler, so SDK callers could not
tell a missing workspace path from a real failure — the only fs verb with
that gap. `pull()` now pre-flights the source with `symlink_metadata`
(not `metadata`: a dangling symlink is a valid tar source — the link
itself gets archived) and routes the error through the shared
`err_frame` classifier. tar remains the authority for every other
failure; the stderr→Internal mapping is untouched.

Wire and SDKs need no change: `KindNotFound` already flows generically
(the volume sysfs discovery branches on it today), verified by reading
`sdk/go/tree.go` and `protocol/wire/frame.go`. No fixture pins the old
classification.

Tests: `tree_e2e` 8→10 — missing leaf → not_found, missing parent →
not_found, dangling symlink → archived as a link (extracted and verified
with `read_link`).

Gates (Linux container, rust 1.97.1, bare-metal testbed): `cargo fmt
--check` clean, `clippy --all-targets` zero warnings, full suite green —
17 lib + 80 integration tests including the three new cases; the rest of
the suite unchanged.