### PR TITLE
pool: bring a claim's volumes up concurrently

### DIFF
--- a/sandboxd/pool/pool_test.go
+++ b/sandboxd/pool/pool_test.go
@@ -809,6 +809,7 @@ type fakeEngine struct {
 	staleReconciles                   []string // VM names ReconcileStaleCreate was called on
 	installCAErr                      error
 	diskAttachErr                     error
+	diskAttachErrFor                  string // volume name whose DiskAttach fails; "" = never
 	diskAttachCancel                  context.CancelFunc
 	mountVolumeErr                    error
 	unmountVolumeErr                  error
@@ -825,6 +826,8 @@ type fakeEngine struct {
 	hibernateErrCompletes                                                              bool   // hibernateErr fires after the snapshot lands (CLI timeout)
 	tap                                                                                string // non-empty: lifecycle records carry this NIC tap
 	listCount                                                                          int
+
+	attachRendezvous *sync.WaitGroup // non-nil: DiskAttach waits there until every attach has arrived
 
 	cloneStall      chan struct{} // non-nil: Clone blocks until closed
 	probeStall      chan struct{} // non-nil: Probe blocks until closed
@@ -1043,14 +1046,22 @@ func (f *fakeEngine) InstallCACert(_ context.Context, vsockSocket string, _ []by
 
 func (f *fakeEngine) DiskAttach(_ context.Context, _ string, spec engine.VolumeSpec) error {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.volumeSpecs = append(f.volumeSpecs, spec)
 	f.volumeOps = append(f.volumeOps, "attach:"+spec.Name)
 	f.attachDirty[spec.Name] = volumeDirty(spec.Path)
-	if f.diskAttachCancel != nil {
-		f.diskAttachCancel()
+	cancel, rendezvous, err := f.diskAttachCancel, f.attachRendezvous, f.diskAttachErr
+	if spec.Name == f.diskAttachErrFor {
+		err = errors.New("attach failed")
 	}
-	return f.diskAttachErr
+	f.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if rendezvous != nil {
+		rendezvous.Done()
+		rendezvous.Wait()
+	}
+	return err
 }
 
 func (f *fakeEngine) MountVolume(_ context.Context, _, name, mount string, rw bool) error {

--- a/sandboxd/pool/volume.go
+++ b/sandboxd/pool/volume.go
@@ -178,10 +178,9 @@ func (m *Manager) confirmVolumesClean(volumes []resolvedVolume) error {
 	return nil
 }
 
-// applyVolumes brings the resolved set up, a goroutine per volume past the
-// first: cocoon serializes the attach itself, so what overlaps is the CLI
-// spawn, the device settle wait and the guest mount. applied is that same set
-// in request shape, recorded on the sandbox only once every mount is up.
+// applyVolumes brings the resolved set up concurrently: cocoon serializes the
+// attach per VM, so what overlaps is the CLI spawns, settle waits and guest
+// mounts. applied is the request-shaped set, recorded once every mount is up.
 func (m *Manager) applyVolumes(ctx context.Context, sb *types.Sandbox, volumes []resolvedVolume, applied []types.Volume) error {
 	switch len(volumes) {
 	case 0:

--- a/sandboxd/pool/volume.go
+++ b/sandboxd/pool/volume.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/projecteru2/core/log"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/cocoonstack/sandbox/sandboxd/engine"
 	"github.com/cocoonstack/sandbox/sandboxd/types"
@@ -177,27 +178,45 @@ func (m *Manager) confirmVolumesClean(volumes []resolvedVolume) error {
 	return nil
 }
 
-// applyVolumes attaches and mounts the resolved set; applied is that same set
+// applyVolumes brings the resolved set up, a goroutine per volume past the
+// first: cocoon serializes the attach itself, so what overlaps is the CLI
+// spawn, the device settle wait and the guest mount. applied is that same set
 // in request shape, recorded on the sandbox only once every mount is up.
 func (m *Manager) applyVolumes(ctx context.Context, sb *types.Sandbox, volumes []resolvedVolume, applied []types.Volume) error {
-	if len(volumes) == 0 {
+	switch len(volumes) {
+	case 0:
 		return nil
-	}
-	for _, volume := range volumes {
-		// Write-ahead: the marker must be durable before any guest write can be.
-		if volume.disk.RW {
-			if err := markVolumeDirty(volume.disk.Path); err != nil {
-				return fmt.Errorf("mark volume %q dirty: %w", volume.applied.Name, err)
-			}
+	case 1:
+		if err := m.applyVolume(ctx, sb, volumes[0]); err != nil {
+			return err
 		}
-		if err := m.eng.DiskAttach(ctx, sb.VMName, volume.disk); err != nil {
-			return fmt.Errorf("attach volume %q: %w", volume.applied.Name, err)
+	default:
+		group, groupCtx := errgroup.WithContext(ctx)
+		for _, volume := range volumes {
+			group.Go(func() error { return m.applyVolume(groupCtx, sb, volume) })
 		}
-		if err := m.eng.MountVolume(ctx, sb.VsockSocket, volume.applied.Name, volume.applied.Mount, volume.disk.RW); err != nil {
-			return fmt.Errorf("setup volume %q: %w", volume.applied.Name, err)
+		if err := group.Wait(); err != nil {
+			return err
 		}
 	}
 	sb.Volumes = applied
+	return nil
+}
+
+// applyVolume keeps one volume's steps strictly ordered; siblings overlap freely.
+func (m *Manager) applyVolume(ctx context.Context, sb *types.Sandbox, volume resolvedVolume) error {
+	// Write-ahead: the marker must be durable before any guest write can be.
+	if volume.disk.RW {
+		if err := markVolumeDirty(volume.disk.Path); err != nil {
+			return fmt.Errorf("mark volume %q dirty: %w", volume.applied.Name, err)
+		}
+	}
+	if err := m.eng.DiskAttach(ctx, sb.VMName, volume.disk); err != nil {
+		return fmt.Errorf("attach volume %q: %w", volume.applied.Name, err)
+	}
+	if err := m.eng.MountVolume(ctx, sb.VsockSocket, volume.applied.Name, volume.applied.Mount, volume.disk.RW); err != nil {
+		return fmt.Errorf("setup volume %q: %w", volume.applied.Name, err)
+	}
 	return nil
 }
 

--- a/sandboxd/pool/volume_test.go
+++ b/sandboxd/pool/volume_test.go
@@ -8,13 +8,15 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/cocoonstack/sandbox/sandboxd/config"
+	"github.com/cocoonstack/sandbox/sandboxd/engine"
 	"github.com/cocoonstack/sandbox/sandboxd/types"
 )
 
-func TestClaimProvisionAppliesVolumesInOrder(t *testing.T) {
+func TestClaimProvisionAppliesVolumesInRequestOrder(t *testing.T) {
 	first := writeVolumeImage(t, "imagenet.img", "first")
 	second := writeVolumeImage(t, "weights.img", "second")
 	eng := newFakeEngine()
@@ -35,19 +37,20 @@ func TestClaimProvisionAppliesVolumesInOrder(t *testing.T) {
 	if !slices.Equal(sb.Volumes, wantApplied) {
 		t.Errorf("volumes=%v, want %v", sb.Volumes, wantApplied)
 	}
-	wantOps := []string{
-		"provision", "probe",
-		"attach:weights", "mount:weights:/models",
-		"attach:imagenet", "mount:imagenet:/volumes/imagenet",
+	wantLead := []string{"provision", "probe"}
+	if ops := eng.volumeOpsLog(); len(ops) < len(wantLead) || !slices.Equal(ops[:len(wantLead)], wantLead) {
+		t.Errorf("operations=%v, want %v ahead of every volume op", ops, wantLead)
 	}
-	if !slices.Equal(eng.volumeOps, wantOps) {
-		t.Errorf("operations=%v, want %v", eng.volumeOps, wantOps)
+	assertVolumeBringUp(t, eng, wantApplied)
+	wantSpecs := []engine.VolumeSpec{
+		{Name: "imagenet", Path: first, DirectIO: "off"},
+		{Name: "weights", Path: second, DirectIO: "on"},
 	}
-	if !slices.Equal(eng.volumeMounts, wantApplied) {
-		t.Errorf("mounts=%v, want %v", eng.volumeMounts, wantApplied)
-	}
-	if got := eng.volumeSpecs; len(got) != 2 || got[0].Path != second || got[0].DirectIO != "on" || got[1].Path != first {
-		t.Errorf("attached specs=%+v", got)
+	specs := slices.SortedFunc(slices.Values(eng.volumeSpecs), func(a, b engine.VolumeSpec) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	if !slices.Equal(specs, wantSpecs) {
+		t.Errorf("attached specs=%+v, want %+v", specs, wantSpecs)
 	}
 	persisted, err := newClaimStore(m.dataDir).load()
 	if err != nil {
@@ -67,6 +70,90 @@ func TestClaimProvisionAppliesVolumesInOrder(t *testing.T) {
 		if string(got) != want {
 			t.Errorf("backing image %s=%q, want %q", path, got, want)
 		}
+	}
+}
+
+func TestClaimProvisionBringsMixedVolumesUpConcurrently(t *testing.T) {
+	dataset := writeVolumeImage(t, "dataset.img", "dataset")
+	weights := writeVolumeImage(t, "weights.img", "weights")
+	scratch := writeVolumeImage(t, "scratch.img", "scratch")
+	cache := writeVolumeImage(t, "cache.img", "cache")
+	eng := newFakeEngine()
+	m := newVolumeManager(t, eng, []config.VolumeSpec{
+		{Name: "dataset", Path: dataset},
+		{Name: "weights", Path: weights},
+		{Name: "scratch", Path: scratch, Writable: true},
+		{Name: "cache", Path: cache, Writable: true},
+	})
+	requested := []types.Volume{
+		{Name: "weights", Mount: "/models"},
+		{Name: "scratch", Mode: types.VolumeModeRW},
+		{Name: "dataset"},
+		{Name: "cache", Mount: "/cache", Mode: types.VolumeModeRW},
+	}
+	wantApplied := []types.Volume{
+		{Name: "weights", Mount: "/models"},
+		{Name: "scratch", Mount: "/volumes/scratch", Mode: types.VolumeModeRW},
+		{Name: "dataset", Mount: "/volumes/dataset"},
+		{Name: "cache", Mount: "/cache", Mode: types.VolumeModeRW},
+	}
+	// Every attach must be in flight at once: a sequential apply blocks here.
+	var attaches sync.WaitGroup
+	attaches.Add(len(requested))
+	eng.attachRendezvous = &attaches
+
+	sb, err := m.ClaimProvision(t.Context(), testKey, 0, "", "", requested)
+	if err != nil {
+		t.Fatalf("ClaimProvision: %v", err)
+	}
+	if !slices.Equal(sb.Volumes, wantApplied) {
+		t.Errorf("volumes=%v, want the request order %v", sb.Volumes, wantApplied)
+	}
+	assertVolumeBringUp(t, eng, wantApplied)
+	if !volumeDirty(scratch) || !volumeDirty(cache) {
+		t.Error("live writable claim left an image unmarked")
+	}
+	if volumeDirty(dataset) || volumeDirty(weights) {
+		t.Error("read-only volume of a mixed claim was marked dirty")
+	}
+}
+
+func TestClaimProvisionOneVolumeAttachFailureFailsWholeClaim(t *testing.T) {
+	first := writeVolumeImage(t, "first.img", "first")
+	broken := writeVolumeImage(t, "broken.img", "broken")
+	third := writeVolumeImage(t, "third.img", "third")
+	eng := newFakeEngine()
+	eng.diskAttachErrFor = "broken"
+	m := newVolumeManager(t, eng, []config.VolumeSpec{
+		{Name: "first", Path: first, Writable: true},
+		{Name: "broken", Path: broken, Writable: true},
+		{Name: "third", Path: third},
+	})
+
+	_, err := m.ClaimProvision(t.Context(), testKey, 0, "", "", []types.Volume{
+		{Name: "first", Mode: types.VolumeModeRW},
+		{Name: "broken", Mode: types.VolumeModeRW},
+		{Name: "third"},
+	})
+	if err == nil || !strings.Contains(err.Error(), `attach volume "broken"`) {
+		t.Fatalf("ClaimProvision: %v, want the failing volume's attach error", err)
+	}
+	if len(eng.removes) != 1 {
+		t.Errorf("removes=%v, want the failed VM destroyed", eng.removes)
+	}
+	if !volumeDirty(first) || !volumeDirty(broken) {
+		t.Error("failed claim cleared a writable marker, opening an image no writer flushed")
+	}
+	if volumeDirty(third) {
+		t.Error("read-only volume was marked dirty")
+	}
+	for _, name := range []string{"first", "broken", "third"} {
+		if holders := volumeHoldersOf(m, name); holders != (volumeHolders{}) {
+			t.Errorf("registry for %s after the failure=%+v, want empty", name, holders)
+		}
+	}
+	if _, gauges := m.Info(); gauges.Claimed != 0 {
+		t.Errorf("claimed=%d, want 0", gauges.Claimed)
 	}
 }
 
@@ -397,6 +484,37 @@ func TestClaimProvisionRejectsMissingVolumePathBeforeProvision(t *testing.T) {
 	}
 	if len(eng.colds)+len(eng.clones) != 0 {
 		t.Errorf("provisioned colds=%v clones=%v", eng.colds, eng.clones)
+	}
+}
+
+// assertVolumeBringUp pins each volume's own marker→attach→mount order and the
+// completeness of the set; cross-volume order is free — they come up together.
+func assertVolumeBringUp(t *testing.T, eng *fakeEngine, applied []types.Volume) {
+	t.Helper()
+	ops := eng.volumeOpsLog()
+	brought := 0
+	for _, op := range ops {
+		if strings.HasPrefix(op, "attach:") || strings.HasPrefix(op, "mount:") {
+			brought++
+		}
+	}
+	if brought != 2*len(applied) {
+		t.Errorf("bring-up ops=%v, want one attach and one mount per volume of %v", ops, applied)
+	}
+	for _, volume := range applied {
+		attach := slices.Index(ops, "attach:"+volume.Name)
+		mount := slices.Index(ops, "mount:"+volume.Name+":"+volume.Mount)
+		if attach < 0 || mount < attach {
+			t.Errorf("volume %s: attach=%d mount=%d in %v, want the attach first", volume.Name, attach, mount, ops)
+		}
+		if volume.RW() && !eng.dirtyAtAttach(volume.Name) {
+			t.Errorf("volume %s attached before its dirty marker was durable", volume.Name)
+		}
+	}
+	byName := func(a, b types.Volume) int { return strings.Compare(a.Name, b.Name) }
+	mounts := slices.SortedFunc(slices.Values(eng.volumeMounts), byName)
+	if want := slices.SortedFunc(slices.Values(applied), byName); !slices.Equal(mounts, want) {
+		t.Errorf("mounts=%v, want %v", mounts, want)
 	}
 }
 

--- a/sandboxd/pool/volume_test.go
+++ b/sandboxd/pool/volume_test.go
@@ -488,7 +488,7 @@ func TestClaimProvisionRejectsMissingVolumePathBeforeProvision(t *testing.T) {
 }
 
 // assertVolumeBringUp pins each volume's own marker→attach→mount order and the
-// completeness of the set; cross-volume order is free — they come up together.
+// completeness of the set; cross-volume order is free.
 func assertVolumeBringUp(t *testing.T, eng *fakeEngine, applied []types.Volume) {
 	t.Helper()
 	ops := eng.volumeOpsLog()


### PR DESCRIPTION
Multi-volume claims paid a strictly sequential attach+settle+mount per
volume (~60-90ms marginal each, measured on bare metal in the #72 round).
The per-volume pipeline — write-ahead marker (rw), disk attach, sysfs
settle, guest mount — now runs concurrently across a claim's volumes via
errgroup; cocoon serializes the hypervisor attach per VM internally, so
what overlaps is the CLI subprocess spawns, the 5-10ms device settle
waits, and the guest mount execs.

- Volume-less and single-volume claims are untouched (0 → early return,
  1 → inline, no goroutine).
- The response echo and persisted entries keep request order; per-volume
  ordering (marker strictly before attach before mount) is unchanged.
- Failure keeps fail-fast semantics: first error cancels the group, the
  claim fails, the VM is destroyed, holds release through the existing
  defer. One deliberate delta, pinned by test: a failed multi-rw claim
  now leaves every rw image marked (all markers are written up front),
  not just those before the failure point — the conservative direction
  of the block-don't-heal contract.
- The concurrency pin has teeth: the new mixed 4-volume test gates every
  attach on a rendezvous that deadlocks under sequential apply (verified
  by temporarily reverting to a loop — the test times out — then
  restoring).

Gates: build, -race across the module (20x on the apply tests, no
flakes), dual-GOOS golangci-lint 0 issues, gofmt clean, asl dual-GOOS
zero findings. Bare-metal A/B for the multi-volume latency claim follows
as a comment.

**Hardware verdict (see the A/B comment for full data):** the win is gated on
guest vCPU count — the overlapped work is guest-CPU-bound. 1.00x on the
1-vCPU `small` tier, 1.33x at 2 vCPU, 1.70x (2.55x marginal per-volume) at
4 vCPU. Single-volume and release paths unchanged on every tier. The round
also surfaced pre-existing #78 (sysfs-vs-devtmpfs bring-up race), fixed
separately.
