### PR TITLE
test(python): pin all four enum sets, and the git_branch actions in use

### DIFF
--- a/sdk/python/tests/test_wire_binding.py
+++ b/sdk/python/tests/test_wire_binding.py
@@ -153,7 +153,48 @@ def test_call_site_matches_fixture(monkeypatch, stem, replies, invoke):
             assert value == fixture[key], f"field {key!r}: {value!r} != {fixture[key]!r}"
 
 
-def test_enum_error_kinds_match_corpus():
+def test_enum_value_sets_match_corpus():
     enums = json.loads((FIXTURES / "enums.json").read_text())
     assert set(enums["error_kind"]) == {"bad_request", "not_found", "unimplemented", "internal"}
     assert set(enums["event_kind"]) == {"created", "modified", "deleted", "renamed"}
+    assert set(enums["file_kind"]) == {"file", "dir", "symlink", "other"}
+    assert set(enums["git_branch_action"]) == {"list", "create", "delete", "checkout"}
+
+
+class BranchActionConn:
+    """Records the action each git_branch verb puts on the wire."""
+
+    def __init__(self, sent):
+        self.sent = sent
+        self.action = ""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        pass
+
+    def send(self, op, **fields):
+        self.action = fields.get("action")
+        self.sent.append(self.action)
+
+    def recv(self):
+        if self.action == "list":
+            return {"type": "git_branches", "branches": [], "current": ""}
+        return {"type": "done"}
+
+    def recv_until(self, *terminal):
+        yield self.recv()
+
+
+def test_git_branch_actions_come_from_the_corpus(monkeypatch):
+    enums = json.loads((FIXTURES / "enums.json").read_text())
+    sb = Sandbox(client=Client("127.0.0.1:1"), id="sb_1", token="tok", owner="127.0.0.1:1")
+    sent = []
+    monkeypatch.setattr(sb, "_dial", lambda: BranchActionConn(sent))
+
+    sb.git_branches("/w")
+    sb.git_create_branch("/w", "b")
+    sb.git_delete_branch("/w", "b")
+    sb.git_checkout("/w", "b")
+    assert set(sent) == set(enums["git_branch_action"])


### PR DESCRIPTION
Stacked on #81. Closes the Python half of a wire-corpus drift gap; the Rust half (Response encode paths are never fixture-verified) is left for its own change.

## The gap

`protocol/wire/fixtures/v1/enums.json` is the shared anti-drift corpus. Go (`TestEnumValueSetsMatchFixture`) and Rust (`enum_value_sets_match_fixture`) both pin **all four** sets. Python pinned **two**: `error_kind` and `event_kind`.

Of the two missing, `git_branch_action` is load-bearing — `sandbox.py:191,194,197,200` hardcodes `"list"`, `"checkout"`, `"create"`, `"delete"` straight into the request. A rename on the silkd side would have reached users as a runtime rejection with nothing in the suite failing first.

## What is added

- `test_enum_value_sets_match_corpus` now covers `file_kind` and `git_branch_action` alongside the existing two.
- `test_git_branch_actions_come_from_the_corpus` drives the four real verbs through a recording conn and asserts the actions they emit are exactly the corpus set — so the literals stay tied to the contract, not just the constant list.

## Validation

- `pytest` 152 passed, `ruff check` clean
- mutation-tested: renaming `action="checkout"` to `"switch"` in `sandbox.py` fails the new test