### PR TITLE
egress: a promoted-template claim takes the tenant policy alone

### DIFF
--- a/docs/egress.md
+++ b/docs/egress.md
@@ -102,7 +102,9 @@ A missing policy on either side is an empty allow-list, not a pass: a tenant
 without its own `egress` block reaches nothing — upgrading, a tenant that
 relied on inheriting its pool's policy must now declare one — so granting a tenant egress —
 and the secret injection that rides it — is always an explicit act. Root
-claims have no tenant layer and take the pool's policy whole. Secrets are
+claims have no tenant layer and take the pool's policy whole; a promoted
+template has no pool layer, so a tenant's claim of one takes the tenant's
+policy alone (a root claim of a promoted template stays denied). Secrets are
 registered separately and referenced by name — the value comes from the
 environment, never the config file.
 

--- a/sandboxd/pool/egress.go
+++ b/sandboxd/pool/egress.go
@@ -183,18 +183,22 @@ func (m *Manager) poolIntercepts(key types.PoolKey) bool {
 	return m.poolEgress[key].Intercepts()
 }
 
-// effectivePolicy resolves pool ∩ tenant; root has no tenant layer.
+// effectivePolicy resolves pool ∩ tenant; root has no tenant layer, and a
+// promoted template — a key no pool is configured for — has no pool layer.
 func (m *Manager) effectivePolicy(sb *types.Sandbox) (egress.Evaluator, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	poolPol := m.poolEgress[sb.Key]
+	tenantPol := m.tenantEgress[sb.Tenant]
 	if poolPol == nil {
-		return nil, false
+		if m.pools[sb.Key] != nil || sb.Tenant == "" || tenantPol == nil {
+			return nil, false
+		}
+		return *tenantPol, true
 	}
 	if sb.Tenant == "" {
 		return *poolPol, true
 	}
-	tenantPol := m.tenantEgress[sb.Tenant]
 	if tenantPol == nil {
 		return nil, false
 	}

--- a/sandboxd/pool/egress_test.go
+++ b/sandboxd/pool/egress_test.go
@@ -140,19 +140,26 @@ func TestEffectivePolicyComposition(t *testing.T) {
 	cases := []struct {
 		name        string
 		tenant      string
+		pooled      bool
 		pool, tnPol *egress.Policy
 		allow, deny string
 		wantArmed   bool
 	}{
-		{"root takes the pool policy whole", "", both, nil, "a.test", "z.test", true},
-		{"root without a pool policy", "", nil, nil, "", "", false},
-		{"tenant intersects", "acme", both, tenantOnly, "b.test", "a.test", true}, // a.test allowed by pool, denied by tenant
-		{"tenant declaring no policy", "acme", both, nil, "", "", false},
-		{"tenant on a policyless pool", "acme", nil, tenantOnly, "", "", false},
-		{"neither", "acme", nil, nil, "", "", false},
+		{"root takes the pool policy whole", "", true, both, nil, "a.test", "z.test", true},
+		{"root without a pool policy", "", true, nil, nil, "", "", false},
+		{"tenant intersects", "acme", true, both, tenantOnly, "b.test", "a.test", true}, // a.test allowed by pool, denied by tenant
+		{"tenant declaring no policy", "acme", true, both, nil, "", "", false},
+		{"tenant on a policyless pool", "acme", true, nil, tenantOnly, "", "", false},
+		{"tenant on a promoted template", "acme", false, nil, tenantOnly, "b.test", "a.test", true},
+		{"root on a promoted template", "", false, nil, nil, "", "", false},
+		{"neither", "acme", false, nil, nil, "", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			m.pools = map[types.PoolKey]*pool{}
+			if tc.pooled {
+				m.pools[testKey] = &pool{key: testKey}
+			}
 			m.poolEgress = map[types.PoolKey]*egress.Policy{}
 			if tc.pool != nil {
 				m.poolEgress[testKey] = tc.pool


### PR DESCRIPTION
Fixes #98.

## What

Since #81, `pool.effectivePolicy` returns no evaluator unless a pool policy exists for the claim's key. A promoted template never has one — `Promote`/`DeleteTemplate` refuse keys a configured pool owns (`pooledHash`), and the refill loop would `buildGolden` a template name that is not an image — so every promoted-template claim was default-deny regardless of the tenant's `egress` block, and the none lane's only route out was closed for on-demand claims (a bake warmup through the guest's `127.0.0.1:3128` relay failed 45/45 on v0.1.6 and passed 45/45 on 218eee1 with the same config).

This keeps #81's contract for pooled keys and treats a *missing* pool layer as absent rather than empty:

- key with a configured pool: unchanged — pool ∩ tenant; a pool without a policy grants nothing; root takes the pool policy whole.
- key with no configured pool (a promoted template, or an image cold-booted on demand — the repro's `rt:24.04` claim on a node without `pools` is the latter): a tenant claim takes the tenant policy alone; a root claim stays denied (no layer at all).

`m.pools[key]` is the discriminator, so a pool configured with `warm: 0` and no `egress` still denies exactly as #81 intended. Residual, accepted: `m.pools` is API-mutable, so draining a policy-less pool via `SetPools` turns its key unpooled and a later tenant cold-boot claim of it takes the tenant policy — no secret is involved (a policy-less pool has none), it takes an operator drain, and the guest gets only the tenant's own allow-list.

## Changes

- `sandboxd/pool/egress.go` `effectivePolicy`.
- `sandboxd/pool/egress_test.go` `TestEffectivePolicyComposition`: cases now say whether the key is pooled; adds "tenant on a promoted template" (armed with the tenant policy) and "root on a promoted template" (denied); "tenant on a policyless pool" keeps expecting deny.
- `docs/egress.md`: the promoted-template rule next to the intersection rule.

## Gates

`go build ./...`, `go test ./...` (sandboxd), `make go-lint` (golangci-lint run + fmt, GOOS linux+darwin) all clean.
