### PR TITLE
fix: release idle upstream conns on egress Close; skip unreadable subdirs in fs.find

### DIFF
--- a/sandboxd/egress/proxy.go
+++ b/sandboxd/egress/proxy.go
@@ -12,9 +12,12 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/cocoonstack/sandbox/sandboxd/utils"
 )
+
+const idleConnTimeout = 90 * time.Second
 
 // hopHeaders are hop-by-hop and proxy-scoped headers this hop owns: stripped
 // from forwarded requests and from relayed responses rather than passed on.
@@ -85,7 +88,7 @@ func New(sandbox, tenant string, policy Evaluator, secrets Secrets, ca *CA, dial
 		dial:    dial,
 		// The stdlib default of 2 idle conns per host re-dials bursty
 		// same-host plaintext traffic.
-		tr:    &http.Transport{DialContext: dial, MaxIdleConnsPerHost: 8},
+		tr:    &http.Transport{DialContext: dial, MaxIdleConnsPerHost: 8, IdleConnTimeout: idleConnTimeout},
 		conns: map[net.Conn]struct{}{},
 	}
 	if ca != nil {
@@ -93,6 +96,7 @@ func New(sandbox, tenant string, policy Evaluator, secrets Secrets, ca *CA, dial
 			DialContext:         dial,
 			TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS12},
 			MaxIdleConnsPerHost: 8,
+			IdleConnTimeout:     idleConnTimeout,
 		}
 		p.leaves = map[string]*tls.Certificate{}
 	}
@@ -117,6 +121,10 @@ func (p *Proxy) Close() {
 	p.connMu.Unlock()
 	for _, conn := range conns {
 		_ = conn.Close()
+	}
+	p.tr.CloseIdleConnections()
+	if p.mitmTr != nil {
+		p.mitmTr.CloseIdleConnections()
 	}
 }
 

--- a/sandboxd/egress/proxy.go
+++ b/sandboxd/egress/proxy.go
@@ -92,12 +92,8 @@ func New(sandbox, tenant string, policy Evaluator, secrets Secrets, ca *CA, dial
 		conns: map[net.Conn]struct{}{},
 	}
 	if ca != nil {
-		p.mitmTr = &http.Transport{
-			DialContext:         dial,
-			TLSClientConfig:     &tls.Config{MinVersion: tls.VersionTLS12},
-			MaxIdleConnsPerHost: 8,
-			IdleConnTimeout:     idleConnTimeout,
-		}
+		p.mitmTr = p.tr.Clone()
+		p.mitmTr.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
 		p.leaves = map[string]*tls.Certificate{}
 	}
 	return p

--- a/sandboxd/egress/proxy_test.go
+++ b/sandboxd/egress/proxy_test.go
@@ -52,6 +52,43 @@ func TestForwardAllowInjectsSecretAndOverwritesGuestHeader(t *testing.T) {
 	}
 }
 
+func TestCloseReleasesIdleUpstreamConns(t *testing.T) {
+	closed := make(chan struct{}, 4)
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "hello")
+	}))
+	upstream.Config.ConnState = func(_ net.Conn, st http.ConnState) {
+		if st == http.StateClosed {
+			closed <- struct{}{}
+		}
+	}
+	upstream.Start()
+	defer upstream.Close()
+
+	policy := Policy{Allow: []Rule{{Host: "api.internal"}}}
+	p := New("sb_1", "acme", policy, nil, nil, fixedDial(upstream.Listener.Addr().String()), nil)
+	front := httptest.NewServer(p)
+	defer front.Close()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://api.internal/x", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := proxyClient(t, front.URL).Do(req)
+	if err != nil {
+		t.Fatalf("proxied GET: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	p.Close()
+	select {
+	case <-closed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upstream connection still open after Close")
+	}
+}
+
 func TestForwardNeverInjectsInterceptSecret(t *testing.T) {
 	reached := false
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/go/silkd/silkdtest/fake.go
+++ b/sdk/go/silkd/silkdtest/fake.go
@@ -287,9 +287,15 @@ func (f *Fake) fsFind(conn net.Conn, req *wire.FsFind) {
 	if req.Glob != "" {
 		nameRe = globRegexp(req.Glob)
 	}
-	walkErr := filepath.WalkDir(f.abs(req.Path), func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+	root := f.abs(req.Path)
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		switch {
+		case err != nil && path == root:
 			return err
+		case err != nil && d != nil && d.IsDir():
+			return fs.SkipDir
+		case err != nil || d.IsDir():
+			return nil
 		}
 		if nameRe != nil && !nameRe.MatchString(d.Name()) {
 			return nil

--- a/sdk/go/silkd/silkdtest/fake.go
+++ b/sdk/go/silkd/silkdtest/fake.go
@@ -289,12 +289,13 @@ func (f *Fake) fsFind(conn net.Conn, req *wire.FsFind) {
 	}
 	root := f.abs(req.Path)
 	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		switch {
-		case err != nil && path == root:
-			return err
-		case err != nil && d != nil && d.IsDir():
-			return fs.SkipDir
-		case err != nil || d.IsDir():
+		if err != nil {
+			if path == root {
+				return err
+			}
+			return nil
+		}
+		if d.IsDir() {
 			return nil
 		}
 		if nameRe != nil && !nameRe.MatchString(d.Name()) {

--- a/silkd/src/find.rs
+++ b/silkd/src/find.rs
@@ -32,17 +32,16 @@ pub async fn find<W: AsyncWrite + Unpin>(
         Some(Ok(re)) => Some(re),
         Some(Err(e)) => return proto::error_frame(w, ErrorKind::BadRequest, e.to_string()).await,
     };
-    let mut stack = vec![path];
-    while let Some(dir) = stack.pop() {
-        let mut rd = match fs::read_dir(&dir).await {
-            Ok(rd) => rd,
-            Err(e) => return err_frame(w, &e, "read_dir").await,
-        };
+    let mut rd = match fs::read_dir(&path).await {
+        Ok(rd) => rd,
+        Err(e) => return err_frame(w, &e, "read_dir").await,
+    };
+    let mut stack = Vec::new();
+    loop {
         loop {
             let ent = match rd.next_entry().await {
                 Ok(Some(ent)) => ent,
-                Ok(None) => break,
-                Err(e) => return err_frame(w, &e, "read_dir").await,
+                _ => break,
             };
             let Ok(ft) = ent.file_type().await else {
                 continue;
@@ -54,8 +53,15 @@ pub async fn find<W: AsyncWrite + Unpin>(
                 scan_file(w, &re, &p).await?;
             }
         }
+        rd = loop {
+            let Some(dir) = stack.pop() else {
+                return proto::write_frame(w, &Response::Done).await;
+            };
+            if let Ok(rd) = fs::read_dir(&dir).await {
+                break rd;
+            }
+        };
     }
-    proto::write_frame(w, &Response::Done).await
 }
 
 /// Rewrites every `pattern` match to `replacement` in each of `files`,

--- a/silkd/src/find.rs
+++ b/silkd/src/find.rs
@@ -36,12 +36,15 @@ pub async fn find<W: AsyncWrite + Unpin>(
         Ok(rd) => rd,
         Err(e) => return err_frame(w, &e, "read_dir").await,
     };
+    let mut root = true;
     let mut stack = Vec::new();
     loop {
         loop {
             let ent = match rd.next_entry().await {
                 Ok(Some(ent)) => ent,
-                _ => break,
+                Ok(None) => break,
+                Err(e) if root => return err_frame(w, &e, "read_dir").await,
+                Err(_) => break,
             };
             let Ok(ft) = ent.file_type().await else {
                 continue;
@@ -53,6 +56,7 @@ pub async fn find<W: AsyncWrite + Unpin>(
                 scan_file(w, &re, &p).await?;
             }
         }
+        root = false;
         rd = loop {
             let Some(dir) = stack.pop() else {
                 return proto::write_frame(w, &Response::Done).await;

--- a/silkd/src/find.rs
+++ b/silkd/src/find.rs
@@ -2,7 +2,7 @@
 //! rewrites matches in named files. Regex handling lives here so agents pass a
 //! pattern as data rather than shell-quoting it through exec.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use regex::Regex;
 use tokio::fs;
@@ -32,13 +32,14 @@ pub async fn find<W: AsyncWrite + Unpin>(
         Some(Ok(re)) => Some(re),
         Some(Err(e)) => return proto::error_frame(w, ErrorKind::BadRequest, e.to_string()).await,
     };
-    let mut rd = match fs::read_dir(&path).await {
-        Ok(rd) => rd,
-        Err(e) => return err_frame(w, &e, "read_dir").await,
-    };
+    let mut stack = vec![PathBuf::from(path)];
     let mut root = true;
-    let mut stack = Vec::new();
-    loop {
+    while let Some(dir) = stack.pop() {
+        let mut rd = match fs::read_dir(&dir).await {
+            Ok(rd) => rd,
+            Err(e) if root => return err_frame(w, &e, "read_dir").await,
+            Err(_) => continue,
+        };
         loop {
             let ent = match rd.next_entry().await {
                 Ok(Some(ent)) => ent,
@@ -51,21 +52,14 @@ pub async fn find<W: AsyncWrite + Unpin>(
             };
             let p = ent.path();
             if ft.is_dir() {
-                stack.push(p.to_string_lossy().into_owned());
+                stack.push(p);
             } else if ft.is_file() && name_matches(&p, name_re.as_ref()) {
                 scan_file(w, &re, &p).await?;
             }
         }
         root = false;
-        rd = loop {
-            let Some(dir) = stack.pop() else {
-                return proto::write_frame(w, &Response::Done).await;
-            };
-            if let Ok(rd) = fs::read_dir(&dir).await {
-                break rd;
-            }
-        };
     }
+    proto::write_frame(w, &Response::Done).await
 }
 
 /// Rewrites every `pattern` match to `replacement` in each of `files`,


### PR DESCRIPTION
## sandboxd/egress

`Proxy` builds two `http.Transport`s per sandbox (`tr`, `mitmTr`) with `IdleConnTimeout` unset and `Close` only closed the hijacked tunnels, never the transports' idle pool. Upstream keep-alive connections (and their `readLoop` goroutines, which pin the transport) outlived the released claim; nothing in the module called `CloseIdleConnections`. `Close` now drops the idle pool on both transports, and both expire idle connections after 90 s.

- `TestCloseReleasesIdleUpstreamConns`: one proxied GET, then `Close`; the upstream's `ConnState` must observe `StateClosed`. With the `CloseIdleConnections` calls removed the test reports `upstream connection still open after Close`.

## silkd/src/find.rs

`fs.find` treated a `read_dir` failure on a queued subdirectory as fatal (`err_frame` mid-stream, after matches had already shipped) while `scan_file` deliberately skips unreadable files. An agent grepping a tree that a build is mutating lost the whole search. The root directory stays fatal (a bad path is a request error); a queued subdirectory that cannot be opened, or whose iteration fails, is skipped.

## Gates

`GOWORK=off make go-lint`: 0 issues ×10 (5 modules × linux/darwin). `asl ./...` in sandboxd both GOOS: clean. `make lint` + `make test` (boot/init + silkd, fmt/clippy/test): green. `make go-test`: green.