### PR TITLE
review(wire): GitFileStatus ahead of the response type it serves

### DIFF
--- a/protocol/wire/frame.go
+++ b/protocol/wire/frame.go
@@ -617,6 +617,13 @@ type Event struct {
 
 func (Event) RespType() string { return "event" }
 
+// GitFileStatus is one porcelain-v2 entry; Staged/Unstaged are XY status codes.
+type GitFileStatus struct {
+	Path     string `json:"path"`
+	Staged   string `json:"staged"`
+	Unstaged string `json:"unstaged"`
+}
+
 // GitStatusResult answers GitStatus.
 type GitStatusResult struct {
 	Branch    string          `json:"branch"`
@@ -627,13 +634,6 @@ type GitStatusResult struct {
 }
 
 func (GitStatusResult) RespType() string { return "git_status_result" }
-
-// GitFileStatus is one porcelain-v2 entry; Staged/Unstaged are XY status codes.
-type GitFileStatus struct {
-	Path     string `json:"path"`
-	Staged   string `json:"staged"`
-	Unstaged string `json:"unstaged"`
-}
 
 // GitCommitResult answers GitCommit with the new commit hash.
 type GitCommitResult struct {


### PR DESCRIPTION
A pure declaration move, split out of #130.

`GitFileStatus` is a method-less vocabulary type consumed by
`GitStatusResult.Files`. The house layout rule puts such a type ahead of the
first method-bearing type it serves, but it sat below `GitStatusResult`'s whole
block instead. During #130 that region was being edited by #129, so the move was
held back to keep the diffs hunk-disjoint. #129 is merged, so it lands here.

Nothing but the declaration order changes: same fields, same JSON tags, same
godoc line. The shared fixture corpus still pins exactly 61 frames on both the
Rust and Go sides.

## Gates

```
asl ./...                 0 findings
GOOS=linux asl ./...      0 findings
GOWORK=off make go-lint   ten "0 issues." lines (5 modules x 2 GOOS), fmt --diff silent
go test -race -count=1    18 packages ok across the 5 modules
go build ./...            sandboxd, sdk/go, e2e and mcp all still build
```